### PR TITLE
Pass -dead_strip -dead_strip_dylibs -bind_at_load on macOS

### DIFF
--- a/qt/i2pd_qt/i2pd_qt.pro
+++ b/qt/i2pd_qt/i2pd_qt.pro
@@ -210,6 +210,9 @@ macx {
 	LIBS += $$BOOSTROOT/lib/libboost_filesystem.a
 	LIBS += $$BOOSTROOT/lib/libboost_program_options.a
 	LIBS += $$UPNPROOT/lib/libminiupnpc.a
+	LIBS += -Wl,-dead_strip
+	LIBS += -Wl,-dead_strip_dylibs
+	LIBS += -Wl,-bind_at_load
 }
 
 linux:!android {


### PR DESCRIPTION
Before:
```
% wc -c i2pd_qt.app/Contents/MacOS/i2pd_qt 
 48243884 i2pd_qt.app/Contents/MacOS/i2pd_qt
```
After:
```
% wc -c i2pd_qt.app/Contents/MacOS/i2pd_qt
 39394204 i2pd_qt.app/Contents/MacOS/i2pd_qt
```