### PR TITLE
EXIT_SUCCESS return code declaration

### DIFF
--- a/i2p.cpp
+++ b/i2p.cpp
@@ -1,5 +1,5 @@
 #include <thread>
-
+#include <stdlib.h>
 #include "Daemon.h"
 
 int main( int argc, char* argv[] )


### PR DESCRIPTION
Looks like EXIT_SUCCESS is undeclared:

```
mipsel-linux-uclibc-gcc -o obj/i2p.o i2p.cpp -c -O2 -pipe -mips32 -mtune=mips32 -fno-caller-saves -std=gnu++0x -D_GLIBCXX_USE_NANOSLEEP  -I/home/ryzhovau/Entware/openwrt_trunk/staging_dir/target-mipsel-linux-gnu/opt/include -I/home/ryzhovau/Entware/openwrt_trunk/staging_dir/target-mipsel-linux-gnu/include -I/opt/entware/toolchain-entware/include
i2p.cpp: In function 'int main(int, char**)':
i2p.cpp:15:9: error: 'EXIT_SUCCESS' was not declared in this scope
make[3]: *** [obj/i2p.o] Error 1
make[3]: Leaving directory `/home/ryzhovau/Entware/openwrt_trunk/build_dir/target-mipsel-linux-gnu/i2pd-0.1-20140610'
```

gcc 4.6.4 + uClibc 0.9.32 cross-compilation toolchain for MIPS embedded systems.
