### PR TITLE
Better checking if boost::asio::buffer works with std::array

### DIFF
--- a/I2PControl.cpp
+++ b/I2PControl.cpp
@@ -209,7 +209,7 @@ namespace client
 	{
 		auto request = std::make_shared<I2PControlBuffer>();
 		socket->async_read_some (
-#if BOOST_VERSION >= 104900
+#if defined(BOOST_ASIO_HAS_STD_ARRAY)
 			boost::asio::buffer (*request),  
 #else
 			boost::asio::buffer (request->data (), request->size ()), 


### PR DESCRIPTION
Currently, checking whether boost::asio::buffer constructor accepts std::array is performed by checking boost version. This fails with clang 3.4 and boost 1.54. Luckily, boost has `BOOST_ASIO_HAS_STD_ARRAY` flag specifically for this.