### PR TITLE
Improve i2pd.conf example

### DIFF
--- a/contrib/i2pd.conf
+++ b/contrib/i2pd.conf
@@ -1,231 +1,337 @@
-## Configuration file for a typical i2pd user
-## See https://i2pd.readthedocs.io/en/latest/user-guide/configuration/
-## for more options you can use in this file.
+#   Configuration file for a typical i2pd user
+#   See https://i2pd.readthedocs.io/en/latest/user-guide/configuration/
+#   for more options you can use in this file.
 
-## Lines that begin with "## " try to explain what's going on. Lines
-## that begin with just "#" are disabled commands: you can enable them
-## by removing the "#" symbol.
+#   Lines that begin with "# " (hashtag space) try to explain what's going on.
+#   Lines that begin with just "#" are disabled commands: you can enable them by
+#   removing the "#" symbol.
 
-## Tunnels config file
-## Default: ~/.i2pd/tunnels.conf or /var/lib/i2pd/tunnels.conf
-# tunconf = /var/lib/i2pd/tunnels.conf
 
-## Tunnels config files path
-## Use that path to store separated tunnels in different config files.
-## Default: ~/.i2pd/tunnels.d or /var/lib/i2pd/tunnels.d
-# tunnelsdir = /var/lib/i2pd/tunnels.conf.d
+# Tunnels config file
+# Default: ~/.i2pd/tunnels.conf or /var/lib/i2pd/tunnels.conf
+#tunconf = /var/lib/i2pd/tunnels.conf
 
-## Where to write pidfile (don't write by default)
-# pidfile = /var/run/i2pd.pid
+# Tunnels config files path
+# Use that path to store separated tunnels in different config files.
+# Default: ~/.i2pd/tunnels.d or /var/lib/i2pd/tunnels.d
+#tunnelsdir = /var/lib/i2pd/tunnels.conf.d
 
-## Logging configuration section
-## By default logs go to stdout with level 'info' and higher
-##
-## Logs destination (valid values: stdout, file, syslog)
-##  * stdout - print log entries to stdout
-##  * file - log entries to a file
-##  * syslog - use syslog, see man 3 syslog
-# log = file
-## Path to logfile (default - autodetect)
-# logfile = /var/log/i2pd.log
-## Log messages above this level (debug, *info, warn, error, none)
-## If you set it to none, logging will be disabled
-# loglevel = info
-## Write full CLF-formatted date and time to log (default: write only time)
-# logclftime = true
+# Where to write pidfile
+# By default i2pd doesn't create pidfile
+#pidfile = /var/run/i2pd.pid
 
-## Daemon mode. Router will go to background after start
-# daemon = true
 
-## Specify a family, router belongs to (default - none)
-# family =
+# Logging
+#
+# Log destination
+# Valid values:
+#  * stdout - print log entries to stdout
+#  * file - log entries to a file
+#  * syslog - use syslog, see man 3 syslog
+#log = file
 
-## External IP address to listen for connections
-## By default i2pd sets IP automatically
-# host = 1.2.3.4
+# Path to logfile (default - autodetect)
+#logfile = /var/log/i2pd.log
 
-## Port to listen for connections
-## By default i2pd picks random port. You MUST pick a random number too,
-## don't just uncomment this
-# port = 4567
+# Log level
+# Valid values listed from smallest amount of logging to highest:
+#  * none - disables logging
+#  * error
+#  * warn
+#  * info - logs go to stdout
+#  * debug - logs go to stdout
+#loglevel = info
 
-## Enable communication through ipv4
-ipv4 = true
-## Enable communication through ipv6
-ipv6 = false
+# Write full CLF-formatted date and time to log
+# By default i2pd write only time, no date
+#logclftime = true
 
-## Network interface to bind to
-# ifname =
-## You can specify different interfaces for IPv4 and IPv6
-# ifname4 = 
-# ifname6 = 
+# Daemon mode. Router will go to background after start.
+#daemon = true
 
-## Enable NTCP transport (default = true)
-# ntcp = true
-## If you run i2pd behind a proxy server, you can only use NTCP transport with ntcpproxy option 
-## Should be http://address:port or socks://address:port
-# ntcpproxy = http://127.0.0.1:8118
-## Enable SSU transport (default = true)
-# ssu = true
+# Specify a family the router belongs to
+# By default there's no family specified
+#family =
 
-## Should we assume we are behind NAT? (false only in MeshNet)
-# nat = true
+# External IP address to listen for connections
+# By default i2pd sets IP automatically
+#host = 1.2.3.4
 
-## Bandwidth configuration
-## L limit bandwidth to 32KBs/sec, O - to 256KBs/sec, P - to 2048KBs/sec,
-## X - unlimited
-## Default is X for floodfill, L for regular node
-# bandwidth = L
-## Max % of bandwidth limit for transit. 0-100. 100 by default
-# share = 100
+# Port to listen for connections
+# By default i2pd picks random port.
+# Value range: 0-65535
+#port = 0
 
-## Router will not accept transit tunnels, disabling transit traffic completely
-## (default = false)
-# notransit = true
+# Enable communication through IPv4
+# Default: true
+#ipv4 = true
 
-## Router will be floodfill
-# floodfill = true
+# Enable communication through IPv6
+# Default: false
+#ipv6 = true
+
+# Network interface to bind to
+#ifname =
+# You can specify different interfaces for IPv4 and IPv6
+#ifname4 =
+#ifname6 =
+
+# Enable NTCP transport
+# Default: true
+#ntcp = true
+
+# If you run i2pd behind a proxy server, you can only use NTCP transport with
+# ntcpproxy option.
+# Example: http://address:port or socks://address:port
+#ntcpproxy = http://127.0.0.1:8118
+
+# Enable SSU transport
+# Default: true
+#ssu = true
+
+# Should we assume we are behind NAT?
+# Default in MeshNet: false
+# Default: true
+#nat = true
+
+# Bandwidth limit
+# Set to a valid letter or a number of KB/s
+# Valid letters:
+#   * L - up to 32 KB/s
+#   * O - up to 256 KB/s
+#   * P - up to 2048 KB/s
+#   * X - unlimited
+# Value range: 1-9000
+# Default for floodfill: X
+# Default: L
+#bandwidth = L
+
+# Max % of bandwidth limit for transit.
+# Value range: 0-100
+# Default: 100
+#share = 100
+
+# Don't accept transit tunnels, disabling transit traffic completely
+# Default: false
+#notransit = true
+
+# Router will be floodfill
+# Default: false
+#floodfill = true
+
 
 [http]
-## Web Console settings
-## Uncomment and set to 'false' to disable Web Console
-# enabled = true
-## Address and port service will listen on
+# Web Console settings
+# Set to 'false' to disable Web Console
+# Default: true
+#enabled = true
+
+# Address and port service will listen on
 address = 127.0.0.1
 port = 7070
-## Path to web console, default "/"
-# webroot = /
-## Uncomment following lines to enable Web Console authentication 
-# auth = true
-# user = i2pd
-# pass = changeme
+
+# Path to web console
+# Default: /
+#webroot = /
+
+# Enable Web Console authentication
+#auth = true
+#user = i2pd
+#pass = changeme
+
 
 [httpproxy]
-## Uncomment and set to 'false' to disable HTTP Proxy
-# enabled = true
-## Address and port service will listen on
+# httpproxy section also accepts I2CP parameters, like "inbound.length" etc.
+
+# Set to 'false' to disable HTTP Proxy
+# Default: true
+#enabled = true
+
+# Address and port service will listen on
 address = 127.0.0.1
 port = 4444
-## Optional keys file for proxy local destination
-# keys = http-proxy-keys.dat
-## Enable address helper for adding .i2p domains with "jump URLs" (default: true)
-# addresshelper = true
-## Address of a proxy server inside I2P, which is used to visit regular Internet
-# outproxy = http://false.i2p
-## httpproxy section also accepts I2CP parameters, like "inbound.length" etc.
+
+# Optional keys file for proxy local destination
+#keys = http-proxy-keys.dat
+
+# Enable address helper for adding .i2p domains with "jump URLs"
+# Default: true
+#addresshelper = true
+
+# Address of a proxy server inside I2P, which is used to visit regular Internet
+#outproxy = http://false.i2p
+
 
 [socksproxy]
-## Uncomment and set to 'false' to disable SOCKS Proxy
-# enabled = true
-## Address and port service will listen on
+# socksproxy section also accepts I2CP parameters, like "inbound.length" etc.
+
+# Set to 'false' to disable SOCKS Proxy
+# Default: true
+#enabled = true
+
+# Address and port service will listen on
 address = 127.0.0.1
 port = 4447
-## Optional keys file for proxy local destination
-# keys = socks-proxy-keys.dat
-## Socks outproxy. Example below is set to use Tor for all connections except i2p
-## Uncomment and set to 'true' to enable using of SOCKS outproxy
-# outproxy.enabled = false
-## Address and port of outproxy
-# outproxy = 127.0.0.1
-# outproxyport = 9050
-## socksproxy section also accepts I2CP parameters, like "inbound.length" etc.
+# Optional keys file for proxy local destination
+#keys = socks-proxy-keys.dat
+
+# Socks outproxy.
+# Set to 'true' to enable using of SOCKS outproxy
+# Default: false
+#outproxy.enabled = false
+
+# Address and port of outproxy
+# Example is set to use default Tor port for all connections except i2p
+#outproxy = 127.0.0.1
+#outproxyport = 9050
+
 
 [sam]
-## Uncomment and set to 'true' to enable SAM Bridge
+# Set to 'true' to enable SAM Bridge
 enabled = true
-## Address and port service will listen on
-# address = 127.0.0.1
-# port = 7656
+
+# Address and port service will listen on
+#address = 127.0.0.1
+#port = 7656
+
 
 [bob]
-## Uncomment and set to 'true' to enable BOB command channel
-# enabled = false
-## Address and port service will listen on
-# address = 127.0.0.1
-# port = 2827
+# Set to 'true' to enable BOB command channel
+#enabled = false
+
+# Address and port service will listen on
+#address = 127.0.0.1
+#port = 2827
+
 
 [i2cp]
-## Uncomment and set to 'true' to enable I2CP protocol
-# enabled = false
-## Address and port service will listen on
-# address = 127.0.0.1
-# port = 7654
+# Set to 'true' to enable I2CP protocol
+#enabled = false
+
+# Address and port service will listen on
+#address = 127.0.0.1
+#port = 7654
+
 
 [i2pcontrol]
-## Uncomment and set to 'true' to enable I2PControl protocol
-# enabled = false
-## Address and port service will listen on
-# address = 127.0.0.1
-# port = 7650
-## Authentication password. "itoopie" by default
-# password = itoopie
+# Set to 'true' to enable I2PControl protocol
+#enabled = false
+
+# Address and port service will listen on
+#address = 127.0.0.1
+#port = 7650
+
+# Authentication password.
+# Default: itoopie
+#password = itoopie
+
 
 [precomputation]
-## Enable or disable elgamal precomputation table
-## By default, enabled on i386 hosts
-# elgamal = true
+# Enable or disable elgamal precomputation table
+# Default on i386: true
+# Default: false
+#elgamal = true
+
 
 [upnp]
-## Enable or disable UPnP: automatic port forwarding (enabled by default in WINDOWS, ANDROID)
-# enabled = false
-## Name i2pd appears in UPnP forwardings list (default = I2Pd)
-# name = I2Pd
+# Enable or disable UPnP: automatic port forwarding
+# By default enabled in Windows and Android
+#enabled = false
+
+# Name i2pd appears in UPnP forwardings list
+# Default: I2Pd
+#name = I2Pd
+
 
 [reseed]
-## Options for bootstrapping into I2P network, aka reseeding
-## Enable or disable reseed data verification.
+# Options for bootstrapping into I2P network, aka reseeding
+# Enable or disable reseed data verification.
 verify = true
-## URLs to request reseed data from, separated by comma
-## Default: "mainline" I2P Network reseeds
-# urls = https://reseed.i2p-projekt.de/,https://i2p.mooo.com/netDb/,https://netdb.i2p2.no/
-## Path to local reseed data file (.su3) for manual reseeding
-# file = /path/to/i2pseeds.su3
-## or HTTPS URL to reseed from
-# file = https://legit-website.com/i2pseeds.su3
-## Path to local ZIP file or HTTPS URL to reseed from
-# zipfile = /path/to/netDb.zip
-## If you run i2pd behind a proxy server, set proxy server for reseeding here
-## Should be http://address:port or socks://address:port
-# proxy = http://127.0.0.1:8118
-## Minimum number of known routers, below which i2pd triggers reseeding. 25 by default
-# threshold = 25
+
+# URLs to request reseed data from, separated by comma
+# By default "mainline" I2P Network reseeds
+#urls = https://reseed.i2p-projekt.de/,https://i2p.mooo.com/netDb/,https://netdb.i2p2.no/
+
+# Path to a local reseed data file (.su3) or a HTTPS URL for manual reseeding
+#file = /path/to/i2pseeds.su3
+#file = https://legit-website.com/i2pseeds.su3
+
+# Path to a local ZIP file or HTTPS URL to reseed from
+#zipfile = /path/to/netDb.zip
+
+# If you run i2pd behind a proxy server, set proxy server for reseeding here
+# Example values:
+#   * http://address:port
+#   * socks://address:port
+#proxy = http://127.0.0.1:8118
+
+# Minimum number of known routers, below which i2pd triggers reseeding.
+# Default: 25
+#threshold = 25
+
 
 [addressbook]
-## AddressBook subscription URL for initial setup
-## Default: inr.i2p at "mainline" I2P Network
-# defaulturl = http://joajgazyztfssty4w2on5oaqksz6tqoxbduy553y34mf4byv6gpq.b32.i2p/export/alive-hosts.txt
-## Optional subscriptions URLs, separated by comma
-# subscriptions = http://inr.i2p/export/alive-hosts.txt,http://stats.i2p/cgi-bin/newhosts.txt,http://rus.i2p/hosts.txt
+# AddressBook subscription URL for initial setup
+# By default inr.i2p at "mainline" I2P Network
+#defaulturl = http://joajgazyztfssty4w2on5oaqksz6tqoxbduy553y34mf4byv6gpq.b32.i2p/export/alive-hosts.txt
+
+# Optional subscriptions URLs, separated by comma
+#subscriptions = http://inr.i2p/export/alive-hosts.txt,http://stats.i2p/cgi-bin/newhosts.txt,http://rus.i2p/hosts.txt
+
 
 [limits]
-## Maximum active transit sessions (default:2500)
-# transittunnels = 2500
-## Limit number of open file descriptors (0 - use system limit)  
-# openfiles = 0
-## Maximum size of corefile in Kb (0 - use system limit) 
-# coresize = 0
-## Threshold to start probabalistic backoff with ntcp sessions (0 - use system limit) 
-# ntcpsoft = 0
-## Maximum number of ntcp sessions (0 - use system limit) 
-# ntcphard = 0
+# Maximum active transit sessions
+# Default: 2500
+#transittunnels = 2500
+
+# Limit number of open file descriptors
+# Special values:
+#   * 0 - use system limit
+# Default: 0
+#openfiles = 0
+
+# Maximum size of corefile in Kb
+# Special values:
+#   * 0 - use system limit
+#coresize = 0
+
+# Threshold to start probabilistic backoff with ntcp sessions
+# Special values:
+#   * 0 - use system limit
+#ntcpsoft = 0
+
+# Maximum number of ntcp sessions
+# Special values:
+#   * 0 - use system limit
+#ntcphard = 0
+
 
 [trust]
-## Enable explicit trust options. false by default
-# enabled = true
-## Make direct I2P connections only to routers in specified Family.
-# family = MyFamily
-## Make direct I2P connections only to routers specified here. Comma separated list of base64 identities.
-# routers = 
-## Should we hide our router from other routers? false by default
-# hidden = true
+# Enable explicit trust options.
+# Default: false
+#enabled = true
+
+# Make direct I2P connections only to routers in specified Family.
+#family = MyFamily
+
+# Make direct I2P connections only to routers specified here. Comma separated
+# list of base64 identities.
+#routers =
+
+# Should we hide our router from other routers?
+# Default: false
+#hidden = true
+
 
 [exploratory]
-## Exploratory tunnels settings with default values
-# inbound.length = 2 
-# inbound.quantity = 3
-# outbound.length = 2
-# outbound.quantity = 3
+# Exploratory tunnels settings with default values
+#inbound.length = 2
+#inbound.quantity = 3
+#outbound.length = 2
+#outbound.quantity = 3
+
 
 [persist]
-## Save peer profiles on disk (default: true)
-# profiles = true
+# Save peer profiles on disk
+# Default: true
+#profiles = true


### PR DESCRIPTION
- In case of default port setting, change it to `0` so that a random one
  would be assigned for i2pd in case where user uncomments the setting
  without changing the port
- In case of ipv6 setting change it to `true` since the default
  behaviour is to not use IPv6, and the only reason to uncomment it
  would be to set it to `true`.
- try to specify default values and/or default behaviour
- make things more consistent
- remove trailing whitespaces
- formatting