### PR TITLE
add .dir-locals.el for emacs users

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,3 @@
+((c++-mode . ((indent-tabs-mode . t)
+							(tab-width . 2)))
+ (c-mode . ((mode . c++))))

--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,3 +1,2 @@
-((c++-mode . ((indent-tabs-mode . t)
-              (tab-width . 2)))
+((c++-mode . ((indent-tabs-mode . t)))
  (c-mode . ((mode . c++))))

--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,3 +1,3 @@
 ((c++-mode . ((indent-tabs-mode . t)
-							(tab-width . 2)))
+              (tab-width . 2)))
  (c-mode . ((mode . c++))))


### PR DESCRIPTION
add [emacs directory variables](https://www.gnu.org/software/emacs/manual/html_node/emacs/Directory-Variables.html) that set default indentation to use tabs.