### PR TITLE
Fixed upstart i2pd forking

### DIFF
--- a/debian/i2pd.upstart
+++ b/debian/i2pd.upstart
@@ -6,4 +6,6 @@ stop on runlevel [016] or unmounting-filesystem
 # these can be overridden in /etc/init/i2pd.override
 env LOGFILE="/var/log/i2pd.log"
 
+expect fork
+
 exec /usr/sbin/i2pd --daemon --service --log=file --logfile=$LOGFILE


### PR DESCRIPTION
Upstart can't track daemonize fork without expect fork