### PR TITLE
Respect for netId option in api.cpp #696

### DIFF
--- a/api.cpp
+++ b/api.cpp
@@ -33,6 +33,10 @@ namespace api
 #else
 		i2p::crypto::InitCrypto (true);
 #endif		
+
+                int netID; i2p::config::GetOption("netid", netID);
+                i2p::context.SetNetID (netID);
+
 		i2p::context.Init ();	
 	}
 


### PR DESCRIPTION
https://github.com/PurpleI2P/i2pd/issues/696

It was fixed in Daemon.cpp, but in api.cpp it seems to be remain default.