### PR TITLE
Don't use deprecated boost::asio::ssl::context ctor

### DIFF
--- a/daemon/I2PControl.cpp
+++ b/daemon/I2PControl.cpp
@@ -35,7 +35,7 @@ namespace client
 	I2PControlService::I2PControlService (const std::string& address, int port):
 		m_IsRunning (false), m_Thread (nullptr),
 		m_Acceptor (m_Service, boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string(address), port)),
-		m_SSLContext (m_Service, boost::asio::ssl::context::sslv23),
+		m_SSLContext (boost::asio::ssl::context::sslv23),
 		m_ShutdownTimer (m_Service)
 	{
 		i2p::config::GetOption("i2pcontrol.password", m_Password);

--- a/libi2pd/Reseed.cpp
+++ b/libi2pd/Reseed.cpp
@@ -522,7 +522,7 @@ namespace data
 		boost::asio::io_service service;
 		boost::system::error_code ecode;
 
-		boost::asio::ssl::context ctx(service, boost::asio::ssl::context::sslv23);
+		boost::asio::ssl::context ctx(boost::asio::ssl::context::sslv23);
 		ctx.set_verify_mode(boost::asio::ssl::context::verify_none);
 		boost::asio::ssl::stream<boost::asio::ip::tcp::socket> s(service, ctx);
 


### PR DESCRIPTION
This was removed in boost 1.66, in prior versions the service
argument was not used