### PR TITLE
replace random_shuffle with shuffle

### DIFF
--- a/libi2pd/Tunnel.cpp
+++ b/libi2pd/Tunnel.cpp
@@ -1,5 +1,6 @@
 #include <string.h>
 #include "I2PEndian.h"
+#include <random>
 #include <thread>
 #include <algorithm>
 #include <vector>
@@ -45,7 +46,7 @@ namespace tunnel
 		// shuffle records
 		std::vector<int> recordIndicies;
 		for (int i = 0; i < numRecords; i++) recordIndicies.push_back(i);
-		std::random_shuffle (recordIndicies.begin(), recordIndicies.end());
+		std::shuffle (recordIndicies.begin(), recordIndicies.end(), std::mt19937(std::random_device()()));
 
 		// create real records
 		uint8_t * records = msg->GetPayload () + 1;

--- a/libi2pd/TunnelPool.cpp
+++ b/libi2pd/TunnelPool.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <random>
 #include "I2PEndian.h"
 #include "Crypto.h"
 #include "Tunnel.h"
@@ -441,7 +442,7 @@ namespace tunnel
 		int size = m_ExplicitPeers->size ();
 		std::vector<int> peerIndicies;
 		for (int i = 0; i < size; i++) peerIndicies.push_back(i);
-		std::random_shuffle (peerIndicies.begin(), peerIndicies.end());
+		std::shuffle (peerIndicies.begin(), peerIndicies.end(), std::mt19937(std::random_device()()));
 
 		int numHops = isInbound ? m_NumInboundHops : m_NumOutboundHops;
 		for (int i = 0; i < numHops; i++)


### PR DESCRIPTION
random_shuffle is gone with C++17.

Found and fixed with clang-tidy.