### PR TITLE
Lmdb storage backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ USE_AVX		:= yes
 USE_STATIC	:= no
 USE_MESHNET	:= no
 USE_UPNP	:= no
+USE_LMDB	:= yes
 
 ifeq ($(WEBSOCKETS),1)
 	NEEDED_CXXFLAGS += -DWITH_EVENTS
@@ -45,6 +46,11 @@ endif
 
 ifeq ($(USE_MESHNET),yes)
 	NEEDED_CXXFLAGS += -DMESHNET
+endif
+
+ifeq ($(USE_LMDB),yes)
+	NEEDED_CXXFLAGS += -DLMDB
+	LDLIBS += -llmdb
 endif
 
 NEEDED_CXXFLAGS += -I$(LIB_SRC_DIR) -I$(LIB_CLIENT_SRC_DIR)

--- a/libi2pd/Config.cpp
+++ b/libi2pd/Config.cpp
@@ -231,6 +231,11 @@ namespace config {
 			("exploratory.outbound.quantity", value<int>()->default_value(3), "Exploratory outbound tunnels quantity")
 		;
 
+		options_description storage("Persistent storage options for NetDb, profiles, etc.");
+		storage.add_options()
+				("storage.engine", value<std::string>()->default_value("fs"), "Storage engine")
+		;
+
 		m_OptionsDesc
 			.add(general)
 			.add(limits)
@@ -248,6 +253,7 @@ namespace config {
 			.add(trust)
 			.add(websocket)
 			.add(exploratory)
+			.add(storage)
 		;
 	}
 

--- a/libi2pd/NetDb.cpp
+++ b/libi2pd/NetDb.cpp
@@ -37,7 +37,13 @@ namespace data
 
 	void NetDb::Start ()
 	{
-		m_Storage.reset(new FsIdentStorage("netDb", "r", "routerInfo-", "dat"));
+		std::string engine;
+		i2p::config::GetOption("storage.engine", engine);
+		if (engine == "lmdb")
+			m_Storage.reset(new MdbIdentStorage("netDb.lmdb"));
+		else
+			m_Storage.reset(new FsIdentStorage("netDb", "r", "routerInfo-", "dat"));
+
 		m_Storage->Init();
 		InitProfilesStorage ();
 		m_Families.LoadCertificates ();

--- a/libi2pd/NetDb.hpp
+++ b/libi2pd/NetDb.hpp
@@ -7,6 +7,7 @@
 #include <list>
 #include <string>
 #include <thread>
+#include <memory>
 #include <mutex>
 
 #include "Base.h"
@@ -19,6 +20,7 @@
 #include "Tunnel.h"
 #include "TunnelPool.h"
 #include "Reseed.h"
+#include "Storage.h"
 #include "NetDbRequests.h"
 #include "Family.h"
 
@@ -93,8 +95,6 @@ namespace data
 
 			/** visit all lease sets we currently store */
 			void VisitLeaseSets(LeaseSetVisitor v);
-			/** visit all router infos we have currently on disk, usually insanely expensive, does not access in memory RI */
-			void VisitStoredRouterInfos(RouterInfoVisitor v);
 			/** visit all router infos we have loaded in memory, cheaper than VisitLocalRouterInfos but locks access while visiting */
 			void VisitRouterInfos(RouterInfoVisitor v);
 			/** visit N random router that match using filter, then visit them with a visitor, return number of RouterInfos that were visited */
@@ -105,7 +105,7 @@ namespace data
 		private:
 
 			void Load ();
-			bool LoadRouterInfo (const std::string & path);
+			bool LoadRouterInfo (const char *buffer, size_t len);
 			void SaveUpdated ();
 			void Run (); // exploratory thread
 			void Explore (int numDestinations);
@@ -135,7 +135,7 @@ namespace data
 			GzipInflator m_Inflator;
 			Reseeder * m_Reseeder;
 			Families m_Families;
-			i2p::fs::HashedStorage m_Storage;
+			std::unique_ptr<IdentStorage> m_Storage;
 
 			friend class NetDbRequests;
 			NetDbRequests m_Requests;

--- a/libi2pd/Profiling.cpp
+++ b/libi2pd/Profiling.cpp
@@ -2,6 +2,7 @@
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/ini_parser.hpp>
 #include "Base.h"
+#include "Config.h"
 #include "FS.h"
 #include "Log.h"
 #include "Profiling.h"
@@ -173,7 +174,12 @@ namespace data
 
 	void InitProfilesStorage ()
 	{
-		m_ProfilesStorage.reset(new FsIdentStorage("peerProfiles", "p", "profile-", "txt"));
+		std::string engine;
+		i2p::config::GetOption("storage.engine", engine);
+		if (engine == "lmdb")
+			m_ProfilesStorage.reset(new MdbIdentStorage("peerProfiles.lmdb"));
+		else
+			m_ProfilesStorage.reset(new FsIdentStorage("peerProfiles", "p", "profile-", "txt"));
 		m_ProfilesStorage->Init();
 
 	}

--- a/libi2pd/Profiling.h
+++ b/libi2pd/Profiling.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include "Identity.h"
+#include "Storage.h"
 
 namespace i2p
 {
@@ -61,6 +62,9 @@ namespace data
 	std::shared_ptr<RouterProfile> GetRouterProfile (const IdentHash& identHash);
 	void InitProfilesStorage ();
 	void DeleteObsoleteProfiles ();
+	bool BeginProfilesStorageUpdate();
+	bool EndProfilesStorageUpdate();
+	void DeInitProfilesStorage();
 }
 }
 

--- a/libi2pd/RouterInfo.h
+++ b/libi2pd/RouterInfo.h
@@ -120,6 +120,7 @@ namespace data
 			RouterInfo (const std::string& fullPath);
 			RouterInfo (const RouterInfo& ) = default;
 			RouterInfo& operator=(const RouterInfo& ) = default;
+			RouterInfo (const uint8_t * buf, int len, bool);
 			RouterInfo (const uint8_t * buf, int len);
 			~RouterInfo ();
 
@@ -167,6 +168,7 @@ namespace data
 
 			const uint8_t * GetBuffer () const { return m_Buffer; };
 			const uint8_t * LoadBuffer (); // load if necessary
+			const uint8_t * LoadBuffer(const uint8_t *buf, size_t len); //load from memory
 			int GetBufferLen () const { return m_BufferLen; };
 			void CreateBuffer (const PrivateKeys& privateKeys);
 

--- a/libi2pd/Storage.cpp
+++ b/libi2pd/Storage.cpp
@@ -77,5 +77,158 @@ void FsIdentStorage::Iterate(const DVisitor &f)
 	m_Storage.Iterate(fv);
 }
 
+#ifdef LMDB
+//MdbIdentStorage
+MdbIdentStorage::~MdbIdentStorage()
+{
+}
+
+bool MdbIdentStorage::Init()
+{
+	m_Path = i2p::fs::GetDataDir() + i2p::fs::dirSep + m_Name;
+
+	if (!boost::filesystem::exists(m_Path))
+		boost::filesystem::create_directory(m_Path);
+
+	if (!mdb_env_create(&env))
+	{
+
+		int ret = mdb_env_open(env, m_Path.c_str(), MDB_NOTLS, 0664);
+		if (!ret)
+		{
+			return true;
+		}
+		mdb_env_close(env);
+	}
+	return false;
+}
+
+void MdbIdentStorage::DeInit()
+{
+	if (m_Initialized)
+		DeInitWrite();
+	mdb_env_close(env);
+}
+
+bool MdbIdentStorage::BeginUpdate()  //TODO: remove unneeded memory juggling
+{
+	return InitWrite();
+}
+
+bool MdbIdentStorage::EndUpdate()
+{
+	return DeInitWrite();
+}
+
+bool MdbIdentStorage::Store(const i2p::data::IdentHash &ident, const StorageRecord& record)
+{
+	if (!m_Initialized)
+	{
+		return false;
+	}
+
+	MDB_val data;
+	data.mv_data = const_cast<char*>(record.data.get());
+	data.mv_size = record.len;
+
+	MDB_val key;
+	key.mv_data = const_cast<uint8_t*>(ident.data());
+	key.mv_size = 32;
+	return !mdb_put(txn, dbi, &key, &data, 0);
+}
+
+StorageRecord MdbIdentStorage::Fetch(const i2p::data::IdentHash &ident)
+{
+	StorageRecord result;
+
+	MDB_txn *trn;
+	MDB_dbi dbh;
+	if (!mdb_txn_begin(env, NULL, MDB_RDONLY, &trn))
+	{
+		if (!mdb_open(trn, NULL, 0, &dbh))
+		{
+			MDB_val key, data;
+			key.mv_data = const_cast<uint8_t*>(ident.data());
+			key.mv_size = 32;
+			if (!mdb_get(trn, dbh, &key, &data))
+			{
+				result = StorageRecord((char*)data.mv_data, data.mv_size);
+			}
+
+			mdb_txn_abort(trn);
+			mdb_close(env, dbh);
+		}
+	}
+	return result;
+}
+
+bool MdbIdentStorage::Remove(const IdentHash &ident)
+{
+	if (!m_Initialized)
+	{
+		return false;
+	}
+
+	MDB_val key;
+	key.mv_data = const_cast<uint8_t*>(ident.data());
+	key.mv_size = 32;
+	return !mdb_del(txn, dbi, &key, NULL);
+}
+
+void MdbIdentStorage::Iterate(const DVisitor & f)
+{
+	MDB_txn *trn;
+	MDB_dbi dbh;
+	MDB_val data, key;
+	MDB_cursor *cursor;
+
+	if(!mdb_txn_begin(env, NULL, MDB_RDONLY, &trn))
+	{
+		if (!mdb_open(trn, NULL, 0, &dbh))
+		{
+			if (!mdb_cursor_open(trn, dbh, &cursor))
+			{
+				while(!mdb_cursor_get(cursor, &key, &data, MDB_NEXT))
+				{
+					StorageRecord record((char*)data.mv_data, data.mv_size);
+					IdentHash ident((uint8_t*)key.mv_data);
+					f(ident, record);
+				}
+				mdb_cursor_close(cursor);
+			}
+
+			mdb_txn_abort(trn);
+			mdb_close(env, dbh);
+		} else
+		{
+			mdb_txn_abort(trn);
+		}
+	}
+}
+
+bool MdbIdentStorage::InitWrite()
+{
+	int ret = mdb_txn_begin(env, NULL, 0, &txn);
+	if (ret)
+		return false;
+
+	ret = mdb_open(txn, NULL, 0, &dbi);
+	if (ret)
+	{
+		mdb_txn_abort(txn);
+		return false;
+	}
+	m_Initialized = true;
+	return true;
+}
+
+bool MdbIdentStorage::DeInitWrite() {
+	int ret = mdb_txn_commit(txn);
+	mdb_close(env, dbi);
+	m_Initialized = false;
+	return  !ret;
+}
+#endif
+
 } //ns data
 } //ns i2p

--- a/libi2pd/Storage.cpp
+++ b/libi2pd/Storage.cpp
@@ -1,0 +1,81 @@
+#include <iostream>
+#include <ios>
+
+#include <boost/filesystem.hpp>
+
+#include "Storage.h"
+
+namespace i2p {
+namespace data {
+
+FsIdentStorage::~FsIdentStorage() {}
+IdentStorage::~IdentStorage() {}
+
+bool IdentStorage::Init() { return true; }
+bool FsIdentStorage::Init()
+{
+	m_Storage.SetPlace(i2p::fs::GetDataDir());
+	if (m_IsB32)
+		m_Storage.Init(i2p::data::GetBase32SubstitutionTable(), 32);
+	else
+		m_Storage.Init(i2p::data::GetBase64SubstitutionTable(), 64);
+	return true;
+}
+
+bool FsIdentStorage::Store(const i2p::data::IdentHash &ident, const StorageRecord &record)
+{
+	std::string strid = m_IsB32 ? ident.ToBase32() : ident.ToBase64();
+	std::string path = m_Storage.Path(strid);
+	std::ofstream ofs(path, std::ios::binary);
+	ofs.write(record.data.get(), record.len);
+	ofs.flush();
+	return true;
+}
+
+StorageRecord FsIdentStorage::Fetch(const i2p::data::IdentHash &ident)
+{
+	std::string strid = m_IsB32 ? ident.ToBase32() : ident.ToBase64();
+	std::string path = m_Storage.Path(strid);
+	if (boost::filesystem::exists(path)) {
+		std::ifstream ifs(path, std::ios::binary);
+		ifs.seekg(0, std::ios::end);
+
+		int size = ifs.tellg();
+		ifs.seekg(0, std::ios::beg);
+
+		StorageRecord result(size);
+
+		ifs.read(result.data.get(), size);
+		return result;
+	}
+
+	return StorageRecord();
+}
+
+bool FsIdentStorage::Remove(const IdentHash & ident)
+{
+	std::string strid = m_IsB32 ? ident.ToBase32() : ident.ToBase64();
+	std::string path = m_Storage.Path(strid);
+	return i2p::fs::Remove(path);
+}
+
+void FsIdentStorage::Iterate(const DVisitor &f)
+{
+	auto fv = [&f, this](const std::string &path)
+	{
+		boost::filesystem::path p(path);
+		std::string id = p.stem().string().substr(m_Fprefix.length());
+		i2p::data::IdentHash ident;
+		if (m_IsB32)
+			ident.FromBase32(id);
+		else
+			ident.FromBase64(id);
+		StorageRecord data = Fetch(ident);
+		if (data.IsValid()) f(ident,data);
+	};
+
+	m_Storage.Iterate(fv);
+}
+
+} //ns data
+} //ns i2p

--- a/libi2pd/Storage.h
+++ b/libi2pd/Storage.h
@@ -5,6 +5,10 @@
 #include <sys/types.h>
 #include <fcntl.h>
 
+#ifdef LMDB
+#include <lmdb.h>
+#endif
+
 #include "FS.h"
 #include "Identity.h"
 #include "Log.h"
@@ -68,6 +72,34 @@ private:
 	bool m_IsB32;
 };
 
+#ifdef LMDB
+class MdbIdentStorage : public IdentStorage
+{
+public:
+	MdbIdentStorage(const char *name) : m_Name(name) {}
+	virtual bool Init();
+	virtual void DeInit();
+	virtual bool BeginUpdate();
+	virtual bool EndUpdate();
+	virtual bool Store(const IdentHash &, const StorageRecord&);
+	virtual bool Remove(const IdentHash &);
+	StorageRecord Fetch(const IdentHash&);
+	virtual void Iterate(const DVisitor&);
+	virtual ~MdbIdentStorage();
+private:
+	bool InitRead();
+	void DeInitRead();
+	bool InitWrite();
+
+	bool DeInitWrite();
+	bool m_Initialized = false;
+	std::string m_Path;
+	std::string m_Name;
+	MDB_env *env;
+	MDB_dbi dbi;
+	MDB_txn *txn;
+};
+#endif
 } //ns data
 } //ns i2p
 

--- a/libi2pd/Storage.h
+++ b/libi2pd/Storage.h
@@ -1,0 +1,74 @@
+#ifndef STORAGE_H
+#define STORAGE_H
+#include <memory>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <fcntl.h>
+
+#include "FS.h"
+#include "Identity.h"
+#include "Log.h"
+
+namespace i2p
+{
+namespace data
+{
+
+class StorageRecord
+{
+public:
+	std::shared_ptr<char[]> data;
+	size_t len;
+	StorageRecord(size_t len): data(new char[len]), len(len) {}
+	StorageRecord(const char *buf, size_t len): StorageRecord(len)
+	{
+		memcpy(data.get(), buf, len);
+	}
+
+	StorageRecord():  data(nullptr), len(0) {}
+	bool IsValid() { return len > 0; }
+};
+
+typedef std::function<void(const IdentHash&, const StorageRecord&)> DVisitor;
+
+class IdentStorage
+{
+public:
+	IdentStorage() {}
+	virtual bool Init();
+	virtual void DeInit() {}
+	virtual bool BeginUpdate() { return true; }
+	virtual bool EndUpdate() { return true; }
+	virtual bool Store(const IdentHash &, const StorageRecord&) { return true; }
+	virtual bool Remove(const IdentHash &) { return true; }
+	virtual StorageRecord Fetch(const IdentHash&) { return StorageRecord(); }
+	virtual void Iterate(const DVisitor&) {}
+	virtual ~IdentStorage();
+};
+
+class FsIdentStorage : public IdentStorage
+{
+public:
+	FsIdentStorage(const char *name, const char* dprefix, const char *fprefix, const char *suffix, bool isB32=false) :
+		m_Storage(name, dprefix, fprefix, suffix), m_Fprefix(fprefix), m_IsB32(isB32) {}
+
+	virtual bool Init();
+	virtual void DeInit() {}
+	virtual bool BeginUpdate() { return true; }
+	virtual bool EndUpdate() { return true; }
+	virtual bool Store(const IdentHash &, const StorageRecord&);
+	virtual bool Remove(const IdentHash &);
+	StorageRecord Fetch(const IdentHash&);
+	virtual void Iterate(const DVisitor&);
+	virtual ~FsIdentStorage();
+
+private:
+	i2p::fs::HashedStorage m_Storage;
+	std::string m_Fprefix;
+	bool m_IsB32;
+};
+
+} //ns data
+} //ns i2p
+
+#endif // STORAGE_H


### PR DESCRIPTION
This pull request is addressing issue of somewhat high disk usage by NetDb and PeerProfiles, which is especially bad for devices with low flash and/or RAM (when using tmpfs), like cheap routers.
Instead of old filesystem-based storage [lmdb](https://symas.com/lmdb/technical/) simple key-value storage database is used. To preserve backwards-compatibility option added to switch between lmdb and old HashedStorage, old one is default value.
Other variants for a database were gdbm(not suitable due to a viral license), tinycdb (djb's constant database implementation, due to immutability forces to recreate and write it on disk on each update, which is not good for flash-based storages), levelDb and tdb(both too complex for such a simple task).
Lmdb is ligtweight (~90K on x86_64) and allows to reduce disk usage 4 times and more compared to old HashedStorage.
I'm new to development and code licenses, there should probably be now a copy of OpenLDAP llicense distributed with i2pd source code and binary as lmdb license says.
There is also a cdb storage backend which is ready and I can make a pull request to merge it too  if needed.