### PR TITLE
libi2pd: use std::move and pass by value

### DIFF
--- a/libi2pd/Datagram.cpp
+++ b/libi2pd/Datagram.cpp
@@ -1,4 +1,5 @@
 #include <string.h>
+#include <utility>
 #include <vector>
 #include "Crypto.h"
 #include "Log.h"
@@ -12,7 +13,7 @@ namespace i2p
 namespace datagram
 {
 	DatagramDestination::DatagramDestination (std::shared_ptr<i2p::client::ClientDestination> owner):
-		m_Owner (owner), m_Receiver (nullptr), m_RawReceiver (nullptr)
+		m_Owner (std::move(owner)), m_Receiver (nullptr), m_RawReceiver (nullptr)
 	{
 	}
 

--- a/libi2pd/Garlic.cpp
+++ b/libi2pd/Garlic.cpp
@@ -2,6 +2,7 @@
 #include "I2PEndian.h"
 #include <map>
 #include <string>
+#include <utility>
 #include "Crypto.h"
 #include "RouterContext.h"
 #include "I2NPProtocol.h"
@@ -61,7 +62,7 @@ namespace garlic
     ElGamalAESSession::ElGamalAESSession (GarlicDestination * owner,
 	    std::shared_ptr<const i2p::data::RoutingDestination> destination, int numTags, bool attachLeaseSet):
         GarlicRoutingSession (owner, attachLeaseSet), 
-        m_Destination (destination), m_NumTags (numTags)
+        m_Destination (std::move(destination)), m_NumTags (numTags)
 	{
 		// create new session tags and session key
 		RAND_bytes (m_SessionKey, 32);

--- a/libi2pd/LeaseSet.cpp
+++ b/libi2pd/LeaseSet.cpp
@@ -1,4 +1,6 @@
 #include <string.h>
+
+#include <utility>
 #include "I2PEndian.h"
 #include "Crypto.h"
 #include "Log.h"
@@ -652,7 +654,7 @@ namespace data
 	}
 
 	LocalLeaseSet::LocalLeaseSet (std::shared_ptr<const IdentityEx> identity, const uint8_t * encryptionPublicKey, std::vector<std::shared_ptr<i2p::tunnel::InboundTunnel> > tunnels):
-		m_ExpirationTime (0), m_Identity (identity)
+		m_ExpirationTime (0), m_Identity (std::move(identity))
 	{
 		int num = tunnels.size ();
 		if (num > MAX_NUM_LEASES) num = MAX_NUM_LEASES;
@@ -689,7 +691,7 @@ namespace data
 	}
 
 	LocalLeaseSet::LocalLeaseSet (std::shared_ptr<const IdentityEx> identity, const uint8_t * buf, size_t len):
-		m_ExpirationTime (0), m_Identity (identity)
+		m_ExpirationTime (0), m_Identity (std::move(identity))
 	{
 		if (buf)
 		{

--- a/libi2pd/RouterInfo.cpp
+++ b/libi2pd/RouterInfo.cpp
@@ -2,6 +2,7 @@
 #include <string.h>
 #include "I2PEndian.h"
 #include <fstream>
+#include <utility>
 #include <boost/lexical_cast.hpp>
 #include <boost/make_shared.hpp>
 #if (BOOST_VERSION >= 105300)
@@ -25,8 +26,8 @@ namespace data
 		m_Addresses = boost::make_shared<Addresses>(); // create empty list
 	}
 
-	RouterInfo::RouterInfo (const std::string& fullPath):
-		m_FullPath (fullPath), m_IsUpdated (false), m_IsUnreachable (false),
+	RouterInfo::RouterInfo (std::string fullPath):
+		m_FullPath (std::move(fullPath)), m_IsUpdated (false), m_IsUnreachable (false),
 		m_SupportedTransports (0), m_Caps (0)
 	{
 		m_Addresses = boost::make_shared<Addresses>(); // create empty list

--- a/libi2pd/RouterInfo.h
+++ b/libi2pd/RouterInfo.h
@@ -132,7 +132,7 @@ namespace data
 			typedef std::list<std::shared_ptr<Address> > Addresses;
 
 			RouterInfo ();
-			RouterInfo (const std::string& fullPath);
+			RouterInfo (std::string fullPath);
 			RouterInfo (const RouterInfo& ) = default;
 			RouterInfo& operator=(const RouterInfo& ) = default;
 			RouterInfo (const uint8_t * buf, int len);

--- a/libi2pd/Streaming.cpp
+++ b/libi2pd/Streaming.cpp
@@ -7,6 +7,8 @@
 #include "Destination.h"
 #include "Streaming.h"
 
+#include <utility>
+
 namespace i2p
 {
 namespace stream
@@ -963,7 +965,7 @@ namespace stream
 	}
 
 	StreamingDestination::StreamingDestination (std::shared_ptr<i2p::client::ClientDestination> owner, uint16_t localPort, bool gzip):
-		m_Owner (owner), m_LocalPort (localPort), m_Gzip (gzip),
+		m_Owner (std::move(owner)), m_LocalPort (localPort), m_Gzip (gzip),
 		m_PendingIncomingTimer (m_Owner->GetService ())
 	{
 	}


### PR DESCRIPTION
Found with clang-tidy's modernize-pass-by-value

Signed-off-by: Rosen Penev <rosenp@gmail.com>