### PR TITLE
Use address instead of host in code and README.md

### DIFF
--- a/ClientContext.cpp
+++ b/ClientContext.cpp
@@ -81,7 +81,7 @@ namespace client
         if (eepKeys.length () > 0) // eepkeys file is presented
         {
             localDestination = LoadLocalDestination (eepKeys, true);
-            auto serverTunnel = new I2PServerTunnel (i2p::util::config::GetArg("-eephost", "127.0.0.1"),
+            auto serverTunnel = new I2PServerTunnel (i2p::util::config::GetArg("-eepaddress", "127.0.0.1"),
                 i2p::util::config::GetArg("-eepport", 80), localDestination);
             serverTunnel->Start ();
             m_ServerTunnels.insert (std::make_pair(localDestination->GetIdentHash (), std::unique_ptr<I2PServerTunnel>(serverTunnel)));

--- a/README.md
+++ b/README.md
@@ -98,15 +98,15 @@ Cmdline options
 * --socksproxyaddress=  - The address to listen on (SOCKS Proxy)
 * --proxykeys=          - optional keys file for proxy's local destination
 * --ircport=            - The local port of IRC tunnel to listen on. 6668 by default
-* --irchost=            - The adddress of IRC tunnel to listen on, 127.0.0.1 by default
+* --ircaddress=         - The adddress of IRC tunnel to listen on, 127.0.0.1 by default
 * --ircdest=            - I2P destination address of IRC server. For example irc.postman.i2p
 * --irckeys=            - optional keys file for tunnel's local destination 
 * --eepkeys=            - File name containing destination keys, for example privKeys.dat.
                           The file will be created if it does not already exist (issue #110).
-* --eephost=            - Address incoming trafic forward to. 127.0.0.1 by default
+* --eepaddress=         - Address incoming trafic forward to. 127.0.0.1 by default
 * --eepport=            - Port incoming trafic forward to. 80 by default
 * --samport=            - Port of SAM bridge. Usually 7656. SAM is off if not specified
-* --samhost=            - Address of SAM bridge, 127.0.0.1 by default (only used if SAM is on)
+* --samaddress=         - Address of SAM bridge, 127.0.0.1 by default (only used if SAM is on)
 * --bobport=            - Port of BOB command channel. Usually 2827. BOB is off if not specified
 * --bobaddress=         - Address of BOB service, 127.0.0.1 by default (only used if BOB is on)
 * --i2pcontrolport=     - Port of I2P control service. Usually 7650. I2PControl is off if not specified


### PR DESCRIPTION
Basically errors in README but also harmonizing eephost.