### PR TITLE
Fix cmake error when -DBUILD_SHARED_LIBS=ON

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -97,6 +97,7 @@ set_target_properties(libi2pd PROPERTIES PREFIX "")
 install(TARGETS libi2pd
   EXPORT libi2pd
   ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
   COMPONENT Libraries)
 # TODO Make libi2pd available to 3rd party projects via CMake as imported target
 # FIXME This pulls stdafx


### PR DESCRIPTION
Fixes "CMake Error: TARGETS given no LIBRARY DESTINATION for shared
library target" by adding LIBRARY parameter to INSTALL call

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>