### PR TITLE
Make persistent storage synchronization interval configurable 

### DIFF
--- a/libi2pd/Config.cpp
+++ b/libi2pd/Config.cpp
@@ -256,6 +256,7 @@ namespace config {
 		options_description persist("Network information persisting options");
 		persist.add_options()
 			("persist.profiles", value<bool>()->default_value(true), "Persist peer profiles (default: true)")
+			("persist.syncinterval", value<unsigned>()->default_value(60), "Peer profiles and NetDb persistent storage sync interval in seconds (0 - save only on exit)")
 		;
 
 		m_OptionsDesc

--- a/libi2pd/NetDb.hpp
+++ b/libi2pd/NetDb.hpp
@@ -110,6 +110,7 @@ namespace data
 			bool LoadRouterInfo (const std::string & path);
 			void SaveUpdated ();
 			void RemoveExpired ();
+			void RemoveObsoleteProfiles ();
 			void Run (); // exploratory thread
 			void Explore (int numDestinations);
 			void Publish ();

--- a/libi2pd/NetDb.hpp
+++ b/libi2pd/NetDb.hpp
@@ -109,6 +109,7 @@ namespace data
 			void Load ();
 			bool LoadRouterInfo (const std::string & path);
 			void SaveUpdated ();
+			void RemoveExpired ();
 			void Run (); // exploratory thread
 			void Explore (int numDestinations);
 			void Publish ();
@@ -129,6 +130,8 @@ namespace data
 			std::map<IdentHash, std::shared_ptr<LeaseSet> > m_LeaseSets;
 			mutable std::mutex m_RouterInfosMutex;
 			std::map<IdentHash, std::shared_ptr<RouterInfo> > m_RouterInfos;
+			mutable std::mutex m_UnsavedProfilesMutex;
+			std::map<IdentHash, std::shared_ptr<RouterProfile>> m_UnsavedProfiles;
 			mutable std::mutex m_FloodfillsMutex;
 			std::list<std::shared_ptr<RouterInfo> > m_Floodfills;
 
@@ -145,6 +148,7 @@ namespace data
 			friend class NetDbRequests;
 			NetDbRequests m_Requests;
 
+			unsigned m_PersistSyncInterval;
 			bool m_PersistProfiles;
 
 		/** router info we are bootstrapping from or nullptr if we are not currently doing that*/

--- a/libi2pd/Profiling.h
+++ b/libi2pd/Profiling.h
@@ -29,6 +29,8 @@ namespace data
 			RouterProfile ();
 			RouterProfile& operator= (const RouterProfile& ) = default;
 
+			boost::posix_time::ptime GetLastUpdateTime () const { return m_LastUpdateTime; };
+
 			void Save (const IdentHash& identHash);
 			void Load (const IdentHash& identHash);
 

--- a/libi2pd/RouterInfo.h
+++ b/libi2pd/RouterInfo.h
@@ -194,6 +194,8 @@ namespace data
 			bool SaveToFile (const std::string& fullPath);
 
 			std::shared_ptr<RouterProfile> GetProfile () const;
+			bool HasProfile () const { return static_cast<bool>(m_Profile); };
+			void SetProfile (const std::shared_ptr<RouterProfile>& profile) { m_Profile = profile; };
 			void SaveProfile () { if (m_Profile) m_Profile->Save (GetIdentHash ()); };
 
 			void Update (const uint8_t * buf, int len);


### PR DESCRIPTION
The option allows users to make disk io/memory usage tradeoffs themselves. Zero interval means saving only at exit, profiles are stored in memory.
