### PR TITLE
Remove unused assigning (success is assinged anyway)

### DIFF
--- a/AddressBook.cpp
+++ b/AddressBook.cpp
@@ -744,7 +744,6 @@ namespace client
 					LogPrint (eLogInfo, "Addressbook: received ", m_Link, " ETag: ", m_Etag, " Last-Modified: ", m_LastModified);
 					if (!response.eof () && !response.fail ())	
 					{
-						success = true;
 						if (!isChunked)
 							success = ProcessResponse (response, isGzip);
 						else


### PR DESCRIPTION
Minor fix.
Also,  172 line of Base.cpp
outCount = 0 is not needed assigning local variable before returning from function.