### PR TITLE
Work in Progress: Proof of consept: "bring your own io_service" - allowing Qt eventloop hooks.

### DIFF
--- a/libi2pd/Destination.h
+++ b/libi2pd/Destination.h
@@ -90,8 +90,8 @@ namespace client
 
 		public:
 
-			LeaseSetDestination (bool isPublic, const std::map<std::string, std::string> * params = nullptr);
-			~LeaseSetDestination ();
+      LeaseSetDestination (bool isPublic, const std::map<std::string, std::string> * params = nullptr, boost::shared_ptr<boost::asio::io_service> service = boost::shared_ptr<boost::asio::io_service>());
+      ~LeaseSetDestination ();
 			const std::string& GetNickname () const { return m_Nickname; };
 
 			virtual bool Start ();
@@ -101,7 +101,7 @@ namespace client
 			virtual bool Reconfigure(std::map<std::string, std::string> i2cpOpts);
 		
 			bool IsRunning () const { return m_IsRunning; };
-			boost::asio::io_service& GetService () { return m_Service; };
+      boost::asio::io_service& GetService () { return (boost::asio::io_service&)*m_Service.get(); };
 			std::shared_ptr<i2p::tunnel::TunnelPool> GetTunnelPool () { return m_Pool; };
 			bool IsReady () const { return m_LeaseSet && !m_LeaseSet->IsExpired () && m_Pool->GetOutboundTunnels ().size () > 0; };
 			std::shared_ptr<const i2p::data::LeaseSet> FindLeaseSet (const i2p::data::IdentHash& ident);
@@ -149,7 +149,7 @@ namespace client
 
 			volatile bool m_IsRunning;
 			std::thread * m_Thread;
-			boost::asio::io_service m_Service;
+      boost::shared_ptr<boost::asio::io_service> m_Service;
 			mutable std::mutex m_RemoteLeaseSetsMutex;
 			std::map<i2p::data::IdentHash, std::shared_ptr<i2p::data::LeaseSet> > m_RemoteLeaseSets;
 			std::map<i2p::data::IdentHash, std::shared_ptr<LeaseSetRequest> > m_LeaseSetRequests;
@@ -184,7 +184,7 @@ namespace client
 			void Ready(ReadyPromise & p);
 #endif
 
-			ClientDestination (const i2p::data::PrivateKeys& keys, bool isPublic, const std::map<std::string, std::string> * params = nullptr);
+      ClientDestination (const i2p::data::PrivateKeys& keys, bool isPublic, const std::map<std::string, std::string> * params = nullptr, boost::shared_ptr<boost::asio::io_service> service = boost::shared_ptr<boost::asio::io_service>());
 			~ClientDestination ();
 
 			virtual bool Start ();

--- a/libi2pd/api.cpp
+++ b/libi2pd/api.cpp
@@ -83,7 +83,15 @@ namespace api
 		auto localDestination = std::make_shared<i2p::client::ClientDestination> (keys, isPublic, params);
 		localDestination->Start ();
 		return localDestination;
-	}
+  }
+
+  std::shared_ptr<i2p::client::ClientDestination> CreateLocalDestination (const i2p::data::PrivateKeys& keys, boost::shared_ptr<boost::asio::io_service> service,
+    bool isPublic, const std::map<std::string, std::string> * params)
+  {
+    auto localDestination = std::make_shared<i2p::client::ClientDestination> (keys, isPublic, params, service);
+    //localDestination->Start ();
+    return localDestination;
+  }
 
 	std::shared_ptr<i2p::client::ClientDestination> CreateLocalDestination (bool isPublic, i2p::data::SigningKeyType sigType,
 		const std::map<std::string, std::string> * params)

--- a/libi2pd/api.h
+++ b/libi2pd/api.h
@@ -3,6 +3,8 @@
 
 #include <memory>
 #include <iostream>
+#include <boost/asio.hpp>
+#include <boost/shared_ptr.hpp>
 #include "Identity.h"
 #include "Destination.h"
 #include "Streaming.h"
@@ -21,7 +23,10 @@ namespace api
 
 	// destinations
 	std::shared_ptr<i2p::client::ClientDestination> CreateLocalDestination (const i2p::data::PrivateKeys& keys, bool isPublic = true,
-		const std::map<std::string, std::string> * params = nullptr);
+    const std::map<std::string, std::string> * params = nullptr);
+  std::shared_ptr<i2p::client::ClientDestination> CreateLocalDestination (const i2p::data::PrivateKeys& keys, boost::shared_ptr<boost::asio::io_service> service,
+    bool isPublic = true, const std::map<std::string, std::string> * params = nullptr);
+
 	std::shared_ptr<i2p::client::ClientDestination> CreateLocalDestination (bool isPublic = false, i2p::data::SigningKeyType sigType = i2p::data::SIGNING_KEY_TYPE_ECDSA_SHA256_P256,
 		const std::map<std::string, std::string> * params = nullptr); // transient destinations usually not published
 	void DestroyLocalDestination (std::shared_ptr<i2p::client::ClientDestination> dest);


### PR DESCRIPTION
The changes suggested allows for ClientDestination events to for example be signalled into Qt applications's main eventloop, making i2p streams accessable via signal&slots (Qt stuff). Basically this is done by providing an option to "bring your own boost::asio::io_service".

Glue project can be found here; https://github.com/mikalv/qtasio

Indenting seems to become retarded with QtCreator - Gonna fix it, if @orignal wants this patch.

Signed-off-by: Mikal Villa <mikalv@mikalv.net>