### PR TITLE
Updated CMake stuff to build OpenSSL version with MSVC++

### DIFF
--- a/Daemon.cpp
+++ b/Daemon.cpp
@@ -1,6 +1,5 @@
 #include <thread>
 #include <memory>
-#include <openssl/ssl.h>
 
 #include "Daemon.h"
 
@@ -20,6 +19,8 @@
 #include "HTTPServer.h"
 #include "I2PControl.h"
 #include "ClientContext.h"
+// ssl.h somehow pulls Windows.h stuff that has to go after asio
+#include <openssl/ssl.h>
 
 #ifdef USE_UPNP
 #include "UPnP.h"

--- a/Daemon.cpp
+++ b/Daemon.cpp
@@ -39,7 +39,7 @@ namespace i2p
 			std::unique_ptr<i2p::client::I2PControlService> m_I2PControlService;
 
 #ifdef USE_UPNP
-			UPnP m_UPnP;
+			i2p::transport::UPnP m_UPnP;
 #endif	
 		};
 

--- a/SAM.cpp
+++ b/SAM.cpp
@@ -450,7 +450,7 @@ namespace client
 		auto keys = i2p::data::PrivateKeys::CreateRandomKeys ();
 #ifdef _MSC_VER
 		size_t len = sprintf_s (m_Buffer, SAM_SOCKET_BUFFER_SIZE, SAM_DEST_REPLY, 
-			keys.GetPublic ().ToBase64 ().c_str (), keys.ToBase64 ().c_str ());	
+			keys.GetPublic ()->ToBase64 ().c_str (), keys.ToBase64 ().c_str ());
 #else			                        
 		size_t len = snprintf (m_Buffer, SAM_SOCKET_BUFFER_SIZE, SAM_DEST_REPLY, 
 		    keys.GetPublic ()->ToBase64 ().c_str (), keys.ToBase64 ().c_str ());

--- a/Win32/Win32Service.h
+++ b/Win32/Win32Service.h
@@ -2,7 +2,6 @@
 #define WIN_32_SERVICE_H__
 
 #include <thread>
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 

--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -16,7 +16,7 @@ set ( CMAKE_SOURCE_DIR ".." )
 
 set (COMMON_SRC
   "${CMAKE_SOURCE_DIR}/AddressBook.cpp"	
-  "${CMAKE_SOURCE_DIR}/CryptoConst.cpp"
+  "${CMAKE_SOURCE_DIR}/Crypto.cpp"
   "${CMAKE_SOURCE_DIR}/Garlic.cpp"
   "${CMAKE_SOURCE_DIR}/I2NPProtocol.cpp"
   "${CMAKE_SOURCE_DIR}/Identity.cpp"
@@ -40,8 +40,7 @@ set (COMMON_SRC
   "${CMAKE_SOURCE_DIR}/Transports.cpp"
   "${CMAKE_SOURCE_DIR}/TunnelEndpoint.cpp"
   "${CMAKE_SOURCE_DIR}/TunnelPool.cpp"
-  "${CMAKE_SOURCE_DIR}/aes.cpp"
-  "${CMAKE_SOURCE_DIR}/base64.cpp"
+  "${CMAKE_SOURCE_DIR}/Base.cpp"
   "${CMAKE_SOURCE_DIR}/util.cpp"
   "${CMAKE_SOURCE_DIR}/Datagram.cpp"
   "${CMAKE_SOURCE_DIR}/Signature.cpp"
@@ -65,7 +64,7 @@ set (DAEMON_SRC
   "${CMAKE_SOURCE_DIR}/I2PTunnel.cpp"
   "${CMAKE_SOURCE_DIR}/SAM.cpp"
   "${CMAKE_SOURCE_DIR}/SOCKS.cpp"
-  "${CMAKE_SOURCE_DIR}/i2p.cpp"
+  "${CMAKE_SOURCE_DIR}/i2pd.cpp"
 )
 
 if (WITH_UPNP)
@@ -91,7 +90,9 @@ if (NOT CMAKE_BUILD_TYPE)
 endif ()
 
 # compiler flags customization (by vendor)
-if (NOT MSVC)
+if (MSVC)
+  add_definitions( -D_WIN32_WINNT=_WIN32_WINNT_WINXP -DWIN32_LEAN_AND_MEAN -DNOMINMAX ) #-DOPENSSL_NO_SSL2 -DOPENSSL_USE_DEPRECATED
+else()
   set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Winvalid-pch" )
   set( CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -pedantic" )
   # TODO: The following is incompatible with static build and enabled hardening for OpenWRT.
@@ -212,18 +213,34 @@ if(NOT DEFINED Boost_INCLUDE_DIRS)
   message(SEND_ERROR "Boost is not found, or your boost version was bellow 1.46. Please download Boost!")
 endif()
 
-find_package ( CryptoPP REQUIRED )
-if(NOT DEFINED CRYPTO++_INCLUDE_DIR)
-  message(SEND_ERROR "Could not find Crypto++. Please download and install it first!")
+find_package ( OpenSSL REQUIRED )
+if(NOT DEFINED OPENSSL_INCLUDE_DIR)
+  message(SEND_ERROR "Could not find OpenSSL. Please download and install it first!")
 endif()
 
 find_package ( MiniUPnPc )
-if (NOT ${MINIUPNPC_FOUND})
+if (MINIUPNPC_FOUND)
+  include_directories( ${MINIUPNPC_INCLUDE_DIR} )
+else ()
   set(WITH_UPNP OFF)
 endif()
 
+find_package ( ZLIB )
+if (NOT DEFINED ZLIB-FOUND )
+  include( ExternalProject )
+  ExternalProject_Add(zlib
+    URL http://zlib.net/zlib-1.2.8.tar.gz
+    PREFIX ${CMAKE_CURRENT_BINARY_DIR}/zlib
+    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+  )
+  add_dependencies( common zlib )
+  ExternalProject_Get_Property(zlib install_dir)
+  set (ZLIB_ROOT ${install_dir} )
+  find_package ( ZLIB REQUIRED )
+endif ()
+
 # load includes
-include_directories( ${Boost_INCLUDE_DIRS} ${CRYPTO++_INCLUDE_DIR} )
+include_directories( ${Boost_INCLUDE_DIRS} ${OPENSSL_INCLUDE_DIR} ${ZLIB_INCLUDE_DIR} )
 
 # show summary
 message(STATUS "---------------------------------------")
@@ -271,7 +288,7 @@ if (WITH_BINARY)
   if(${LAST_Boost_LIBRARIES} MATCHES ".*pthread.*")
     list(REMOVE_AT Boost_LIBRARIES -1)
   endif()
-  target_link_libraries( "${PROJECT_NAME}-bin" common ${DL_LIB} ${Boost_LIBRARIES} ${CRYPTO++_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} )
+  target_link_libraries( "${PROJECT_NAME}-bin" common ${DL_LIB} ${Boost_LIBRARIES} ${OPENSSL_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_THREAD_LIBS_INIT} )
 
   install(TARGETS "${PROJECT_NAME}-bin" RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
   if (MSVC)
@@ -285,7 +302,7 @@ if (WITH_LIBRARY)
   add_library(${PROJECT_NAME} STATIC ${LIBRARY_SRC})
  else ()
   add_library(${PROJECT_NAME} ${LIBRARY_SRC})
-  target_link_libraries( ${PROJECT_NAME} common ${Boost_LIBRARIES} ${CRYPTO++_LIBRARIES})
+  target_link_libraries( ${PROJECT_NAME} common ${Boost_LIBRARIES} ${OPENSSL_LIBRARIES})
  endif ()
   if (WITH_PCH)
     if (MSVC)

--- a/build/cmake_modules/FindMiniUPnPc.cmake
+++ b/build/cmake_modules/FindMiniUPnPc.cmake
@@ -4,12 +4,12 @@ if(MINIUPNPC_INCLUDE_DIR)
    set(MINIUPNPC_FOUND TRUE)
 
 else()
-  find_path(MINIUPNPC_INCLUDE_DIR miniupnpc.h
-      /usr/include/miniupnpc
-      /usr/local/include/miniupnpc
-      /opt/local/include/miniupnpc
-      $ENV{SystemDrive}/miniupnpc
-      ${PROJECT_SOURCE_DIR}/../../miniupnpc
+  find_path(MINIUPNPC_INCLUDE_DIR miniupnpc/miniupnpc.h
+      /usr/include
+      /usr/local/include
+      /opt/local/include
+      $ENV{SystemDrive}
+      ${PROJECT_SOURCE_DIR}/../..
       )
   
   if(MINIUPNPC_INCLUDE_DIR)

--- a/stdafx.h
+++ b/stdafx.h
@@ -48,20 +48,20 @@
 #include <boost/program_options/parsers.hpp>
 #include <boost/algorithm/string.hpp>
 
-#include <cryptopp/aes.h>
-#include <cryptopp/adler32.h>
-#include <cryptopp/asn.h>
-#include <cryptopp/base64.h>
-#include <cryptopp/crc.h>
-#include <cryptopp/dh.h>
-#include <cryptopp/dsa.h>
-#include <cryptopp/eccrypto.h>
-#include <cryptopp/gzip.h>
-#include <cryptopp/hmac.h>
-#include <cryptopp/integer.h>
-#include <cryptopp/modes.h>
-#include <cryptopp/osrng.h>
-#include <cryptopp/sha.h>
-#include <cryptopp/zinflate.h>
+#include <zlib.h>
+
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+#include <openssl/bn.h>
+#include <openssl/dh.h>
+#include <openssl/aes.h>
+#include <openssl/sha.h>
+#include <openssl/md5.h>
+#include <openssl/rand.h>
+#include <openssl/dsa.h>
+#include <openssl/ec.h>
+#include <openssl/ecdsa.h>
+#include <openssl/rsa.h>
+#include <openssl/evp.h>
 
 #endif


### PR DESCRIPTION
Tested with Boost 1.58 and OpenSSL 1.0.1p. You may want to use [Chocolatey](chocolatey.org/) on Windows to `cinst git kdiff3 cmake strawberryperl nasm visualstudio2015community` or whatever is missing. Then from the command line of MSVC
```
perl Configure VC-WIN32 --prefix=C:\OpenSSL-Win32
ms\do_nasm
nmake -f ms\ntdll.mak
nmake -f ms\ntdll.mak install
```
CMake will look for OpenSSL in `C:\OpenSSL-Win32` among other places.