### PR TITLE
Create LogsDirectory in i2pd.service

### DIFF
--- a/contrib/i2pd.service
+++ b/contrib/i2pd.service
@@ -8,6 +8,8 @@ User=i2pd
 Group=i2pd
 RuntimeDirectory=i2pd
 RuntimeDirectoryMode=0700
+LogsDirectory=i2pd
+LogsDirectoryMode=0700
 Type=simple
 ExecStart=/usr/sbin/i2pd --conf=/etc/i2pd/i2pd.conf --tunconf=/etc/i2pd/tunnels.conf --pidfile=/var/run/i2pd/i2pd.pid --logfile=/var/log/i2pd/i2pd.log --daemon --service
 ExecReload=/bin/kill -HUP $MAINPID


### PR DESCRIPTION
Create /var/log/i2pd through LogsDirectory parameter of systemd and set
its permission to 0700 through LogsDirectoryMode. Indeed, this directory
must be created with the correct permission as it is used in ExecStart
command

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>