### PR TITLE
detect GNU/kFreeBSD

### DIFF
--- a/I2PEndian.h
+++ b/I2PEndian.h
@@ -1,7 +1,7 @@
 #ifndef I2PENDIAN_H__
 #define I2PENDIAN_H__
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD_kernel__)
 #include <endian.h>
 #elif __FreeBSD__
 #include <sys/endian.h>


### PR DESCRIPTION
i2pd can be built on Debian GNU/kFreeBSD with this simple change applied.

See https://lists.debian.org/debian-bsd/2010/01/msg00125.html
