### PR TITLE
Pass -dead_strip -dead_strip_dylibs -bind_at_load on macOS

### DIFF
--- a/Makefile.osx
+++ b/Makefile.osx
@@ -2,6 +2,9 @@ CXX = clang++
 CXXFLAGS := ${CXX_DEBUG} -Wall -std=c++11 -DMAC_OSX
 INCFLAGS = -I/usr/local/include
 LDFLAGS := -Wl,-rpath,/usr/local/lib -L/usr/local/lib
+LDFLAGS += -Wl,-dead_strip
+LDFLAGS += -Wl,-dead_strip_dylibs
+LDFLAGS += -Wl,-bind_at_load
 
 ifeq ($(USE_STATIC),yes)
 	LDLIBS = -lz /usr/local/lib/libcrypto.a /usr/local/lib/libssl.a /usr/local/lib/libboost_system.a /usr/local/lib/libboost_date_time.a /usr/local/lib/libboost_filesystem.a /usr/local/lib/libboost_program_options.a -lpthread


### PR DESCRIPTION
From `man ld`.
```
-dead_strip
                 Remove functions and data that are unreachable by the entry point or exported symbols.
```
Before:
```
% wc -c i2pd
 41578144 i2pd
```
After:
```
% wc -c i2pd 
 34982704 i2pd
```

From `man ld`.
```
-dead_strip_dylibs
                 Remove dylibs that are unreachable by the entry point or exported symbols. That is, suppresses the generation of load
                 command commands for dylibs which supplied no symbols during the link. This option should not be used when linking
                 against a dylib which is required at runtime for some indirect reason such as the dylib has an important initializer.
```
Before:
```
% otool -L i2pd
i2pd:
	/opt/local/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
	/opt/local/lib/libcrypto.1.1.dylib (compatibility version 1.1.0, current version 1.1.0)
	/opt/local/lib/libssl.1.1.dylib (compatibility version 1.1.0, current version 1.1.0)
	/opt/local/lib/libboost_system-mt.dylib (compatibility version 0.0.0, current version 0.0.0)
	/opt/local/lib/libboost_date_time-mt.dylib (compatibility version 0.0.0, current version 0.0.0)
	/opt/local/lib/libboost_filesystem-mt.dylib (compatibility version 0.0.0, current version 0.0.0)
	/opt/local/lib/libboost_program_options-mt.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 800.7.0)
```
After:
```
% otool -L i2pd
i2pd:
	/opt/local/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
	/opt/local/lib/libcrypto.1.1.dylib (compatibility version 1.1.0, current version 1.1.0)
	/opt/local/lib/libssl.1.1.dylib (compatibility version 1.1.0, current version 1.1.0)
	/opt/local/lib/libboost_date_time-mt.dylib (compatibility version 0.0.0, current version 0.0.0)
	/opt/local/lib/libboost_filesystem-mt.dylib (compatibility version 0.0.0, current version 0.0.0)
	/opt/local/lib/libboost_program_options-mt.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1281.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 800.7.0)
```

From `man ld`.
```
-bind_at_load
                 Sets a bit in the mach header of the resulting binary which tells dyld to bind all symbols when the binary is loaded,
                 rather than lazily.
```
Before:
```
% otool -l i2pd
Load command 5
            cmd LC_DYLD_INFO_ONLY
        cmdsize 48
     rebase_off 7303168
    rebase_size 2832
       bind_off 7306000
      bind_size 7184
  weak_bind_off 7313184
 weak_bind_size 2046792
  lazy_bind_off 9359976
 lazy_bind_size 18768
     export_off 9378744
    export_size 1235224
```
After:
```
% otool -l i2pd
Load command 5
            cmd LC_DYLD_INFO_ONLY
        cmdsize 48
     rebase_off 6017024
    rebase_size 2800
       bind_off 6019824
      bind_size 22736
  weak_bind_off 6042560
 weak_bind_size 2040064
  lazy_bind_off 0
 lazy_bind_size 0
     export_off 8082624
    export_size 1228224
```