### PR TITLE
Limit tampering with standard C++ library to Linux

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -202,9 +202,11 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   endif ()
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   # more tweaks
-  if (NOT (MSVC OR MSYS OR APPLE))
+  if (LINUX)
     set (CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -stdlib=libstdc++" ) # required for <atomic>
     list(APPEND CMAKE_REQUIRED_LIBRARIES "stdc++") # required to link with -stdlib=libstdc++
+  endif()
+  if (NOT (MSVC OR MSYS OR APPLE))
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-const-variable -Wno-overloaded-virtual -Wno-c99-extensions" )
   endif()
 endif ()


### PR DESCRIPTION
Otherwise it breaks e.g. FreeBSD build where it is not needed at all