### PR TITLE
cmake: add stdlib args for clang build on Linux

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -178,6 +178,9 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   endif ()
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   # more tweaks
+  if (NOT (MSVC OR MSYS OR APPLE))
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libstdc++" )
+  endif()
 endif ()
 
 if (WITH_HARDENING AND MSVC)
@@ -457,6 +460,12 @@ if (WITH_BINARY)
       fixup_bundle(\"${APPS}\"   \"\"   \"${DIRS}\")
       " COMPONENT Runtime)
   endif ()
+
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    if (NOT (MSVC OR MSYS OR APPLE)) # for Clang build on Linux
+      target_link_libraries("${PROJECT_NAME}" stdc++)
+    endif()
+  endif()
 endif ()
 
 install(FILES ../LICENSE


### PR DESCRIPTION
Otherwise linking fails with undefined symbol ... basic_string ... and
libstdc++: DSO not included in link command.

On my armv7h, the clang build seems to not suffer from the leaks that appear with gcc 7.2: #835 
To build with clang: `CC=clang CXX=clang cmake ...`