### PR TITLE
Make tunnels.cfg configurable

### DIFF
--- a/ClientContext.cpp
+++ b/ClientContext.cpp
@@ -243,13 +243,14 @@ namespace client
 	void ClientContext::ReadTunnels ()
 	{
 		boost::property_tree::ptree pt;
+		std::string pathTunnelsConfigFile = i2p::util::filesystem::GetTunnelsConfigFile().string();
 		try
 		{
-			boost::property_tree::read_ini (i2p::util::filesystem::GetFullPath (TUNNELS_CONFIG_FILENAME), pt);
+			boost::property_tree::read_ini (pathTunnelsConfigFile, pt);
 		}
 		catch (std::exception& ex)
 		{
-			LogPrint (eLogWarning, "Can't read ", TUNNELS_CONFIG_FILENAME, ": ", ex.what ());
+			LogPrint (eLogWarning, "Can't read ", pathTunnelsConfigFile, ": ", ex.what ());
 			return;
 		}
 			
@@ -313,7 +314,7 @@ namespace client
 					numServerTunnels++;
 				}
 				else
-					LogPrint (eLogWarning, "Unknown section type=", type, " of ", name, " in ", TUNNELS_CONFIG_FILENAME);
+					LogPrint (eLogWarning, "Unknown section type=", type, " of ", name, " in ", pathTunnelsConfigFile);
 				
 			}
 			catch (std::exception& ex)

--- a/ClientContext.h
+++ b/ClientContext.h
@@ -29,7 +29,6 @@ namespace client
 	const char I2P_SERVER_TUNNEL_KEYS[] = "keys";
 	const char I2P_SERVER_TUNNEL_INPORT[] = "inport";
 	const char I2P_SERVER_TUNNEL_ACCESS_LIST[] = "accesslist";		
-	const char TUNNELS_CONFIG_FILENAME[] = "tunnels.cfg";
 
 	class ClientContext
 	{

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Cmdline options
 * --samport=            - Port of SAM bridge. Usually 7656. SAM is off if not specified
 * --bobport=            - Port of BOB command channel. Usually 2827. BOB is off if not specified
 * --i2pcontrolport=     - Port of I2P control service. Usually 7650. I2PControl is off if not specified
+* --tunnelscfg=         - Tunnels Config file (default: ~/.i2pd/tunnels.cfg or /var/lib/i2pd/tunnels.cfg)
 * --conf=               - Config file (default: ~/.i2pd/i2p.conf or /var/lib/i2pd/i2p.conf)
                           This parameter will be silently ignored if the specified config file does not exist.
                           Options specified on the command line take precedence over those in the config file.

--- a/util.cpp
+++ b/util.cpp
@@ -193,6 +193,14 @@ namespace filesystem
 		return pathConfigFile;
 	}
 
+	boost::filesystem::path GetTunnelsConfigFile()
+	{
+	  boost::filesystem::path pathTunnelsConfigFile(i2p::util::config::GetArg("-tunnelscfg", "tunnels.cfg"));
+		if (!pathTunnelsConfigFile.is_complete())
+		  pathTunnelsConfigFile = GetDataDir() / pathTunnelsConfigFile;
+		return pathTunnelsConfigFile;
+	}
+
 	void ReadConfigFile(std::map<std::string, std::string>& mapSettingsRet,
 						std::map<std::string, std::vector<std::string> >& mapMultiSettingsRet)
 	{

--- a/util.h
+++ b/util.h
@@ -33,6 +33,7 @@ namespace util
 		std::string GetFullPath (const std::string& filename);	
 		boost::filesystem::path GetDefaultDataDir();
 		boost::filesystem::path GetConfigFile();
+		boost::filesystem::path GetTunnelsConfigFile();
 		void ReadConfigFile(std::map<std::string, std::string>& mapSettingsRet,
                 std::map<std::string, std::vector<std::string> >& mapMultiSettingsRet);
 		boost::filesystem::path GetCertificatesDir();


### PR DESCRIPTION
This is the same change that was introduced in https://github.com/PurpleI2P/i2pd/commit/3d489a29962aef779af608b6cb311ec23552ed89 but later lost when the move back from bitbucket happened.