### PR TITLE
Fix flags

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -180,7 +180,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   # more tweaks
   if (NOT (MSVC OR MSYS OR APPLE))
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-const-variable -Wno-overloaded-virtual -Wno-c99-extensions -stdlib=libstdc++" )
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-const-variable -Wno-overloaded-virtual -Wno-c99-extensions" )
   endif()
 endif ()
 


### PR DESCRIPTION
-stdlib should not be changed. It breaks build on e.g. FreeBSD where libc++ is used.