### PR TITLE
fix dockerfile: remove unmet dependencies

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -36,8 +36,8 @@ RUN apk --no-cache --virtual build-dependendencies add make gcc g++ libtool zlib
     && cd /usr/local/bin \
     && strip i2pd \
     && rm -fr /tmp/build && apk --no-cache --purge del build-dependendencies build-base fortify-headers boost-dev zlib-dev openssl-dev \
-    boost-python3 python3 gdbm boost-unit_test_framework boost-python linux-headers boost-prg_exec_monitor \
-    boost-serialization boost-signals boost-wave boost-wserialization boost-math boost-graph boost-regex git pcre \
+    boost-python3 python3 gdbm boost-unit_test_framework linux-headers boost-prg_exec_monitor \
+    boost-serialization boost-wave boost-wserialization boost-math boost-graph boost-regex git pcre \
     libtool g++ gcc pkgconfig
 
 # 2. Adding required libraries to run i2pd to ensure it will run.


### PR DESCRIPTION
While `docker build` I've seen the error: code 2. After some investigation, I've found that there are some dependencies that were not inside the image.

P.S. normally `apk --no-cache --purge del build-dependendencies` fair enough after `apk --no-cache --virtual build-dependendencies add make gcc g++ .... git`, and other dependecies (*boost-python3 python3 gdbm ...*) should also be removed