### PR TITLE
Update Dockerfile

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -36,9 +36,9 @@ RUN apk --no-cache --virtual build-dependendencies add make gcc g++ libtool zlib
     && cd /usr/local/bin \
     && strip i2pd \
     && rm -fr /tmp/build && apk --no-cache --purge del build-dependendencies build-base fortify-headers boost-dev zlib-dev openssl-dev \
-    boost-python3 python3 gdbm boost-unit_test_framework linux-headers boost-prg_exec_monitor \
-    boost-serialization boost-wave boost-wserialization boost-math boost-graph boost-regex git pcre \
-    libtool g++ gcc pkgconfig
+    boost-python3 python3 gdbm boost-unit_test_framework boost-python2 linux-headers boost-prg_exec_monitor \
+    boost-serialization boost-wave boost-wserialization boost-math boost-graph boost-regex git pcre2 \
+    libtool g++ gcc
 
 # 2. Adding required libraries to run i2pd to ensure it will run.
 RUN apk --no-cache add boost-filesystem boost-system boost-program_options boost-date_time boost-thread boost-iostreams openssl musl-utils libstdc++


### PR DESCRIPTION
Fixes dependencies, re-adds `boost-python` as `boost-python2` which was removed in #1408 .