### PR TITLE
Fix Win32 build with CMake and MSVC

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -45,6 +45,10 @@ set (COMMON_SRC
   "${CMAKE_SOURCE_DIR}/Signature.cpp"
 )
 
+if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  list (APPEND COMMON_SRC "${CMAKE_SOURCE_DIR}/I2PEndian.cpp")
+endif ()
+
 add_library(common ${COMMON_SRC})
 
 set (DAEMON_SRC
@@ -80,7 +84,9 @@ else ()
 endif ()
 
 # compiler flags customization (by vendor)
+if (NOT MSVC)
 add_definitions ( "-Wall -Wextra -fPIC" )
+endif ()
 
 # check for c++11 support
 include(CheckCXXCompilerFlag)
@@ -90,7 +96,7 @@ if (CXX11_SUPPORTED)
   add_definitions( "-std=c++11" )
 elseif (CXX0X_SUPPORTED) # gcc 4.6
   add_definitions( "-std=c++0x" )
-else ()
+elseif (NOT MSVC)
   message(SEND_ERROR "C++11 standart not seems to be supported by compiler. Too old version?")
 endif ()
 
@@ -117,6 +123,7 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   list (APPEND DAEMON_SRC "${CMAKE_SOURCE_DIR}/DaemonLinux.cpp")
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Windows")
   list (APPEND DAEMON_SRC "${CMAKE_SOURCE_DIR}/DaemonWin32.cpp")
+  list (APPEND DAEMON_SRC "${CMAKE_SOURCE_DIR}/Win32/Win32Service.cpp")
 endif ()
 
 if (WITH_AESNI)
@@ -125,6 +132,10 @@ endif()
 
 # libraries
 find_package ( Threads REQUIRED )
+
+if (WITH_STATIC)
+  set(Boost_USE_STATIC_LIBS ON)
+endif ()
 
 find_package ( Boost COMPONENTS system filesystem regex program_options date_time REQUIRED )
 if(NOT DEFINED Boost_INCLUDE_DIRS)
@@ -159,7 +170,9 @@ include(GNUInstallDirs)
 
 if (WITH_BINARY)
   add_executable ( "${PROJECT_NAME}-bin" ${DAEMON_SRC} )
+ if(NOT MSVC) # FIXME: incremental linker file name (.ilk) collision for dll & exe
   set_target_properties("${PROJECT_NAME}-bin" PROPERTIES OUTPUT_NAME "${PROJECT_NAME}")
+ endif()
 
   if (WITH_HARDENING AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set_target_properties("${PROJECT_NAME}-bin" PROPERTIES LINK_FLAGS "-z relro -z now" )
@@ -168,15 +181,23 @@ if (WITH_BINARY)
   if (WITH_STATIC)
     set(BUILD_SHARED_LIBS OFF)
     set_target_properties("${PROJECT_NAME}-bin" PROPERTIES LINK_FLAGS "-static" )
+  else()
+    add_definitions(-DBOOST_ALL_DYN_LINK)
   endif ()
 
   target_link_libraries( "${PROJECT_NAME}-bin" common ${Boost_LIBRARIES} ${CRYPTO++_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} )
 
   install(TARGETS "${PROJECT_NAME}-bin" RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+  install(FILES $<TARGET_PDB_FILE:${PROJECT_NAME}-bin> DESTINATION "bin" CONFIGURATIONS DEBUG)
 endif ()
 
 if (WITH_LIBRARY)
+ if (MSVC)
+  # FIXME: DLL would not have any symbols unless we use __declspec(dllexport) through out the code
+  add_library(${PROJECT_NAME} ${LIBRARY_SRC})
+ else ()
   add_library(${PROJECT_NAME} SHARED ${LIBRARY_SRC})
-  target_link_libraries( ${PROJECT_NAME} common )
-  install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} )
+  target_link_libraries( ${PROJECT_NAME} common ${Boost_LIBRARIES} ${CRYPTO++_LIBRARIES})
+ endif ()
+  install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif ()

--- a/build/cmake_modules/FindCryptoPP.cmake
+++ b/build/cmake_modules/FindCryptoPP.cmake
@@ -12,6 +12,9 @@ else(CRYPTO++_INCLUDE_DIR AND CRYPTO++_LIBRARIES)
       /opt/local/include/crypto++
       /opt/local/include/cryptopp
       $ENV{SystemDrive}/Crypto++/include
+      $ENV{CRYPTOPP}
+      $ENV{CRYPTOPP}/include
+      ${PROJECT_SOURCE_DIR}/../../cryptopp
       )
 
   find_library(CRYPTO++_LIBRARIES NAMES cryptopp
@@ -20,7 +23,31 @@ else(CRYPTO++_INCLUDE_DIR AND CRYPTO++_LIBRARIES)
       /usr/local/lib
       /opt/local/lib
       $ENV{SystemDrive}/Crypto++/lib
+      $ENV{CRYPTOPP}/lib
       )
+
+  if(MSVC AND NOT CRYPTO++_LIBRARIES) # Give a chance for MSVC multiconfig
+      if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+          set(PLATFORM x64)
+      else()
+          set(PLATFORM Win32)
+      endif()
+      find_library(CRYPTO++_LIBRARIES_RELEASE NAMES cryptlib cryptopp
+          PATHS
+          $ENV{CRYPTOPP}/Win32/Output/Release
+          ${PROJECT_SOURCE_DIR}/../../cryptopp/${PLATFORM}/Output/Release
+      )
+      find_library(CRYPTO++_LIBRARIES_DEBUG NAMES cryptlib cryptopp
+          PATHS
+          $ENV{CRYPTOPP}/Win32/Output/Debug
+          ${PROJECT_SOURCE_DIR}/../../cryptopp/${PLATFORM}/Output/Debug
+      )
+      set(CRYPTO++_LIBRARIES
+          debug ${CRYPTO++_LIBRARIES_DEBUG}
+          optimized ${CRYPTO++_LIBRARIES_RELEASE}
+          CACHE PATH "Path to Crypto++ library" FORCE
+      )
+  endif()
 
   if(CRYPTO++_INCLUDE_DIR AND CRYPTO++_LIBRARIES)
     set(CRYPTO++_FOUND TRUE)

--- a/build/cmake_modules/FindCryptoPP.cmake
+++ b/build/cmake_modules/FindCryptoPP.cmake
@@ -33,14 +33,16 @@ else(CRYPTO++_INCLUDE_DIR AND CRYPTO++_LIBRARIES)
           set(PLATFORM Win32)
       endif()
       find_library(CRYPTO++_LIBRARIES_RELEASE NAMES cryptlib cryptopp
+          HINTS
+          ${PROJECT_SOURCE_DIR}/../../cryptopp/${PLATFORM}/Output/Release
           PATHS
           $ENV{CRYPTOPP}/Win32/Output/Release
-          ${PROJECT_SOURCE_DIR}/../../cryptopp/${PLATFORM}/Output/Release
       )
       find_library(CRYPTO++_LIBRARIES_DEBUG NAMES cryptlib cryptopp
+          HINTS
+          ${PROJECT_SOURCE_DIR}/../../cryptopp/${PLATFORM}/Output/Debug
           PATHS
           $ENV{CRYPTOPP}/Win32/Output/Debug
-          ${PROJECT_SOURCE_DIR}/../../cryptopp/${PLATFORM}/Output/Debug
       )
       set(CRYPTO++_LIBRARIES
           debug ${CRYPTO++_LIBRARIES_DEBUG}


### PR DESCRIPTION
This allows to generate MSVC projects with CMake. JOM also works.
Boost can be linked in as a DLL, but one has to apply a [patch](https://svn.boost.org/trac/boost/ticket/6797) for program_options to link correctly as few symbols are erroneously not exported by Boost.
Few CMake guesses are added to discover cryptopp unpacked into a sibling directory.

For 64 bit Boost, I'd recommend
```
b2 --build-type=complete --without-python address-model=64  --stagedir=stage64
```
and then setting `Boost_LIBRARY_DIR`, e.g. with cmake-gui, to `<your boost root>/stage64/lib`. It will discover everything from there.
If you plan to use runtime & Boost DLLs, adjust Runtime Library for crypto++ project accordingly (cryptlib⇨Properties⇨Configuration Properties⇨C/C++⇨Code Generation⇨Runtime Library).