### PR TITLE
Add libi2pd.so to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ obj/*.o
 router.info
 router.keys
 i2p
+libi2pd.so
 netDb
 
 # Autotools


### PR DESCRIPTION
`libi2pd.so` is a compilation artifact, so it should be ignored.
Also if you are using i2pd as git-submodule, you always get message `modified:   i2pd (modified content)`.