### PR TITLE
systemd issue in centos 7

### DIFF
--- a/contrib/rpm/i2pd.service
+++ b/contrib/rpm/i2pd.service
@@ -5,6 +5,7 @@ After=network.target
 [Service]
 User=i2pd
 Group=i2pd
+PermissionsStartOnly=True
 RuntimeDirectory=i2pd
 RuntimeDirectoryMode=0700
 Type=simple


### PR DESCRIPTION
Not working pre-create pid-file dir (/run/i2pd).
It can be fixed with one of this ways:

> PermissionsStartOnly=True

or 
> ExecStartPre=/bin/mkdir -p -m 0700 /var/run/i2pd
> ExecStartPre=/bin/chown i2pd: /var/run/i2pd

First way is prefer because RuntimeDirectory's options already used.