### PR TITLE
fix gcc 7 on ubuntu

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -21,6 +21,8 @@ else ifeq ($(shell expr match ${CXXVER} "4\.6"),3) # = 4.6
 	NEEDED_CXXFLAGS += -std=c++0x
 else ifeq ($(shell expr match ${CXXVER} "[5-7]\.[0-9]"),3) # gcc >= 5.0
 	NEEDED_CXXFLAGS += -std=c++11
+else ifeq ($(shell expr match ${CXXVER} "7"),1) # gcc 7 ubuntu
+	NEEDED_CXXFLAGS += -std=c++11
 else # not supported
 	$(error Compiler too old)
 endif


### PR DESCRIPTION
ubuntu artsy uses a weird gcc that wasn't detected right

this fixes it