### PR TITLE
Catch exception in SSUServer that would dump core.

### DIFF
--- a/core/RouterInfo.cpp
+++ b/core/RouterInfo.cpp
@@ -426,7 +426,7 @@ namespace data
 
     void RouterInfo::CreateBuffer (const PrivateKeys& privateKeys)
     {
-        m_Timestamp = i2p::util::GetMillisecondsSinceEpoch (); // refresh timstamp
+        m_Timestamp = i2p::util::GetMillisecondsSinceEpoch (); // refresh timestamp
         std::stringstream s;
         uint8_t ident[1024];
         auto identLen = privateKeys.GetPublic ().ToBuffer (ident, 1024);

--- a/core/transport/SSU.cpp
+++ b/core/transport/SSU.cpp
@@ -136,11 +136,19 @@ namespace transport
 
     void SSUServer::Send (const uint8_t * buf, size_t len, const boost::asio::ip::udp::endpoint& to)
     {
-        if (to.protocol () == boost::asio::ip::udp::v4()) 
-            m_Socket.send_to (boost::asio::buffer (buf, len), to);
+        if (to.protocol () == boost::asio::ip::udp::v4())
+            try {
+                m_Socket.send_to (boost::asio::buffer (buf, len), to);
+            } catch (const std::exception& ex) {
+                LogPrint (eLogError, "SSUServer send error: ", ex.what());
+            }
         else
-            m_SocketV6.send_to (boost::asio::buffer (buf, len), to);
-    }   
+            try {
+                m_SocketV6.send_to (boost::asio::buffer (buf, len), to);
+            } catch (const std::exception& ex) {
+                LogPrint (eLogError, "SSUServer V6 send error: ", ex.what());
+            }
+    }
 
     void SSUServer::Receive ()
     {


### PR DESCRIPTION
Fixes #280 

I'd rather leave this as-is with the assumption that in the future, i2pd will have a "disable outbound UDP" option - and that will eventually lead to some re-writing anyway. If there is a better way to handle this for now, I'm all ears!