### PR TITLE
Build DEB package with CMake and uPNP

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: i2pd
 Section: net
 Priority: extra
 Maintainer: hagen <hagen@i2pmail.org>
-Build-Depends: debhelper (>= 9.0.0), dpkg-dev (>= 1.16.1~),
+Build-Depends: cmake (>= 2.8.12), debhelper (>= 9.0.0), dpkg-dev (>= 1.16.1~),
  gcc (>= 4.7) | clang (>= 3.3),
  libboost-system-dev (>= 1.46),
  libboost-date-time-dev,

--- a/debian/i2pd.install
+++ b/debian/i2pd.install
@@ -1,4 +1,4 @@
-i2pd usr/sbin/
+usr/bin/i2pd usr/sbin/
 docs/i2pd.conf      etc/i2pd/
 docs/tunnels.conf etc/i2pd/
 docs/subscriptions.txt etc/i2pd/

--- a/debian/rules
+++ b/debian/rules
@@ -11,7 +11,10 @@ CXXFLAGS+=$(CPPFLAGS)
 PREFIX=/usr
 
 %:
-	dh $@ --parallel
+	dh $@ --parallel --buildsystem=cmake --sourcedirectory=build
+
+override_dh_auto_configure:
+	dh_auto_configure -- -DWITH_UPNP=ON
 
 override_dh_strip:
 	dh_strip --dbg-package=i2pd-dbg


### PR DESCRIPTION
- Build Debian package using CMake instead of the shipped Makefile
- enable uPNP support during build