### PR TITLE
Write service log to separate directory

### DIFF
--- a/Daemon.cpp
+++ b/Daemon.cpp
@@ -107,7 +107,7 @@ namespace i2p
 			{
 				if (isDaemon)
 				{
-					std::string logfile_path = IsService () ? "/var/log" : i2p::util::filesystem::GetDataDir().string();
+					std::string logfile_path = IsService () ? "/var/log/i2pd" : i2p::util::filesystem::GetDataDir().string();
 #ifndef _WIN32
 					logfile_path.append("/i2pd.log");
 #else

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,7 +13,7 @@ Command line options
 * --pidfile=            - Where to write pidfile (dont write by default)
 * --daemon=             - Enable or disable daemon mode. 1 for yes, 0 for no.
 * --svcctl=             - Windows service management (--svcctl="install" or --svcctl="remove")
-* --service=            - 1 if uses system folders (/var/run/i2pd.pid, /var/log/i2pd.log, /var/lib/i2pd).
+* --service=            - 1 if uses system folders (/var/run/i2pd.pid, /var/log/i2pd/i2pd.log, /var/lib/i2pd).
 * --v6=                 - 1 if supports communication through ipv6, off by default
 * --floodfill=          - 1 if router is floodfill, off by default
 * --bandwidth=          - L if bandwidth is limited to 32Kbs/sec, O - to 256Kbs/sec, P - unlimited


### PR DESCRIPTION
Пакую i2pd в качестве дистрибутивного пакета, готового к работе "из коробки". Разумеется, хочется чтобы общесистемный сервис HTTP/Socks-прокси работал из под непривилегированного пользователя.

Обычно хорошие unix-демоны при старте выполняют привелегированные операции (пишут .pid-файл, открываю лог, сетевые сокеты) и понижают свои привилегии до минимально необходимых для дальнейшей работы (опционально, делая непосредственно перед этим системный вызов chroot). Но i2pd не таков, по крайней мере на данный момент (релиз 2.3.0). Его надо или запускать от суперпользователя (так понимаю, этот вариант предполагается "по умолчанию") или же от обычного пользователя, но ограничивая при этом "высокими" номерами портов и списком каталогов, доступных для чтения/записи.

Чтобы упростить пакетирование, выбрал второй вариант. Пока столкнулся с двуми трудностями: 1) нужны права для записи pid-файла при старте. 2) нужен доступ на запись логов. И если путь до пид-файла можно указать аргументом запуска, то путь до файла лога - нет. Разумеется, давать непривелегированному пользователю право на запись непосредственно в /var/log - неправильно. Чтобы решить эту проблему и сделан данный патч. Если писать лог-файл в отдельную директорию, то ей можно назначить минимально нужные права (заодно и отнять права на редактирование/удаление ротированных логов).

Конечно, гораздо лучше было бы иметь возможность задать лог-файл аргументом при запуске, но на это мне, боюсь. компетенции не хватит.