### PR TITLE
Don't do peertest if nat=false (#915)

### DIFF
--- a/libi2pd/Transports.cpp
+++ b/libi2pd/Transports.cpp
@@ -110,7 +110,7 @@ namespace transport
 	Transports transports;
 
 	Transports::Transports ():
-		m_IsOnline (true), m_IsRunning (false), m_Thread (nullptr), m_Service (nullptr),
+		m_IsOnline (true), m_IsRunning (false), m_IsNAT (true), m_Thread (nullptr), m_Service (nullptr),
 		m_Work (nullptr), m_PeerCleanupTimer (nullptr), m_PeerTestTimer (nullptr),
 		m_NTCPServer (nullptr), m_SSUServer (nullptr), m_DHKeysPairSupplier (5), // 5 pre-generated keys
 		m_TotalSentBytes(0), m_TotalReceivedBytes(0), m_TotalTransitTransmittedBytes (0),
@@ -141,6 +141,9 @@ namespace transport
 			m_PeerCleanupTimer = new boost::asio::deadline_timer (*m_Service);
 	 		m_PeerTestTimer = new boost::asio::deadline_timer (*m_Service);
 		}
+
+                bool nat;	 i2p::config::GetOption("nat", nat);
+                SetNAT (nat);
 
 		m_DHKeysPairSupplier.Start ();
 		m_IsRunning = true;
@@ -221,8 +224,12 @@ namespace transport
 		}
 		m_PeerCleanupTimer->expires_from_now (boost::posix_time::seconds(5*SESSION_CREATION_TIMEOUT));
 		m_PeerCleanupTimer->async_wait (std::bind (&Transports::HandlePeerCleanupTimer, this, std::placeholders::_1));
-		m_PeerTestTimer->expires_from_now (boost::posix_time::minutes(PEER_TEST_INTERVAL));
-		m_PeerTestTimer->async_wait (std::bind (&Transports::HandlePeerTestTimer, this, std::placeholders::_1));
+
+                if (IsNAT())
+                {
+                    m_PeerTestTimer->expires_from_now (boost::posix_time::minutes(PEER_TEST_INTERVAL));
+                    m_PeerTestTimer->async_wait (std::bind (&Transports::HandlePeerTestTimer, this, std::placeholders::_1));
+                }
 	}
 
 	void Transports::Stop ()
@@ -605,9 +612,8 @@ namespace transport
 		}
 		if (m_SSUServer)
 		{
-			bool nat;	 i2p::config::GetOption("nat", nat);
 			bool isv4 = i2p::context.SupportsV4 ();
-			if (nat && isv4)
+			if (IsNAT() && isv4)
 				i2p::context.SetStatus (eRouterStatusTesting);
 			for (int i = 0; i < 5; i++)
 			{

--- a/libi2pd/Transports.h
+++ b/libi2pd/Transports.h
@@ -84,6 +84,9 @@ namespace transport
 			bool IsOnline() const { return m_IsOnline; };
 			void SetOnline (bool online) { m_IsOnline = online; };
 
+			bool IsNAT() const { return m_IsNAT; };
+			void SetNAT (bool nat) { m_IsNAT = nat; };
+
 			boost::asio::io_service& GetService () { return *m_Service; };
 			std::shared_ptr<i2p::crypto::DHKeys> GetNextDHKeysPair ();
 			void ReuseDHKeysPair (std::shared_ptr<i2p::crypto::DHKeys> pair);
@@ -146,7 +149,7 @@ namespace transport
 
 		private:
 
-			bool m_IsOnline, m_IsRunning;
+			bool m_IsOnline, m_IsRunning, m_IsNAT;
 			std::thread * m_Thread;
 			boost::asio::io_service * m_Service;
 			boost::asio::io_service::work * m_Work;


### PR DESCRIPTION
**REVIEW PLEASE**

Added ``Transports::m_IsNAT`` field and it's getter and setter, so we don't have to read config all the time.