### PR TITLE
Inherit _publicly_ from shared_from_this in I2PService

### DIFF
--- a/libi2pd_client/I2PService.h
+++ b/libi2pd_client/I2PService.h
@@ -14,7 +14,7 @@ namespace i2p
 namespace client
 {
 	class I2PServiceHandler;
-	class I2PService : std::enable_shared_from_this<I2PService>
+	class I2PService : public std::enable_shared_from_this<I2PService>
 	{
 		public:
 			typedef std::function<void(const boost::system::error_code &)> ReadyCallback;


### PR DESCRIPTION
We're using I2PServerTunnel and I2PClientTunnel (which both inherit from I2PService) in our project. We also have our custom "sockets" which are basically pairs:

```
struct my_socket {
    asio::ip::tcp::socket socket;
    shared_ptr<I2PService> i2p_tunnel;
};
```
The reasoning being that while an instance of `my_socket` is present, the tunnel won't get closed.

If the `enable_shared_from_this` base is private, we can't create `shared_ptr<I2PService>` and we need ugly workarounds such as:

```
struct my_socket {
    asio::ip::tcp::socket socket;
    shared_ptr<unique_ptr<I2PService>> i2p_tunnel;
};
```
