### PR TITLE
Add apparmor profile to debian. #974

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: i2pd
 Section: net
 Priority: optional
 Maintainer: R4SAS <r4sas@i2pmail.org>
-Build-Depends: debhelper (>= 9), dpkg-dev (>= 1.16.1~), gcc (>= 4.7) | clang (>= 3.3), libboost-system-dev (>= 1.46), libboost-date-time-dev, libboost-filesystem-dev, libboost-program-options-dev, libminiupnpc-dev, libssl-dev, zlib1g-dev
+Build-Depends: debhelper (>= 9), dpkg-dev (>= 1.16.1~), gcc (>= 4.7) | clang (>= 3.3), libboost-system-dev (>= 1.46), libboost-date-time-dev, libboost-filesystem-dev, libboost-program-options-dev, libminiupnpc-dev, libssl-dev, zlib1g-dev, dh-apparmor
 Standards-Version: 3.9.6
 Homepage: http://i2pd.website/
 Vcs-Git: git://github.com/PurpleI2P/i2pd.git
@@ -12,7 +12,7 @@ Package: i2pd
 Architecture: any
 Pre-Depends: adduser
 Depends: ${shlibs:Depends}, ${misc:Depends}
-Suggests: tor, privoxy
+Suggests: tor, privoxy, apparmor
 Description: A full-featured C++ implementation of I2P client.
  I2P (Invisible Internet Protocol) is a universal anonymous network layer. All
  communications over I2P are anonymous and end-to-end encrypted, participants

--- a/debian/i2pd.install
+++ b/debian/i2pd.install
@@ -3,3 +3,4 @@ contrib/i2pd.conf      etc/i2pd/
 contrib/tunnels.conf etc/i2pd/
 contrib/subscriptions.txt etc/i2pd/
 contrib/certificates/ usr/share/i2pd/
+contrib/apparmor/usr.sbin.i2pd etc/apparmor.d

--- a/debian/rules
+++ b/debian/rules
@@ -12,6 +12,7 @@ PREFIX=/usr
 
 %:
 	dh $@ --parallel
+	dh_apparmor --profile-name=usr.sbin.i2pd -pi2pd
 
 override_dh_strip:
 	dh_strip --dbg-package=i2pd-dbg


### PR DESCRIPTION
* I tested this by building locally, and installing the Debian packages in a Docker container.
* This change only moves the existing apparmor profile to the location Debian expects it to be.
* This change **does not** enable apparmor, but makes it easier for users who do use it with Debian (and will be nice for when Debian does decide to enable apparmor by default)