### PR TITLE
The temporary object elemination part#1

### DIFF
--- a/AddressBook.cpp
+++ b/AddressBook.cpp
@@ -173,7 +173,7 @@ namespace client
 			return 0;
 		}
 
-		for (auto it: addresses) {
+		for (const auto& it: addresses) {
 			f << it.first << "," << it.second.ToBase32 () << std::endl;
 			num++;
 		}
@@ -252,7 +252,7 @@ namespace client
 			}	
 			LogPrint (eLogError, "Addressbook: subscription download timeout");
 			m_IsDownloading = false;
-		}	
+		}
 		if (m_Storage)
 		{
 			m_Storage->Save (m_Addresses);
@@ -260,7 +260,7 @@ namespace client
 			m_Storage = nullptr;
 		}
 		m_DefaultSubscription = nullptr;	
-		for (auto it: m_Subscriptions)
+		for (auto& it: m_Subscriptions)
 			delete it;
 		m_Subscriptions.clear ();	
 	}	
@@ -418,7 +418,7 @@ namespace client
 	{
 		std::map<std::string, i2p::data::IdentHash> localAddresses;
 		m_Storage->LoadLocal (localAddresses);
-		for (auto it: localAddresses)
+		for (const auto& it: localAddresses)
 		{
 			auto dot = it.first.find ('.');
 			if (dot != std::string::npos)

--- a/BOB.cpp
+++ b/BOB.cpp
@@ -536,8 +536,8 @@ namespace client
 	void BOBCommandSession::ListCommandHandler (const char * operand, size_t len)
 	{
 		LogPrint (eLogDebug, "BOB: list");
-		auto& destinations = m_Owner.GetDestinations ();
-		for (auto it: destinations)
+		const auto& destinations = m_Owner.GetDestinations ();
+		for (const auto& it: destinations)
 			SendData (it.first.c_str ());
 		SendReplyOK ("Listing done");
 	}	
@@ -619,7 +619,7 @@ namespace client
 	BOBCommandChannel::~BOBCommandChannel ()
 	{
 		Stop ();
-		for (auto it: m_Destinations)
+		for (const auto& it: m_Destinations)
 			delete it.second;
 	}
 
@@ -633,7 +633,7 @@ namespace client
 	void BOBCommandChannel::Stop ()
 	{
 		m_IsRunning = false;
-		for (auto it: m_Destinations)
+		for (auto& it: m_Destinations)
 			it.second->Stop ();
 		m_Acceptor.cancel ();	
 		m_Service.stop ();

--- a/ClientContext.cpp
+++ b/ClientContext.cpp
@@ -194,7 +194,7 @@ namespace client
 
 		LogPrint(eLogInfo, "Clients: stopping AddressBook");
 		m_AddressBook.Stop ();		
-		for (auto it: m_Destinations)
+		for (auto& it: m_Destinations)
 			it.second->Stop ();
 		m_Destinations.clear ();
 		m_SharedLocalDestination = nullptr; 

--- a/Destination.cpp
+++ b/Destination.cpp
@@ -103,7 +103,7 @@ namespace client
 	{
 		if (m_IsRunning)	
 			Stop ();
-		for (auto it: m_LeaseSetRequests)
+		for (auto& it: m_LeaseSetRequests)
 			if (it.second->requestComplete) it.second->requestComplete (nullptr);
 		m_LeaseSetRequests.clear ();
 		if (m_Pool)
@@ -635,7 +635,7 @@ namespace client
 				it = m_RemoteLeaseSets.erase (it);
 			}	
 			else 
-				it++;
+				++it;
 		}
 	}	
 
@@ -663,7 +663,7 @@ namespace client
 		{	
 			m_StreamingDestination = std::make_shared<i2p::stream::StreamingDestination> (GetSharedFromThis ()); // TODO:
 			m_StreamingDestination->Start ();	
-			for (auto it: m_StreamingDestinationsByPorts)
+			for (auto& it: m_StreamingDestinationsByPorts)
 				it.second->Start ();
 			return true;
 		}	
@@ -677,7 +677,7 @@ namespace client
 		{
 			m_StreamingDestination->Stop ();
 			m_StreamingDestination = nullptr;
-			for (auto it: m_StreamingDestinationsByPorts)
+			for (auto& it: m_StreamingDestinationsByPorts)
 				it.second->Stop ();
 			if (m_DatagramDestination)
 			{

--- a/Garlic.cpp
+++ b/Garlic.cpp
@@ -111,7 +111,7 @@ namespace garlic
 				it = m_UnconfirmedTagsMsgs.erase (it);
 			}	
 			else 
-				it++;
+				++it;
 		}
 	}
 
@@ -123,7 +123,7 @@ namespace garlic
 			if (ts >= it->creationTime + OUTGOING_TAGS_EXPIRATION_TIMEOUT)
 				it = m_SessionTags.erase (it);
 			else 
-				it++;
+				++it;
 		}
 		CleanupUnconfirmedTags ();
 		return !m_SessionTags.empty () || !m_UnconfirmedTagsMsgs.empty ();
@@ -144,7 +144,7 @@ namespace garlic
 				ret = true;
 			}	
 			else
-				it++;
+				++it;
 		}	
 		return ret;
 	}
@@ -615,7 +615,7 @@ namespace garlic
 				it = m_Tags.erase (it);
 			}	
 			else
-				it++;
+				++it;
 		}
 		if (numExpiredTags > 0)
 			LogPrint (eLogDebug, "Garlic: ", numExpiredTags, " tags expired for ", GetIdentHash().ToBase64 ());
@@ -631,7 +631,7 @@ namespace garlic
 				it = m_Sessions.erase (it);
 			}
 			else
-				it++;
+				++it;
 		}
 	}
 
@@ -643,26 +643,26 @@ namespace garlic
 	void GarlicDestination::DeliveryStatusSent (GarlicRoutingSessionPtr session, uint32_t msgID)
 	{
 		m_DeliveryStatusSessions[msgID] = session;
-	}		
+	}
 
 	void GarlicDestination::HandleDeliveryStatusMessage (std::shared_ptr<I2NPMessage> msg)
 	{
 		uint32_t msgID = bufbe32toh (msg->GetPayload ());
 		{
 			auto it = m_DeliveryStatusSessions.find (msgID);
-			if (it != m_DeliveryStatusSessions.end ())			
+			if (it != m_DeliveryStatusSessions.end ())
 			{
 				it->second->MessageConfirmed (msgID);
 				m_DeliveryStatusSessions.erase (it);
 				LogPrint (eLogDebug, "Garlic: message ", msgID, " acknowledged");
-			}	
+			}
 		}
 	}
 
 	void GarlicDestination::SetLeaseSetUpdated ()
 	{
-		std::unique_lock<std::mutex> l(m_SessionsMutex);	
-		for (auto it: m_Sessions)
+		std::unique_lock<std::mutex> l(m_SessionsMutex);
+		for (auto& it: m_Sessions)
 			it.second->SetLeaseSetUpdated ();
 	}
 

--- a/HTTP.cpp
+++ b/HTTP.cpp
@@ -160,7 +160,7 @@ namespace http {
     strsplit(query, tokens, '&');
 
     params.clear();
-    for (auto it : tokens) {
+    for (const auto& it : tokens) {
       std::size_t eq = it.find ('=');
       if (eq != std::string::npos) {
         auto e = std::pair<std::string, std::string>(it.substr(0, eq), it.substr(eq + 1));

--- a/HTTPProxy.cpp
+++ b/HTTPProxy.cpp
@@ -105,7 +105,7 @@ namespace proxy {
 		ss << "<p>" << description << "</p>\r\n";
 		std::string content = ss.str();
 		SendProxyError(content);
-  }
+	}
 
 	void HTTPReqHandler::HostNotFound(std::string & host) {
 		std::stringstream ss;
@@ -113,13 +113,13 @@ namespace proxy {
 		   << "<p>Remote host not found in router's addressbook</p>\r\n"
 		   << "<p>You may try to find this host on jumpservices below:</p>\r\n"
 		   << "<ul>\r\n";
-		for (auto & js : jumpservices) {
+		for (const auto& js : jumpservices) {
 			ss << "  <li><a href=\"" << js.second << host << "\">" << js.first << "</a></li>\r\n";
 		}
 		ss << "</ul>\r\n";
 		std::string content = ss.str();
 		SendProxyError(content);
-  }
+	}
 
 	void HTTPReqHandler::SendProxyError(std::string & content)
 	{
@@ -164,7 +164,7 @@ namespace proxy {
 		req.del_header("Forwarded");
 		/* drop proxy-disclosing headers */
 		std::vector<std::string> toErase;
-		for (auto it : req.headers) {
+		for (const auto& it : req.headers) {
 			if (it.first.compare(0, 12, "X-Forwarded-") == 0) {
 				toErase.push_back(it.first);
 			} else if (it.first.compare(0, 6, "Proxy-") == 0) {
@@ -173,7 +173,7 @@ namespace proxy {
 				/* allow */
 			}
 		}
-		for (auto header : toErase) {
+		for (const auto& header : toErase) {
 			req.headers.erase(header);
 		}
 		/* replace headers */

--- a/HTTPServer.cpp
+++ b/HTTPServer.cpp
@@ -210,7 +210,7 @@ namespace http {
 		s << "<b>Router Family:</b> " << i2p::context.GetRouterInfo().GetProperty("family") << "<br>\r\n";
 		s << "<b>Router Caps:</b> " << i2p::context.GetRouterInfo().GetProperty("caps") << "<br>\r\n";
 		s << "<b>Our external address:</b>" << "<br>\r\n" ;
-		for (auto address : i2p::context.GetRouterInfo().GetAddresses())
+		for (const auto& address : i2p::context.GetRouterInfo().GetAddresses())
 		{
 			switch (address->transportStyle)
 			{
@@ -283,7 +283,7 @@ namespace http {
 			}	
 			s << "<br>\r\n";
 			s << "<b>Tags</b><br>Incoming: " << dest->GetNumIncomingTags () << "<br>Outgoing:<br>" << std::endl;
-			for (auto it: dest->GetSessions ())
+			for (const auto& it: dest->GetSessions ())
 			{
 				s << i2p::client::context.GetAddressBook ().ToAddress(it.first) << " ";
 				s << it.second->GetNumOutgoingTags () << "<br>" << std::endl;
@@ -314,7 +314,7 @@ namespace http {
 			s << "<th>Status</th>";
 			s << "</tr>";
 
-			for (auto it: dest->GetAllStreams ())
+			for (const auto& it: dest->GetAllStreams ())
 			{	
 				s << "<tr>";
 				s << "<td>" << it->GetSendStreamID () << "</td>";
@@ -432,7 +432,7 @@ namespace http {
 	void ShowTransitTunnels (std::stringstream& s)
 	{
 		s << "<b>Transit tunnels:</b><br>\r\n<br>\r\n";
-		for (auto it: i2p::tunnel::tunnels.GetTransitTunnels ())
+		for (const auto& it: i2p::tunnel::tunnels.GetTransitTunnels ())
 		{
 			if (std::dynamic_pointer_cast<i2p::tunnel::TransitTunnelGateway>(it))
 				s << it->GetTunnelID () << " ⇒ ";
@@ -451,7 +451,7 @@ namespace http {
 		if (ntcpServer)
 		{	
 			s << "<b>NTCP</b><br>\r\n";
-			for (auto it: ntcpServer->GetNTCPSessions ())
+			for (const auto& it: ntcpServer->GetNTCPSessions ())
 			{
 				if (it.second && it.second->IsEstablished ())
 				{
@@ -469,7 +469,7 @@ namespace http {
 		if (ssuServer)
 		{
 			s << "<br>\r\n<b>SSU</b><br>\r\n";
-			for (auto it: ssuServer->GetSessions ())
+			for (const auto& it: ssuServer->GetSessions ())
 			{
 				auto endpoint = it.second->GetRemoteEndpoint ();
 				if (it.second->IsOutgoing ()) s << " ⇒ ";
@@ -481,7 +481,7 @@ namespace http {
 				s << "<br>\r\n" << std::endl;
 			}
 			s << "<br>\r\n<b>SSU6</b><br>\r\n";
-			for (auto it: ssuServer->GetSessionsV6 ())
+			for (const auto& it: ssuServer->GetSessionsV6 ())
 			{
 				auto endpoint = it.second->GetRemoteEndpoint ();
 				if (it.second->IsOutgoing ()) s << " ⇒ ";
@@ -526,7 +526,7 @@ namespace http {
 		s << i2p::client::context.GetAddressBook ().ToAddress(ident) << "</a><br>\r\n";
 		s << "<br>\r\n";
 		s << "<b>Streams:</b><br>\r\n";
-		for (auto it: session->ListSockets())
+		for (const auto& it: session->ListSockets())
 		{
 			switch (it->GetSocketType ())
 			{

--- a/I2CP.cpp
+++ b/I2CP.cpp
@@ -659,7 +659,7 @@ namespace client
 	{
 		m_IsRunning = false;
 		m_Acceptor.cancel ();
-		for (auto it: m_Sessions)
+		for (auto& it: m_Sessions)
 			it.second->Stop ();
 		m_Sessions.clear ();
 		m_Service.stop ();

--- a/I2NPProtocol.cpp
+++ b/I2NPProtocol.cpp
@@ -202,7 +202,7 @@ namespace i2p
 		len += 32;
 		buf[len] = routers.size (); 
 		len++;
-		for (auto it: routers)
+		for (const auto& it: routers)
 		{
 			memcpy (buf + len, it, 32);
 			len += 32;

--- a/I2PControl.cpp
+++ b/I2PControl.cpp
@@ -358,7 +358,7 @@ namespace client
 
 	void I2PControlService::RouterInfoHandler (const boost::property_tree::ptree& params, std::ostringstream& results)
 	{
-		for (auto it = params.begin (); it != params.end (); it++)
+		for (auto it = params.begin (); it != params.end (); ++it)
 		{
 			LogPrint (eLogDebug, "I2PControl: RouterInfo request: ", it->first);
 			auto it1 = m_RouterInfoHandlers.find (it->first);
@@ -434,7 +434,7 @@ namespace client
 
 	void I2PControlService::RouterManagerHandler (const boost::property_tree::ptree& params, std::ostringstream& results)
 	{
-		for (auto it = params.begin (); it != params.end (); it++)
+		for (auto it = params.begin (); it != params.end (); ++it)
 		{
 			if (it != params.begin ()) results << ",";	
 			LogPrint (eLogDebug, "I2PControl: RouterManager request: ", it->first);
@@ -483,7 +483,7 @@ namespace client
 // network setting
 	void I2PControlService::NetworkSettingHandler (const boost::property_tree::ptree& params, std::ostringstream& results)
 	{
-		for (auto it = params.begin (); it != params.end (); it++)
+		for (auto it = params.begin (); it != params.end (); ++it)
 		{
 			if (it != params.begin ()) results << ",";	
 			LogPrint (eLogDebug, "I2PControl: NetworkSetting request: ", it->first);

--- a/LeaseSet.cpp
+++ b/LeaseSet.cpp
@@ -64,10 +64,10 @@ namespace data
 			return;
 		}	
 
-		// reset existing leases	
+		// reset existing leases
 		if (m_StoreLeases)
-			for (auto it: m_Leases)
-				it->isUpdated = false;		
+			for (auto& it: m_Leases)
+				it->isUpdated = false;
 		else	
 			m_Leases.clear ();
 
@@ -123,7 +123,7 @@ namespace data
 					m_Leases.erase (it++);
 				}	
 				else
-					it++;
+					++it;
 			}
 		}
 
@@ -167,7 +167,7 @@ namespace data
 	{
 		auto ts = i2p::util::GetMillisecondsSinceEpoch ();
 		std::vector<std::shared_ptr<const Lease> > leases;
-		for (auto it: m_Leases)
+		for (const auto& it: m_Leases)
 		{
 			auto endDate = it->endDate;
 			if (withThreshold)
@@ -183,7 +183,7 @@ namespace data
 	bool LeaseSet::HasExpiredLeases () const
  	{
 		auto ts = i2p::util::GetMillisecondsSinceEpoch ();
-		for (auto it: m_Leases)
+		for (const auto& it: m_Leases)
 			if (ts >= it->endDate) return true;
 		return false;
  	}	

--- a/NetDb.cpp
+++ b/NetDb.cpp
@@ -51,7 +51,7 @@ namespace data
 	{
 		if (m_IsRunning)
 		{	
-			for (auto it: m_RouterInfos)
+			for (auto& it: m_RouterInfos)
 				it.second->SaveProfile ();
 			DeleteObsoleteProfiles ();
 			m_RouterInfos.clear ();
@@ -339,7 +339,7 @@ namespace data
 		m_LastLoad = i2p::util::GetSecondsSinceEpoch();
 		std::vector<std::string> files;
 		m_Storage.Traverse(files);
-		for (auto path : files)
+		for (const auto& path : files)
 			LoadRouterInfo(path);
 
 		LogPrint (eLogInfo, "NetDb: ", m_RouterInfos.size(), " routers loaded (", m_Floodfills.size (), " floodfils)");
@@ -357,7 +357,7 @@ namespace data
 			expirationTimeout = i2p::context.IsFloodfill () ? NETDB_FLOODFILL_EXPIRATION_TIMEOUT*1000LL :
 					NETDB_MIN_EXPIRATION_TIMEOUT*1000LL + (NETDB_MAX_EXPIRATION_TIMEOUT - NETDB_MIN_EXPIRATION_TIMEOUT)*1000LL*NETDB_MIN_ROUTERS/total;	
 
-		for (auto it: m_RouterInfos)
+		for (auto& it: m_RouterInfos)
 		{	
 			std::string ident = it.second->GetIdentHashBase64();
 			std::string path  = m_Storage.Path(ident);
@@ -405,7 +405,7 @@ namespace data
 						it = m_RouterInfos.erase (it);
 						continue;
 					}	
-					it++;
+					++it;
 				}
 			}	
 			// clean up expired floodfiils
@@ -415,7 +415,7 @@ namespace data
 					if ((*it)->IsUnreachable ())
 						it = m_Floodfills.erase (it);
 					else
-						it++;
+						++it;
 			}	
 		}
 	}
@@ -901,7 +901,7 @@ namespace data
 		{	
 			uint32_t i = 0;
 			std::unique_lock<std::mutex> l(m_RouterInfosMutex);
-			for (auto it: m_RouterInfos)
+			for (const auto& it: m_RouterInfos)
 			{	
 				if (i >= ind)
 				{	
@@ -933,7 +933,7 @@ namespace data
 		else	
 			minMetric.SetMax ();
 		std::unique_lock<std::mutex> l(m_FloodfillsMutex);
-		for (auto it: m_Floodfills)
+		for (const auto& it: m_Floodfills)
 		{	
 			if (!it->IsUnreachable ())
 			{	
@@ -964,7 +964,7 @@ namespace data
 		if (closeThanUsOnly) ourMetric = destKey ^ i2p::context.GetIdentHash ();
 		{
 			std::unique_lock<std::mutex> l(m_FloodfillsMutex);
-			for (auto it: m_Floodfills)
+			for (const auto& it: m_Floodfills)
 			{
 				if (!it->IsUnreachable ())
 				{	
@@ -983,11 +983,11 @@ namespace data
 
 		std::vector<IdentHash> res;	
 		size_t i = 0;			
-		for (auto it: sorted)
+		for (const auto& it: sorted)
 		{
 			if (i < num)
 			{
-				auto& ident = it.r->GetIdentHash ();
+				const auto& ident = it.r->GetIdentHash ();
 				if (!excluded.count (ident))
 				{	
 					res.push_back (ident);
@@ -1016,7 +1016,7 @@ namespace data
 		IdentHash destKey = CreateRoutingKey (destination);
 		minMetric.SetMax ();
 		// must be called from NetDb thread only
-		for (auto it: m_RouterInfos)
+		for (const auto& it: m_RouterInfos)
 		{	
 			if (!it.second->IsFloodfill ())
 			{	
@@ -1042,7 +1042,7 @@ namespace data
 				it = m_LeaseSets.erase (it);
 			}	
 			else 
-				it++;
+				++it;
 		}
 	}
 
@@ -1054,7 +1054,7 @@ namespace data
 			if (ts > it->second.second + 180) // 3 minutes
 				it = m_LookupResponses.erase (it);
 			else
-				it++;
+				++it;
 		}
 	}
 }

--- a/NetDbRequests.cpp
+++ b/NetDbRequests.cpp
@@ -141,7 +141,7 @@ namespace data
 			if (done)
 				it = m_RequestedDestinations.erase (it);
 			else
-				it++;
+				++it;
 		}	
 	}
 }

--- a/Profiling.cpp
+++ b/Profiling.cpp
@@ -167,7 +167,7 @@ namespace data
 
 		std::vector<std::string> files;
 		m_ProfilesStorage.Traverse(files);
-		for (auto path: files) {
+		for (const auto& path: files) {
 			if (stat(path.c_str(), &st) != 0) {
 				LogPrint(eLogWarning, "Profiling: Can't stat(): ", path);
 				continue;

--- a/Queue.h
+++ b/Queue.h
@@ -7,6 +7,7 @@
 #include <thread>
 #include <condition_variable>
 #include <functional>
+#include <utility>
 
 namespace i2p
 {
@@ -20,7 +21,7 @@ namespace util
 			void Put (Element e)
 			{
 				std::unique_lock<std::mutex>  l(m_QueueMutex);
-				m_Queue.push (e);	
+				m_Queue.push (std::move(e));
 				m_NonEmpty.notify_one ();
 			}
 
@@ -29,7 +30,7 @@ namespace util
 				if (!vec.empty ())
 				{	
 					std::unique_lock<std::mutex>  l(m_QueueMutex);
-					for (auto it: vec)
+					for (const auto& it: vec)
 						m_Queue.push (it);	
 					m_NonEmpty.notify_one ();
 				}	

--- a/Tunnel.h
+++ b/Tunnel.h
@@ -224,7 +224,7 @@ namespace tunnel
 			std::list<std::shared_ptr<TunnelPool>> m_Pools;
 			std::shared_ptr<TunnelPool> m_ExploratoryPool;
 			i2p::util::Queue<std::shared_ptr<I2NPMessage> > m_Queue;
-      
+
 			// some stats
 			int m_NumSuccesiveTunnelCreations, m_NumFailedTunnelCreations;
 


### PR DESCRIPTION
This commit includes several types of temporary object elimination. I most part is related to missing reference for _auto_ type variables for range based _for_. It also includes corrections for loops based on iterators to prefix form.