### PR TITLE
Improve HTTP/S header handling, reorganize HTTPS, note on TLS.

### DIFF
--- a/client/ClientContext.cpp
+++ b/client/ClientContext.cpp
@@ -71,7 +71,7 @@ namespace client
                 ircPort, localDestination
             );
             ircTunnel->Start ();
-            // TODO: allow muliple tunnels on the same port (but on a different address)
+            // TODO: allow multiple tunnels on the same port (but on a different address)
             m_ClientTunnels.insert(std::make_pair(
                 ircPort, std::unique_ptr<I2PClientTunnel>(ircTunnel)
             ));

--- a/client/Daemon.cpp
+++ b/client/Daemon.cpp
@@ -76,9 +76,11 @@ namespace i2p
             int port = i2p::util::config::GetArg("-port", 0);
             if (port)
                 i2p::context.UpdatePort (port);                 
-            const char * host = i2p::util::config::GetCharArg("-host", "");
-            if (host && host[0])
-                i2p::context.UpdateAddress (boost::asio::ip::address::from_string (host));  
+            const std::string host = i2p::util::config::GetArg("-host", "");
+            // The host option is deprecated, so this was always true.
+            // Because of -Waddress, it's now exposed as the hack it was.
+            if (&host && host[0])
+                i2p::context.UpdateAddress (boost::asio::ip::address::from_string (host));
 
             i2p::context.SetSupportsV6 (i2p::util::config::GetArg("-v6", 0));
             i2p::context.SetFloodfill (i2p::util::config::GetArg("-floodfill", 0));

--- a/core/AddressBook.cpp
+++ b/core/AddressBook.cpp
@@ -487,11 +487,10 @@ namespace client
             {
                 std::stringstream request, response;
                 // standard header
-                request << "GET " << u.path_ << " HTTP/1.1\r\nHost: " << u.host_
-                << "\r\nAccept: */*\r\n" << "User-Agent: Wget/1.11.4\r\n" << "Connection: close\r\n";
+		request << i2p::util::http::httpHeader(u.path_, u.host_, "1.1");
                 if (m_Etag.length () > 0) // etag
                     request << i2p::util::http::IF_NONE_MATCH << ": \"" << m_Etag << "\"\r\n";
-                if (m_LastModified.length () > 0) // if-modfief-since
+                if (m_LastModified.length () > 0) // if modified since
                     request << i2p::util::http::IF_MODIFIED_SINCE << ": " << m_LastModified << "\r\n";
                 request << "\r\n"; // end of header
                 auto stream = m_Book.getSharedLocalDestination()->CreateStream (leaseSet, u.port_);

--- a/core/AddressBook.cpp
+++ b/core/AddressBook.cpp
@@ -466,7 +466,7 @@ namespace client
         bool success = false;   
         i2p::util::http::url u (m_Link);
         i2p::data::IdentHash ident;
-        if (m_Book.GetIdentHash (u.host_, ident) && m_Book.getSharedLocalDestination())
+        if (m_Book.GetIdentHash (u.m_host, ident) && m_Book.getSharedLocalDestination())
         {
             std::condition_variable newDataReceived;
             std::mutex newDataReceivedMutex;
@@ -487,13 +487,13 @@ namespace client
             {
                 std::stringstream request, response;
                 // standard header
-		request << i2p::util::http::httpHeader(u.path_, u.host_, "1.1");
+		request << i2p::util::http::httpHeader(u.m_path, u.m_host, "1.1");
                 if (m_Etag.length () > 0) // etag
                     request << i2p::util::http::IF_NONE_MATCH << ": \"" << m_Etag << "\"\r\n";
                 if (m_LastModified.length () > 0) // if modified since
                     request << i2p::util::http::IF_MODIFIED_SINCE << ": " << m_LastModified << "\r\n";
                 request << "\r\n"; // end of header
-                auto stream = m_Book.getSharedLocalDestination()->CreateStream (leaseSet, u.port_);
+                auto stream = m_Book.getSharedLocalDestination()->CreateStream (leaseSet, u.m_port);
                 stream->Send ((uint8_t *)request.str ().c_str (), request.str ().length ());
                 
                 uint8_t buf[4096];
@@ -569,10 +569,10 @@ namespace client
                     LogPrint (eLogWarning, "Addressbook HTTP response ", status);
             }
             else
-                LogPrint (eLogError, "Address ", u.host_, " not found");
+                LogPrint (eLogError, "Address ", u.m_host, " not found");
         }
         else
-            LogPrint (eLogError, "Can't resolve ", u.host_);
+            LogPrint (eLogError, "Can't resolve ", u.m_host);
         LogPrint (eLogInfo, "Download complete ", success ? "Success" : "Failed");
         m_Book.DownloadComplete (success);
     }

--- a/core/Reseed.cpp
+++ b/core/Reseed.cpp
@@ -491,7 +491,11 @@ namespace data
         LogPrint (eLogInfo, numCertificates, " certificates loaded");
     }   
 
-//-------------------------------------------------------------
+/*------------------------------------------------------------------
+    TLS has nothing to do with the reseed process (except for HTTPS)
+    Once #244 is resolved, this will all be axed - so moving the
+    following to util.cpp is not worth the effort for now.
+/------------------------------------------------------------------*/
 
     template<class Hash>
     class TlsCipherMAC: public TlsCipher

--- a/core/Reseed.cpp
+++ b/core/Reseed.cpp
@@ -130,7 +130,7 @@ namespace data
     {
         std::string url = host + "i2pseeds.su3";
         LogPrint (eLogInfo, "Downloading SU3 from ", host);
-        std::string su3 = https ? HttpsRequest (url) : i2p::util::http::httpRequest (url);
+        std::string su3 = https ? i2p::util::http::httpsRequest (url) : i2p::util::http::httpRequest (url);
         if (su3.length () > 0)
         {
             std::stringstream s(su3);
@@ -489,30 +489,6 @@ namespace data
             }   
         }   
         LogPrint (eLogInfo, numCertificates, " certificates loaded");
-    }   
-
-    std::string Reseeder::HttpsRequest (const std::string& address)
-    {
-        i2p::util::http::url u(address);
-        if (u.port_ == 80) u.port_ = 443; 
-        TlsSession session (u.host_, u.port_);
-        
-        if (session.IsEstablished ())
-        {
-            // send request     
-            std::stringstream ss;
-            ss << "GET " << u.path_ << " HTTP/1.1\r\nHost: " << u.host_
-            << "\r\nAccept: */*\r\n" << "User-Agent: Wget/1.11.4\r\n" << "Connection: close\r\n\r\n";   
-            session.Send ((uint8_t *)ss.str ().c_str (), ss.str ().length ());
-
-            // read response
-            std::stringstream rs;
-            while (session.Receive (rs))
-                ;
-            return i2p::util::http::GetHttpContent (rs);
-        }
-        else
-            return "";
     }   
 
 //-------------------------------------------------------------

--- a/core/Reseed.h
+++ b/core/Reseed.h
@@ -39,8 +39,6 @@ namespace data
             int ProcessSU3Stream (std::istream& s); 
 
             bool FindZipDataDescriptor (std::istream& s);
-            
-            std::string HttpsRequest (const std::string& address);
 
         private:    
 

--- a/core/RouterContext.cpp
+++ b/core/RouterContext.cpp
@@ -42,8 +42,8 @@ namespace i2p
         int port = i2p::util::config::GetArg("-port", 0);
         if (!port)
             port = m_Rnd.GenerateWord32 (9111, 30777); // I2P network ports range
-        routerInfo.AddSSUAddress (i2p::util::config::GetCharArg("-host", "127.0.0.1"), port, routerInfo.GetIdentHash ());
-        routerInfo.AddNTCPAddress (i2p::util::config::GetCharArg("-host", "127.0.0.1"), port);
+        routerInfo.AddSSUAddress (i2p::util::config::GetArg("-host", "127.0.0.1"), port, routerInfo.GetIdentHash ());
+        routerInfo.AddNTCPAddress (i2p::util::config::GetArg("-host", "127.0.0.1"), port);
         routerInfo.SetCaps (i2p::data::RouterInfo::eReachable | 
             i2p::data::RouterInfo::eSSUTesting | i2p::data::RouterInfo::eSSUIntroducer); // LR, BC
         routerInfo.SetProperty ("coreVersion", I2P_VERSION);

--- a/core/RouterInfo.cpp
+++ b/core/RouterInfo.cpp
@@ -472,7 +472,7 @@ namespace data
         s.write (str.c_str (), len);
     }   
 
-    void RouterInfo::AddNTCPAddress (const char * host, int port)
+    void RouterInfo::AddNTCPAddress (const std::string& host, int port)
     {
         Address addr;
         addr.host = boost::asio::ip::address::from_string (host);
@@ -485,7 +485,7 @@ namespace data
         m_SupportedTransports |= addr.host.is_v6 () ? eNTCPV6 : eNTCPV4;
     }   
 
-    void RouterInfo::AddSSUAddress (const char * host, int port, const uint8_t * key, int mtu)
+    void RouterInfo::AddSSUAddress (const std::string& host, int port, const uint8_t * key, int mtu)
     {
         Address addr;
         addr.host = boost::asio::ip::address::from_string (host);

--- a/core/RouterInfo.h
+++ b/core/RouterInfo.h
@@ -103,8 +103,8 @@ namespace data
             const Address * GetSSUAddress (bool v4only = true) const;
             const Address * GetSSUV6Address () const;
             
-            void AddNTCPAddress (const char * host, int port);
-            void AddSSUAddress (const char * host, int port, const uint8_t * key, int mtu = 0);
+            void AddNTCPAddress (const std::string& host, int port);
+            void AddSSUAddress (const std::string& host, int port, const uint8_t * key, int mtu = 0);
             bool AddIntroducer (const Address * address, uint32_t tag);
             bool RemoveIntroducer (const boost::asio::ip::udp::endpoint& e);
             void SetProperty (const std::string& key, const std::string& value); // called from RouterContext only

--- a/core/util/util.cpp
+++ b/core/util/util.cpp
@@ -63,6 +63,7 @@ http://stackoverflow.com/questions/15660203/inet-pton-identifier-not-found */
 namespace i2p {
 namespace util {
 
+// TODO: this will be replaced by a real option parser soon.
 namespace config {
     std::map<std::string, std::string> mapArgs;
     std::map<std::string, std::vector<std::string> > mapMultiArgs;

--- a/core/util/util.h
+++ b/core/util/util.h
@@ -39,12 +39,6 @@ namespace util
         std::string GetArg(const std::string& strArg, const std::string& strDefault);
 
         /**
-         * @return a command line argument from config::mapArgs as a C-style string
-         * @param nDefault the default value to be returned
-         */
-        const char* GetCharArg(const std::string& strArg, const std::string& nDefault);
-
-        /**
          * @return true if the argument is set, false otherwise
          */
         bool HasArg(const std::string& strArg);

--- a/core/util/util.h
+++ b/core/util/util.h
@@ -124,6 +124,18 @@ namespace util
         const char LAST_MODIFIED[] = "Last-Modified";
         const char TRANSFER_ENCODING[] = "Transfer-Encoding";
 
+	 /**
+         * Header for HTTP/S requests.
+         * @return a string of the complete header
+         */
+	std::string httpHeader(const std::string& path, const std::string& host, const std::string& version);
+
+        /**
+         * Perform an HTTPS request.
+         * @return the result of the request, or an empty string if it fails
+         */
+        std::string httpsRequest(const std::string& address);
+
         /**
          * Perform an HTTP request.
          * @return the result of the request, or an empty string if it fails

--- a/core/util/util.h
+++ b/core/util/util.h
@@ -167,19 +167,29 @@ namespace util
         /**
          * Provides functionality for parsing URLs.
          */
-        struct url {
-            /**
-             * Parse a url given as a string.
+        class url {
+	    /**
+	     * The code for parse() was originally copied/pasted from
+	     * https://stackoverflow.com/questions/2616011/easy-way-to-parse-a-url-in-c-cross-platform
+	     *
+	     * This function is a URI parser (not a URL parser) and is hack at best.
+	     * See cpp-netlib for a better URI parsing implementation with Boost.
+	     *
+	     * Note: fragments are not parsed by this function (if they should
+	     * ever be needed in the future).
+	     *
+             * @param string url
              */
-            url(const std::string& url_s);
-        private:
-            void parse(const std::string& url_s);
+            void parse(const std::string& url);
+	public:
+	     /**
+             * Parse a URI given as a string.
+             */
+            url(const std::string& url);
         public:
-            std::string protocol_, host_, path_, query_;
-            std::string portstr_;
-            unsigned int port_;
-            std::string user_;
-            std::string pass_;
+            std::string m_protocol, m_host, m_path, m_query, m_portstr;
+            unsigned int m_port;
+            std::string m_user, m_pass;
         };
     }
 

--- a/doc/BUILDING.md
+++ b/doc/BUILDING.md
@@ -9,9 +9,7 @@ On Arch Linux
 
 Then, build:
 
-$ cd i2pd/build
-$ cmake ../
-$ make
+$ cd i2pd/build && cmake ../ && make
 
 Then, run it:
 

--- a/doc/BUILD_NOTES.md
+++ b/doc/BUILD_NOTES.md
@@ -17,9 +17,9 @@ Arch
 ----
 
 Required packages:
-*cmake
-*boost
-*crypto++
+* cmake
+* boost
+* crypto++
 
 FreeBSD
 -------

--- a/doc/COMMANDLINE.md
+++ b/doc/COMMANDLINE.md
@@ -1,38 +1,55 @@
-Cmdline options
-===============
+CLI Options
+===========
 
-* --host=               - The external IP (deprecated).
-* --port=               - The port to listen on
-* --httpport=           - The http port to listen on
-* --httpaddress=        - The ip address for the HTTP server, 127.0.0.1 by default
+Basic
+* --host=               - The external IP (deprecated). Default: external interface.
+* --port=               - The port to listen on. Default: random (then saved to router.info).
+* --httpport=           - The HTTP port to listen on for WebUI. Default: 7070
+* --httpaddress=        - The IP address of the WebUI HTTP server. Default: 127.0.0.1
+
+System
 * --log=                - Enable or disable logging to file. 1 for yes, 0 for no.
 * --daemon=             - Enable or disable daemon mode. 1 for yes, 0 for no.
-* --service=            - 1 if uses system folders (/var/run/i2pd.pid, /var/log/i2pd.log, /var/lib/i2pd).
-* --v6=                 - 1 if supports communication through ipv6, off by default
-* --floodfill=          - 1 if router is floodfill, off by default
+* --service=            - 1 if using system folders (/var/run/i2pd.pid, /var/log/i2pd.log, /var/lib/i2pd).
+
+Network
+* --v6=                 - 1 to enable IPv6. Default: disabled.
+* --floodfill=          - 1 to enable router router as floodfill. Default: disabled.
 * --bandwidth=          - L if bandwidth is limited to 32Kbs/sec, O if not. Always O if floodfill, otherwise L by default.
-* --httpproxyport=      - The port to listen on (HTTP Proxy)
-* --httpproxyaddress=   - The address to listen on (HTTP Proxy)
-* --socksproxyport=     - The port to listen on (SOCKS Proxy)
-* --socksproxyaddress=  - The address to listen on (SOCKS Proxy)
-* --proxykeys=          - optional keys file for proxy's local destination
-* --ircport=            - The local port of IRC tunnel to listen on. 6668 by default
-* --ircaddress=         - The adddress of IRC tunnel to listen on, 127.0.0.1 by default
+
+Proxies
+* --httpproxyport=      - The HTTP Proxy port to listen on. Default: 4446
+* --httpproxyaddress=   - The HTTP Proxy address to listen on. Default: 127.0.0.1
+* --socksproxyport=     - The SOCKS Proxy port to listen on. Default: 4447
+* --socksproxyaddress=  - The SOCKS Proxy address to listen on. Default: 127.0.0.1
+* --proxykeys=          - Optional keys file for proxy's local destination
+
+IRC
+* --ircport=            - The local port of IRC tunnel to listen on. Default: 6668
+* --ircaddress=         - The adddress of IRC tunnel to listen on. Default: 127.0.0.1
 * --ircdest=            - I2P destination address of IRC server. For example irc.postman.i2p
-* --irckeys=            - optional keys file for tunnel's local destination
+* --irckeys=            - Optional keys file for tunnel's local destination.
+
+Eepsite
 * --eepkeys=            - File name containing destination keys, for example privKeys.dat.
                           The file will be created if it does not already exist (issue #110).
-* --eepaddress=         - Address incoming trafic forward to. 127.0.0.1 by default
-* --eepport=            - Port incoming trafic forward to. 80 by default
-* --samport=            - Port of SAM bridge. Usually 7656. SAM is off if not specified
-* --samaddress=         - Address of SAM bridge, 127.0.0.1 by default (only used if SAM is on)
-* --bobport=            - Port of BOB command channel. Usually 2827. BOB is off if not specified
-* --bobaddress=         - Address of BOB service, 127.0.0.1 by default (only used if BOB is on)
-* --i2pcontrolport=     - Port of I2P control service. Usually 7650. I2PControl is off if not specified
-* --i2pcontroladdress=  - Address of I2P control service, 127.0.0.1 by default (only used if I2PControl is on)
-* --i2pcontrolpassword= - I2P control service password, "itoopie" by default
-* --tunnelscfg=         - Tunnels Config file (default: ~/.i2pd/tunnels.cfg or /var/lib/i2pd/tunnels.cfg)
-* --conf=               - Config file (default: ~/.i2pd/i2p.conf or /var/lib/i2pd/i2p.conf)
+* --eepaddress=         - Forward incoming traffic to this address. Default: 127.0.0.1
+* --eepport=            - Forward incoming traffic to this port. Default: 80
+
+API
+* --samport=            - Port of SAM bridge (usually 7656). Default: SAM is disabled if not specified.
+* --samaddress=         - Address of SAM bridge. Default: 127.0.0.1 (only used if SAM is enabled).
+* --bobport=            - Port of BOB command channel (usually 2827). BOB is disabled if not specified.
+* --bobaddress=         - Address of BOB service. Default: 127.0.0.1 (only used if BOB is enabled).
+
+I2CP
+* --i2pcontrolport=     - Port of I2P control service (usually 7650). I2PControl is disabled if not specified.
+* --i2pcontroladdress=  - Address of I2P control service. Default: 127.0.0.1 (only used if I2PControl is enabled).
+* --i2pcontrolpassword= - I2P control service password. Default: "itoopie" (without quotations).
+
+Config
+* --tunnelscfg=         - Tunnels Config file. Default: ~/.i2pd/tunnels.cfg -or- /var/lib/i2pd/tunnels.cfg
+* --conf=               - Config file. Default: ~/.i2pd/i2p.conf -or- /var/lib/i2pd/i2p.conf
                           This parameter will be silently ignored if the specified config file does not exist.
                           Options specified on the command line take precedence over those in the config file.
-* --install=            - Installs the webui files, see BUILDING.md for details.
+* --install=            - Installs the WebUI (see doc/BUILDING.md for details).

--- a/doc/CONFIG.md
+++ b/doc/CONFIG.md
@@ -10,7 +10,7 @@ i2p.conf:
 	v6 = 0
 	ircdest = irc.postman.i2p
 
-tunnels.cfg (filename of this config is subject of change):
+tunnels.cfg (filename of this config is subject to change):
 
     ; outgoing tunnel sample, to remote service
     ; mandatory parameters:

--- a/tests/Utility.cpp
+++ b/tests/Utility.cpp
@@ -17,76 +17,76 @@ BOOST_AUTO_TEST_CASE(DecodeUrl)
 }
 BOOST_AUTO_TEST_CASE(ParseUrlProtocol)
 {
-    BOOST_CHECK_EQUAL(url("http://127.0.0.1:7070/asdasd?qqqqqqqqqqqq").protocol_, "http");
-    BOOST_CHECK_EQUAL(url("http://user:password@site.com:err_port/A/B?q").protocol_, "http");
-    BOOST_CHECK_EQUAL(url("ftp://user@localhost:123").protocol_, "ftp");
-    BOOST_CHECK_EQUAL(url("SSH://user:pass@localhost:123").protocol_, "ssh");
-    BOOST_CHECK_EQUAL(url("").protocol_, "");
+    BOOST_CHECK_EQUAL(url("http://127.0.0.1:7070/asdasd?qqqqqqqqqqqq").m_protocol, "http");
+    BOOST_CHECK_EQUAL(url("http://user:password@site.com:err_port/A/B?q").m_protocol, "http");
+    BOOST_CHECK_EQUAL(url("ftp://user@localhost:123").m_protocol, "ftp");
+    BOOST_CHECK_EQUAL(url("SSH://user:pass@localhost:123").m_protocol, "ssh");
+    BOOST_CHECK_EQUAL(url("").m_protocol, "");
 }
 
 BOOST_AUTO_TEST_CASE(ParseUrlHost)
 {
-    BOOST_CHECK_EQUAL(url("http://127.0.0.1:7070/asdasd?qqqqqqqqqqqq").host_, "127.0.0.1");
-    BOOST_CHECK_EQUAL(url("http://user:password@site.com:err_port/A/B?q").host_, "site.com");
-    BOOST_CHECK_EQUAL(url("ftp://user@localhost:123").host_, "localhost");
-    BOOST_CHECK_EQUAL(url("SSH://user:pass@localhost:123").host_, "localhost");
-    BOOST_CHECK_EQUAL(url("").host_, "");
+    BOOST_CHECK_EQUAL(url("http://127.0.0.1:7070/asdasd?qqqqqqqqqqqq").m_host, "127.0.0.1");
+    BOOST_CHECK_EQUAL(url("http://user:password@site.com:err_port/A/B?q").m_host, "site.com");
+    BOOST_CHECK_EQUAL(url("ftp://user@localhost:123").m_host, "localhost");
+    BOOST_CHECK_EQUAL(url("SSH://user:pass@localhost:123").m_host, "localhost");
+    BOOST_CHECK_EQUAL(url("").m_host, "");
 }
 
 
 BOOST_AUTO_TEST_CASE(ParseUrlPath)
 {
-    BOOST_CHECK_EQUAL(url("http://127.0.0.1:7070/asdasd?qqqqqqqqqqqq").path_, "/asdasd");
-    BOOST_CHECK_EQUAL(url("http://user:password@site.com:err_port/A/B?q").path_, "/A/B");
-    BOOST_CHECK_EQUAL(url("ftp://user@localhost:123/A/B/C/D?x=A").path_, "/A/B/C/D");
-    BOOST_CHECK_EQUAL(url("SSH://user:pass@localhost:123").path_, "");
-    BOOST_CHECK_EQUAL(url("").path_, "");
+    BOOST_CHECK_EQUAL(url("http://127.0.0.1:7070/asdasd?qqqqqqqqqqqq").m_path, "/asdasd");
+    BOOST_CHECK_EQUAL(url("http://user:password@site.com:err_port/A/B?q").m_path, "/A/B");
+    BOOST_CHECK_EQUAL(url("ftp://user@localhost:123/A/B/C/D?x=A").m_path, "/A/B/C/D");
+    BOOST_CHECK_EQUAL(url("SSH://user:pass@localhost:123").m_path, "");
+    BOOST_CHECK_EQUAL(url("").m_path, "");
 } 
 BOOST_AUTO_TEST_CASE(ParseUrlQuery)
 {
-    BOOST_CHECK_EQUAL(url("http://127.0.0.1:7070/asdasd?qqqqqqqqqqqq").query_, "qqqqqqqqqqqq");
-    BOOST_CHECK_EQUAL(url("http://user:password@site.com:err_port/A/B?q").query_, "q");
-    BOOST_CHECK_EQUAL(url("ftp://user@localhost:123/A/B/C/D?x=A").query_, "x=A");
-    BOOST_CHECK_EQUAL(url("SSH://user:pass@localhost:123").query_, "");
-    BOOST_CHECK_EQUAL(url("").query_, "");
+    BOOST_CHECK_EQUAL(url("http://127.0.0.1:7070/asdasd?qqqqqqqqqqqq").m_query, "qqqqqqqqqqqq");
+    BOOST_CHECK_EQUAL(url("http://user:password@site.com:err_port/A/B?q").m_query, "q");
+    BOOST_CHECK_EQUAL(url("ftp://user@localhost:123/A/B/C/D?x=A").m_query, "x=A");
+    BOOST_CHECK_EQUAL(url("SSH://user:pass@localhost:123").m_query, "");
+    BOOST_CHECK_EQUAL(url("").m_query, "");
 }
 
 BOOST_AUTO_TEST_CASE(ParseUrlPortStr)
 {
-    BOOST_CHECK_EQUAL(url("http://127.0.0.1:7070/asdasd?qqqqqqqqqqqq").portstr_, "7070");
-    BOOST_CHECK_EQUAL(url("http://user:password@site.com:err_port/A/B?q").portstr_, "err_port");
-    BOOST_CHECK_EQUAL(url("ftp://user@localhost:123/A/B/C/D?x=A").portstr_, "123");
-    BOOST_CHECK_EQUAL(url("SSH://user:pass@localhost:123").portstr_, "123");
-    BOOST_CHECK_EQUAL(url("").portstr_, "80");
+    BOOST_CHECK_EQUAL(url("http://127.0.0.1:7070/asdasd?qqqqqqqqqqqq").m_portstr, "7070");
+    BOOST_CHECK_EQUAL(url("http://user:password@site.com:err_port/A/B?q").m_portstr, "err_port");
+    BOOST_CHECK_EQUAL(url("ftp://user@localhost:123/A/B/C/D?x=A").m_portstr, "123");
+    BOOST_CHECK_EQUAL(url("SSH://user:pass@localhost:123").m_portstr, "123");
+    BOOST_CHECK_EQUAL(url("").m_portstr, "80");
 }
 
 BOOST_AUTO_TEST_CASE(ParseUrlPort)
 {
-    BOOST_CHECK_EQUAL(url("http://127.0.0.1:7070/asdasd?qqqqqqqqqqqq").port_, 7070);
-    BOOST_CHECK_EQUAL(url("http://user:password@site.com:err_port/A/B?q").port_, 80);
-    BOOST_CHECK_EQUAL(url("ftp://user@localhost:123/A/B/C/D?x=A").port_, 123);
-    BOOST_CHECK_EQUAL(url("SSH://user:pass@localhost:123").port_, 123);
-    BOOST_CHECK_EQUAL(url("").port_, 80);
+    BOOST_CHECK_EQUAL(url("http://127.0.0.1:7070/asdasd?qqqqqqqqqqqq").m_port, 7070);
+    BOOST_CHECK_EQUAL(url("http://user:password@site.com:err_port/A/B?q").m_port, 80);
+    BOOST_CHECK_EQUAL(url("ftp://user@localhost:123/A/B/C/D?x=A").m_port, 123);
+    BOOST_CHECK_EQUAL(url("SSH://user:pass@localhost:123").m_port, 123);
+    BOOST_CHECK_EQUAL(url("").m_port, 80);
 }
 
 BOOST_AUTO_TEST_CASE(ParseUrlUser)
 {
-    BOOST_CHECK_EQUAL(url("http://127.0.0.1:7070/asdasd?qqqqqqqqqqqq").user_, "");
-    BOOST_CHECK_EQUAL(url("http://user:password@site.com:err_port/A/B?q").user_, "user");
-    BOOST_CHECK_EQUAL(url("ftp://user@localhost:123/A/B/C/D?x=A").user_, "user");
-    BOOST_CHECK_EQUAL(url("SSH://@localhost:123").user_, "");
-    BOOST_CHECK_EQUAL(url("SSH://user:@localhost:123").user_, "user");
-    BOOST_CHECK_EQUAL(url("").user_, "");
+    BOOST_CHECK_EQUAL(url("http://127.0.0.1:7070/asdasd?qqqqqqqqqqqq").m_user, "");
+    BOOST_CHECK_EQUAL(url("http://user:password@site.com:err_port/A/B?q").m_user, "user");
+    BOOST_CHECK_EQUAL(url("ftp://user@localhost:123/A/B/C/D?x=A").m_user, "user");
+    BOOST_CHECK_EQUAL(url("SSH://@localhost:123").m_user, "");
+    BOOST_CHECK_EQUAL(url("SSH://user:@localhost:123").m_user, "user");
+    BOOST_CHECK_EQUAL(url("").m_user, "");
 }
 
 BOOST_AUTO_TEST_CASE(ParseUrlPassword)
 {
-    BOOST_CHECK_EQUAL(url("http://127.0.0.1:7070/asdasd?qqqqqqqqqqqq").pass_, "");
-    BOOST_CHECK_EQUAL(url("http://user:password@site.com:err_port/A/B?q").pass_, "password");
-    BOOST_CHECK_EQUAL(url("ftp://user@localhost:123/A/B/C/D?x=A").pass_, "");
-    BOOST_CHECK_EQUAL(url("SSH://@localhost:123").pass_, "");
-    BOOST_CHECK_EQUAL(url("SSH://:password@localhost:123").pass_, "password");
-    BOOST_CHECK_EQUAL(url("").pass_, "");
+    BOOST_CHECK_EQUAL(url("http://127.0.0.1:7070/asdasd?qqqqqqqqqqqq").m_pass, "");
+    BOOST_CHECK_EQUAL(url("http://user:password@site.com:err_port/A/B?q").m_pass, "password");
+    BOOST_CHECK_EQUAL(url("ftp://user@localhost:123/A/B/C/D?x=A").m_pass, "");
+    BOOST_CHECK_EQUAL(url("SSH://@localhost:123").m_pass, "");
+    BOOST_CHECK_EQUAL(url("SSH://:password@localhost:123").m_pass, "password");
+    BOOST_CHECK_EQUAL(url("").m_pass, "");
 }
 
 BOOST_AUTO_TEST_CASE(ParseHTTPRequestNoHeaders)


### PR DESCRIPTION
If there was a maintenance or development branch I would PR there, but I think this will do for now.

When bug squashing, I was actually quite confused as to what the relationship of HTTPS was to reseeding so I reviewed and found that there wasn't any - aside from making an HTTPS request to a reseed server (please correct me if I'm wrong). I can see the crypto-logic for keeping the request there but implementation-wise, I found it confusing and contrary to what will eventually be needed for a #244 fix.

I think this PR will streamline the HTTP/S request process and leave reseeding to actual reseeding. I didn't bother touching the TLS portion because of #244 (of which I <b>very</b> much agree with you on) so I simply added a comment for clarity.