### PR TITLE
router.info/router.key to data directory

### DIFF
--- a/RouterContext.cpp
+++ b/RouterContext.cpp
@@ -68,24 +68,46 @@ namespace i2p
 
 	bool RouterContext::Load ()
 	{
-		std::ifstream fk (ROUTER_KEYS, std::ifstream::binary | std::ofstream::in);
+		std::string dataDir = i2p::util::filesystem::GetDataDir ().string ();
+#ifndef _WIN32
+		dataDir.append ("/");
+#else
+		dataDir.append ("\\");
+#endif
+		std::string router_keys = dataDir;
+		router_keys.append (ROUTER_KEYS);
+		std::string router_info = dataDir;
+		router_info.append (ROUTER_INFO);
+
+		std::ifstream fk (router_keys.c_str (), std::ifstream::binary | std::ofstream::in);
 		if (!fk.is_open ())	return false;
 			
 		fk.read ((char *)&m_Keys, sizeof (m_Keys));
 		m_SigningPrivateKey.Initialize (i2p::crypto::dsap, i2p::crypto::dsaq, i2p::crypto::dsag, 
 			CryptoPP::Integer (m_Keys.signingPrivateKey, 20));
 
-		m_RouterInfo = i2p::data::RouterInfo (ROUTER_INFO); // TODO
+		m_RouterInfo = i2p::data::RouterInfo (router_info.c_str ()); // TODO
 		
 		return true;
 	}
 	
 	void RouterContext::Save ()
 	{
-		std::ofstream fk (ROUTER_KEYS, std::ofstream::binary | std::ofstream::out);
+		std::string dataDir = i2p::util::filesystem::GetDataDir ().string ();
+#ifndef _WIN32
+		dataDir.append ("/");
+#else
+		dataDir.append ("\\");
+#endif
+		std::string router_keys = dataDir;
+		router_keys.append (ROUTER_KEYS);
+		std::string router_info = dataDir;
+		router_info.append (ROUTER_INFO);
+
+		std::ofstream fk (router_keys.c_str (), std::ofstream::binary | std::ofstream::out);
 		fk.write ((char *)&m_Keys, sizeof (m_Keys));
 				
-		std::ofstream fi (ROUTER_INFO, std::ofstream::binary | std::ofstream::out);
+		std::ofstream fi (router_info.c_str (), std::ofstream::binary | std::ofstream::out);
 		fi.write ((char *)m_RouterInfo.GetBuffer (), m_RouterInfo.GetBufferLen ());
 	}	
 }	


### PR DESCRIPTION
Loading/Saving to data directory instead of current directory.

Btw, crashed upon loading of new router.info/router.key before my change. Trying to figure it out.

```
(gdb) bt
#0  0x00007ffff62bf9cc in free () from /lib/x86_64-linux-gnu/libc.so.6
#1  0x000000000045246e in __gnu_cxx::new_allocator<i2p::data::RouterInfo::Address>::deallocate (this=0x7fffffffdd60, 
    __p=0x14456c042a3) at /usr/include/c++/4.7/ext/new_allocator.h:100
#2  0x0000000000450708 in std::_Vector_base<i2p::data::RouterInfo::Address, std::allocator<i2p::data::RouterInfo::Address> >::_M_deallocate (this=0x7fffffffdd60, __p=0x14456c042a3, __n=18446744059198958046) at /usr/include/c++/4.7/bits/stl_vector.h:175
#3  0x000000000044cd86 in std::_Vector_base<i2p::data::RouterInfo::Address, std::allocator<i2p::data::RouterInfo::Address> >::~_Vector_base (this=0x7fffffffdd60, __in_chrg=<optimized out>) at /usr/include/c++/4.7/bits/stl_vector.h:161
#4  0x0000000000447ad5 in std::vector<i2p::data::RouterInfo::Address, std::allocator<i2p::data::RouterInfo::Address> >::~vector (
    this=0x7fffffffdd60, __in_chrg=<optimized out>) at /usr/include/c++/4.7/bits/stl_vector.h:404
#5  0x000000000044311f in i2p::data::RouterInfo::~RouterInfo (this=0x7fffffffd350, __in_chrg=<optimized out>) at RouterInfo.h:16
#6  0x000000000046e4b1 in i2p::RouterContext::Load (this=0x7724c0 <i2p::context>) at RouterContext.cpp:89
#7  0x000000000046dd6f in i2p::RouterContext::RouterContext (this=0x7724c0 <i2p::context>) at RouterContext.cpp:14
#8  0x000000000046e899 in __static_initialization_and_destruction_0 (__initialize_p=1, __priority=65535) at RouterContext.cpp:10
#9  0x000000000046e9bc in _GLOBAL__sub_I__ZN3i2p7contextE () at RouterContext.cpp:113
#10 0x00000000004d972d in __libc_csu_init ()
#11 0x00007ffff625de35 in __libc_start_main () from /lib/x86_64-linux-gnu/libc.so.6
#12 0x0000000000433e29 in _start ()
```
