### PR TITLE
cmake: add stdlib args for clang build on Linux

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -184,6 +184,8 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   # more tweaks
   if (NOT (MSVC OR MSYS OR APPLE))
+    set (CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -stdlib=libstdc++" ) # required for <atomic>
+    list(APPEND CMAKE_REQUIRED_LIBRARIES "stdc++") # required to link with -stdlib=libstdc++
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-const-variable -Wno-overloaded-virtual -Wno-c99-extensions" )
   endif()
 endif ()


### PR DESCRIPTION
Otherwise linking fails with undefined symbol ... basic_string ... and
libstdc++: DSO not on included in link command.

or with
Host compiler must support std::atomic!
which is due to
undefined reference to `__gxx_personality_v0' and __cxa_begin_catch and
std::terminate()

This was already patched in 7b537a4e943c2a99db87d63c88c31443ebd1c6f4
PR #972 but it got lost, and also needed some tweaking.

Thested with Clan 5.0.1 on Arch Linux (on armv7h).