### PR TITLE
Don't meddle with stdlib

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -461,12 +461,6 @@ if (WITH_BINARY)
       fixup_bundle(\"${APPS}\"   \"\"   \"${DIRS}\")
       " COMPONENT Runtime)
   endif ()
-
-  if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    if (NOT (MSVC OR MSYS OR APPLE)) # for Clang build on Linux
-      target_link_libraries("${PROJECT_NAME}" stdc++)
-    endif()
-  endif()
 endif ()
 
 install(FILES ../LICENSE


### PR DESCRIPTION
Forgotten part of #1014: -stdlib should not be changed. It breaks build on e.g. FreeBSD where libc++ is used.