### PR TITLE
Added systemd support for debian package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,6 +5,7 @@ Maintainer: hagen <hagen@i2pmail.org>
 Build-Depends: debhelper (>= 9.0.0), dpkg-dev (>= 1.16.1~),
  gcc (>= 4.7) | clang (>= 3.3),
  libboost-system-dev (>= 1.46),
+ dh-systemd (>= 1.5),
  libboost-date-time-dev,
  libboost-filesystem-dev,
  libboost-program-options-dev,

--- a/debian/i2pd.service
+++ b/debian/i2pd.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=I2P Router written in C++
+After=network.target
+
+[Service]
+EnvironmentFile=-/etc/default/i2pd
+User=i2pd
+Group=i2pd
+ExecStart=/usr/sbin/i2pd --pidfile=/var/run/i2pd/i2pd.pid --service --conf=/etc/i2pd/i2pd.conf --tunconf=/etc/i2pd/tunnels.conf ${DAEMON_OPTS}
+Restart=on-failure
+
+# If you have problems with hunging i2pd, you can try enable this
+#LimitNOFILE=4096
+PrivateDevices=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/rules
+++ b/debian/rules
@@ -11,7 +11,7 @@ CXXFLAGS+=$(CPPFLAGS)
 PREFIX=/usr
 
 %:
-	dh $@ --parallel
+	dh $@ --with systemd --parallel
 
 override_dh_strip:
 	dh_strip --dbg-package=i2pd-dbg


### PR DESCRIPTION
It is suitable for modern deb based systems like Debian Jessie (8) or Ubuntu Xenial (16.04).

Logs are written directly into systemd-journald which helps to debug i2pd: `journalctl -f -u i2pd`. Actually there is no need in logrotate rules, but I left them for backward compatibility.