### PR TITLE
Adding option to configure reseed URLs

### DIFF
--- a/Config.cpp
+++ b/Config.cpp
@@ -151,6 +151,23 @@ namespace config {
 	options_description reseed("Reseed options");	
 	reseed.add_options()
 	  ("reseed.file", value<std::string>()->default_value(""),  "Path to .su3 file")
+#ifdef MESHNET
+	  ("reseed.urls", value<std::string>()->default_value("https://reseed.i2p.rocks:8443/"),  "Reseed URLs, separated by comma")
+#else
+	  ("reseed.urls", value<std::string>()->default_value(
+		"https://reseed.i2p-projekt.de/,"
+		"https://i2p.mooo.com/netDb/,"
+		"https://netdb.i2p2.no/,"
+		"https://us.reseed.i2p2.no:444/,"
+		"https://uk.reseed.i2p2.no:444/,"
+		"https://i2p.manas.ca:8443/,"
+		"https://i2p-0.manas.ca:8443/,"
+		"https://reseed.i2p.vzaws.com:8443/,"
+		"https://user.mx24.eu/,"
+		"https://download.xxlspeed.com/,"
+		"https://reseed-ru.lngserv.ru/"
+		),  "Reseed URLs, separated by comma")
+#endif
 	  ;	
 
   	options_description trust("Trust options");

--- a/Reseed.cpp
+++ b/Reseed.cpp
@@ -3,6 +3,7 @@
 #include <sstream>
 #include <boost/asio.hpp>
 #include <boost/asio/ssl.hpp> 
+#include <boost/algorithm/string.hpp>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #include <zlib.h>
@@ -22,26 +23,6 @@ namespace i2p
 {
 namespace data
 {
-	static std::vector<std::string> httpsReseedHostList =
-	{
-#ifdef MESHNET
-		// meshnet i2p reseeds
-		"https://reseed.i2p.rocks:8443/"
-#else
-		// mainline i2p reseeds
-		"https://reseed.i2p-projekt.de/", // Only HTTPS
-		"https://i2p.mooo.com/netDb/",
-		"https://netdb.i2p2.no/", // Only SU3 (v3) support, SNI required
-		"https://us.reseed.i2p2.no:444/",	
-		"https://uk.reseed.i2p2.no:444/",
-		"https://i2p.manas.ca:8443/",
-		"https://i2p-0.manas.ca:8443/",
-		"https://reseed.i2p.vzaws.com:8443/", // Only SU3 (v3) support
-		"https://user.mx24.eu/", // Only HTTPS and SU3 (v3) support
-		"https://download.xxlspeed.com/", // Only HTTPS and SU3 (v3) support
-		"https://reseed-ru.lngserv.ru/"
-#endif
-	};
  
 	Reseeder::Reseeder()
 	{
@@ -53,6 +34,10 @@ namespace data
 
 	int Reseeder::ReseedNowSU3 ()
 	{
+		std::string reseedURLs; i2p::config::GetOption("reseed.urls", reseedURLs);
+		std::vector<std::string> httpsReseedHostList;
+		boost::split(httpsReseedHostList, reseedURLs, boost::is_any_of(","), boost::token_compress_on);
+
 		std::string filename; i2p::config::GetOption("reseed.file", filename);
 		if (filename.length() > 0) // reseed file is specified
 		{

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -73,6 +73,7 @@ All options below still possible in cmdline, but better write it in config file:
 
 * --precomputation.elgamal=  - Use ElGamal precomputated tables. false for x64 and true for other platforms by default  
 * --reseed.file         - Full path to SU3 file to reseed from  
+* --reseed.urls         - Reseed URLs, separated by comma
 
 * --limits.transittunnels=  - Override maximum number of transit tunnels. 2500 by default   
 


### PR DESCRIPTION
You now can run i2pd with options like

    ./i2pd --reseed.urls https://url1.com:8443/,https://url2.com/

And it will download reseed data from those URLs.
