### PR TITLE
Fix and update i2pd.service

### DIFF
--- a/contrib/i2pd.service
+++ b/contrib/i2pd.service
@@ -11,9 +11,9 @@ RuntimeDirectoryMode=0700
 LogsDirectory=i2pd
 LogsDirectoryMode=0700
 Type=forking
-ExecStart=/usr/sbin/i2pd --conf=/etc/i2pd/i2pd.conf --tunconf=/etc/i2pd/tunnels.conf --tunnelsdir=/etc/i2pd/tunnels.conf.d --pidfile=/var/run/i2pd/i2pd.pid --logfile=/var/log/i2pd/i2pd.log --daemon --service
-ExecReload=/bin/kill -HUP $MAINPID
-PIDFile=/var/run/i2pd/i2pd.pid
+ExecStart=/usr/sbin/i2pd --conf=/etc/i2pd/i2pd.conf --tunconf=/etc/i2pd/tunnels.conf --tunnelsdir=/etc/i2pd/tunnels.conf.d --pidfile=/run/i2pd/i2pd.pid --logfile=/var/log/i2pd/i2pd.log --daemon --service
+ExecReload=/bin/sh -c "kill -HUP $MAINPID"
+PIDFile=/run/i2pd/i2pd.pid
 ### Uncomment, if auto restart needed
 #Restart=on-failure
 
@@ -27,7 +27,6 @@ KillSignal=SIGQUIT
 LimitNOFILE=4096
 # To enable write of coredump uncomment this
 #LimitCORE=infinity
-PrivateDevices=yes
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Fix and update i2pd.service

- /var/run on distros with systemd is a symlink to /run , hence the
path changes.

- Remove unnecessary runtime dependency on `/bin/kill` which is
provided by `procps` and might not be available on minimal installs
(e.g. containers). Instead use `/bin/sh` which has a built-in `kill`.

- `PrivateDevices=yes` causes i2pd to fail to start on latest Debian
unstable. Service exits with the following:

```
i2pd.service: Failed to execute command: Operation not permitted
i2pd.service: Failed at step EXEC spawning /usr/sbin/i2pd: Operation not permitted
i2pd.service: Control process exited, code=exited, status=203/EXEC
i2pd.service: Failed with result 'exit-code'.
Failed to start I2P Router written in C++.
```

According to `man systemd.exec` exit code 203 corresponds to the
`execve(2)` system call failing. So it looks like i2pd tries to do
something it shouldn't be doing. The proper fix would be in i2pd, but
who knows how long that would actually take, so to allow people to
actually launch i2pd in meanwhile the line has been removed from the
service file.

Also, surprisingly, right after installing i2pd it started without any
problems, and only after restarting the box i2pd started to fail for no
apparent reason.