### PR TITLE
Add dns.medium.i2p service to optional subscriptions

### DIFF
--- a/contrib/i2pd.conf
+++ b/contrib/i2pd.conf
@@ -195,7 +195,7 @@ verify = true
 ## Default: inr.i2p at "mainline" I2P Network
 # defaulturl = http://joajgazyztfssty4w2on5oaqksz6tqoxbduy553y34mf4byv6gpq.b32.i2p/export/alive-hosts.txt
 ## Optional subscriptions URLs, separated by comma
-# subscriptions = http://inr.i2p/export/alive-hosts.txt,http://stats.i2p/cgi-bin/newhosts.txt,http://rus.i2p/hosts.txt,http://dns3a44zzbexpzpqakipnshxvdovx5vx4wpwknncbcekldjqp2wa.b32.i2p
+# subscriptions = http://inr.i2p/export/alive-hosts.txt,http://stats.i2p/cgi-bin/newhosts.txt,http://rus.i2p/hosts.txt,http://dns3a44zzbexpzpqakipnshxvdovx5vx4wpwknncbcekldjqp2wa.b32.i2p/export/alive-hosts.txt
 
 [limits]
 ## Maximum active transit sessions (default:2500)

--- a/contrib/i2pd.conf
+++ b/contrib/i2pd.conf
@@ -195,7 +195,7 @@ verify = true
 ## Default: inr.i2p at "mainline" I2P Network
 # defaulturl = http://joajgazyztfssty4w2on5oaqksz6tqoxbduy553y34mf4byv6gpq.b32.i2p/export/alive-hosts.txt
 ## Optional subscriptions URLs, separated by comma
-# subscriptions = http://inr.i2p/export/alive-hosts.txt,http://stats.i2p/cgi-bin/newhosts.txt,http://rus.i2p/hosts.txt
+# subscriptions = http://inr.i2p/export/alive-hosts.txt,http://stats.i2p/cgi-bin/newhosts.txt,http://rus.i2p/hosts.txt,http://dns3a44zzbexpzpqakipnshxvdovx5vx4wpwknncbcekldjqp2wa.b32.i2p
 
 [limits]
 ## Maximum active transit sessions (default:2500)


### PR DESCRIPTION
See github.com/medium-isp/medium-dns

Also known as dns.medium.i2p