### PR TITLE
Reorder preprocessor conditions in libi2pd/I2PEndian.h

### DIFF
--- a/libi2pd/I2PEndian.h
+++ b/libi2pd/I2PEndian.h
@@ -3,10 +3,10 @@
 #include <inttypes.h>
 #include <string.h>
 
-#if defined(__linux__) || defined(__FreeBSD_kernel__) || defined(__OpenBSD__)
-#include <endian.h>
-#elif __FreeBSD__
+#if defined(__FreeBSD__)
 #include <sys/endian.h>
+#elif defined(__linux__) || defined(__FreeBSD_kernel__) || defined(__OpenBSD__)
+#include <endian.h>
 #elif defined(__APPLE__) && defined(__MACH__)
 
 #include <libkern/OSByteOrder.h>


### PR DESCRIPTION
The problem is that __FreeBSD_kernel__ may be defined on FreeBSD as
well, while it always needs <sys/endian.h>

In fact, you shouldn't check for __FreeBSD_kernel__ at all, as the code has nothing to do with whether the code runs under FreeBSD kernel or not.