### PR TITLE
Create run dir for i2pd process in systemd unit file

### DIFF
--- a/contrib/debian/i2pd.service
+++ b/contrib/debian/i2pd.service
@@ -5,7 +5,9 @@ After=network.target
 [Service]
 User=i2pd
 Group=i2pd
-Type=forking
+RuntimeDirectory=i2pd
+RuntimeDirectoryMode=0700
+Type=simple
 ExecStart=/usr/sbin/i2pd --conf=/etc/i2pd/i2pd.conf --pidfile=/var/run/i2pd/i2pd.pid --logfile=/var/log/i2pd/i2pd.log --daemon --service
 ExecReload=/bin/kill -HUP $MAINPID
 PIDFile=/var/run/i2pd/i2pd.pid


### PR DESCRIPTION
i2pd stops when there is no `/var/run/i2pd` dir.