### PR TITLE
Fix deformed json result with an extra comma

### DIFF
--- a/daemon/I2PControl.cpp
+++ b/daemon/I2PControl.cpp
@@ -512,10 +512,10 @@ namespace client
 	{
 		for (auto it = params.begin (); it != params.end (); it++)
 		{
-			if (it != params.begin ()) results << ",";	
 			LogPrint (eLogDebug, "I2PControl: NetworkSetting request: ", it->first);
 			auto it1 = m_NetworkSettingHandlers.find (it->first);
 			if (it1 != m_NetworkSettingHandlers.end ()) {
+				if (it != params.begin ()) results << ",";
 				(this->*(it1->second))(it->second.data (), results);	
 			} else
 				LogPrint (eLogError, "I2PControl: NetworkSetting unknown request: ", it->first);


### PR DESCRIPTION
The deformed data in I2PControl :
`{"id":1,"result":{"i2p.router.net.bw.in":48,"i2p.router.net.bw.out":48,},"jsonrpc":"2.0"}`
You can see there is an extra comma behind the number 48.