### PR TITLE
makefile: linux: add -latomic

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -44,7 +44,7 @@ ifeq ($(USE_STATIC),yes)
 	LDLIBS += -lpthread -static-libstdc++ -static-libgcc -lrt -ldl
 	USE_AESNI := no
 else
-	LDLIBS = -lcrypto -lssl -lz -lboost_system -lboost_date_time -lboost_filesystem -lboost_program_options -lpthread
+	LDLIBS = -lcrypto -lssl -lz -lboost_system -lboost_date_time -lboost_filesystem -lboost_program_options -lpthread -latomic
 endif
 
 # UPNP Support (miniupnpc 1.5 and higher)


### PR DESCRIPTION
Tested on Arch Linux (x86_64, armv7h) and Debian unstable (on PPC) with gcc 8.2.0. On Arch Linux
on x86_64 it built without this, but also builds with this. Without this
patch On Debian unstable on PPC linking fail with undefined symbols:
/usr/include/c++/8/bits/atomic_base.h:396: undefined reference to `__atomic_load_8'