### PR TITLE
Fix clang warnings

### DIFF
--- a/libi2pd/Tunnel.h
+++ b/libi2pd/Tunnel.h
@@ -116,6 +116,7 @@ namespace tunnel
 	{
 		public:
 
+			using Tunnel::SendTunnelDataMsg;
 			OutboundTunnel (std::shared_ptr<const TunnelConfig> config):
 				Tunnel (config), m_Gateway (this), m_EndpointIdentHash (config->GetLastIdentHash ()) {};
 


### PR DESCRIPTION
Fixed the following clang warnings:
```
libi2pd/Tunnel.h:122:9: warning: 'i2p::tunnel::OutboundTunnel::SendTunnelDataMsg' hides overloaded virtual function [-Woverloaded-virtual]
                        void SendTunnelDataMsg (const uint8_t * gwHash, uint32_t gwTunnel, std::shared_ptr<i2p::I2NPMessage> msg);
                             ^
libi2pd/Tunnel.h:90:9: note: hidden overloaded virtual function 'i2p::tunnel::Tunnel::SendTunnelDataMsg' declared here: different number of parameters
      (1 vs 3)
                        void SendTunnelDataMsg (std::shared_ptr<i2p::I2NPMessage> msg);
                             ^
libi2pd/Tunnel.h:123:17: warning: 'i2p::tunnel::OutboundTunnel::SendTunnelDataMsg' hides overloaded virtual function [-Woverloaded-virtual]
                        virtual void SendTunnelDataMsg (const std::vector<TunnelMessageBlock>& msgs); // multiple messages
                                     ^
libi2pd/Tunnel.h:90:9: note: hidden overloaded virtual function 'i2p::tunnel::Tunnel::SendTunnelDataMsg' declared here: type mismatch at 1st parameter
      ('std::shared_ptr<i2p::I2NPMessage>' vs 'const std::vector<TunnelMessageBlock> &')
                        void SendTunnelDataMsg (std::shared_ptr<i2p::I2NPMessage> msg);
                             ^
```