### PR TITLE
Reload client config on SIGHUP

### DIFF
--- a/DaemonLinux.cpp
+++ b/DaemonLinux.cpp
@@ -13,6 +13,7 @@
 #include "FS.h"
 #include "Log.h"
 #include "RouterContext.h"
+#include "ClientContext.h"
 
 void handle_signal(int sig)
 {
@@ -21,6 +22,7 @@ void handle_signal(int sig)
 		case SIGHUP:
 			LogPrint(eLogInfo, "Daemon: Got SIGHUP, reopening log...");
 			i2p::log::Logger().Reopen ();
+			i2p::client::context.ReloadConfig();
 		break;
 		case SIGINT:
 			if (i2p::context.AcceptsTunnels () && !Daemon.gracefullShutdownInterval)


### PR DESCRIPTION
Like Tor and other daemons, i2pd should be able to reload config without a fully restart. This is usually done with a SIGHUP signal. Implemented and tested on OSX.

@orignal OK for merging?