### PR TITLE
fixed HTTP connection being reset on Windows

### DIFF
--- a/HTTPServer.cpp
+++ b/HTTPServer.cpp
@@ -605,7 +605,8 @@ namespace util
 	{
 		if (ecode != boost::asio::error::operation_aborted)
 		{
-			m_Socket->close ();
+			boost::system::error_code ignored_ec;
+			m_Socket->shutdown(boost::asio::ip::tcp::socket::shutdown_both, ignored_ec);
 			Terminate ();
 		}	
 	}


### PR DESCRIPTION
Ok, so... Some fix has been found. Please note that this is rather a "quick and dirty fix" as I haven't gained full understanding of the server yet. Should you be not satisfied with the quality of patch proposed, feel free to decline. Having that kind of scenario we can postpone it until I understand ins and outs of the server, estimate for that is 2 to 4 weeks.

Nevertheless, it looks like it's a variant of Kohloff's type 3 server with a thread pool (pool size for the time being is 1). I've spotted a couple of issues (memory leak, dead code etc) and will be actively creating new Github issues soon. You may rest assured that this does patch does not break Linux branch, has been tested just now.