### PR TITLE
i2pd.spec delete obsoletes tag

### DIFF
--- a/contrib/rpm/i2pd.spec
+++ b/contrib/rpm/i2pd.spec
@@ -2,7 +2,6 @@ Name:           i2pd
 Version:        2.18.0
 Release:        1%{?dist}
 Summary:        I2P router written in C++
-Obsoletes:      %{name}-systemd
 Conflicts:      i2pd-git
 
 License:        BSD


### PR DESCRIPTION
https://github.com/PurpleI2P/i2pd/pull/1084#issuecomment-362215861

```
Resolving Dependencies
--> Running transaction check
---> Package i2pd.x86_64 0:2.17.0-20171206git.el7.centos will be updated
---> Package i2pd.x86_64 0:2.18.0-1.el7.centos will be obsoleting
---> Package i2pd-systemd.x86_64 0:2.17.0-20171206git.el7.centos will be obsoleted
--> Finished Dependency Resolution

Dependencies Resolved

==========================================================================
 Package   Arch        Version                     Repository        Size
==========================================================================
Installing:
 i2pd      x86_64      2.18.0-1.el7.centos         vorona-i2pd      915 k
     replacing  i2pd-systemd.x86_64 2.17.0-20171206git.el7.centos

Transaction Summary
==========================================================================
Install  1 Package

Total download size: 915 k
Is this ok [y/d/N]:
```
@l-n-s  thx, obsoletes tag is unneeded in next release)