### PR TITLE
link libi2pd to boost and zlib

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -470,6 +470,7 @@ if (WITH_BINARY)
   if (WITH_STATIC)
     set(DL_LIB ${CMAKE_DL_LIBS})
   endif()
+  target_link_libraries(libi2pd ${Boost_LIBRARIES} ${ZLIB_LIBRARY})
   target_link_libraries( "${PROJECT_NAME}" libi2pd libi2pdclient ${DL_LIB} ${Boost_LIBRARIES} ${OPENSSL_LIBRARIES} ${ZLIB_LIBRARY} ${CMAKE_THREAD_LIBS_INIT} ${MINGW_EXTRA} ${DL_LIB} ${CMAKE_REQUIRED_LIBRARIES})
 
   install(TARGETS "${PROJECT_NAME}" RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT Runtime)


### PR DESCRIPTION
so i2pd can build with `LDFLAGS="-Wl,--as-needed"`

See issue https://github.com/PurpleI2P/i2pd/issues/1353