### PR TITLE
Fix. Thanks to zzz @ #i2p-dev

### DIFF
--- a/SSU.h
+++ b/SSU.h
@@ -26,10 +26,11 @@ namespace ssu
 
 	const int SSU_MTU = 1484;
 
-	// payload types (3 bits)
+	// payload types (4 bits)
 	const uint8_t PAYLOAD_TYPE_SESSION_REQUEST = 0;
 	const uint8_t PAYLOAD_TYPE_SESSION_CREATED = 1;
 	const uint8_t PAYLOAD_TYPE_SESSION_CONFIRMED = 2;
+	const uint8_t PAYLOAD_TYPE_SESSION_DESTROY = 8;
 	const uint8_t PAYLOAD_TYPE_RELAY_REQUEST = 3;
 	const uint8_t PAYLOAD_TYPE_RELAY_RESPONSE = 4;
 	const uint8_t PAYLOAD_TYPE_RELAY_INTRO = 5;


### PR DESCRIPTION
Background (IRC Log):
13:52 < zzz> Meeh, I got a i2pd patch for you
13:52 < zzz> ssu.h line 29 change comment '3 bits' back to '4 bits' and below add 
             PAYLOAD_TYPE_SESSION_DESTROYED = 8
13:53 < zzz> he missed it in the copypasta from our UDPPacket.java
13:54 < zzz>     /*\* @since 0.8.1 */
13:54 < zzz>     public static final int PAYLOAD_TYPE_SESSION_DESTROY = 8;
