### PR TITLE
Fix clang warning

### DIFF
--- a/libi2pd/NTCP2.cpp
+++ b/libi2pd/NTCP2.cpp
@@ -1519,7 +1519,7 @@ namespace transport
 
 				boost::asio::streambuf * readbuff = new boost::asio::streambuf;
 				boost::asio::async_read_until(conn->GetSocket(), *readbuff, "\r\n\r\n",
-					[this, readbuff, timer, conn] (const boost::system::error_code & ec, std::size_t transferred)
+					[readbuff, timer, conn] (const boost::system::error_code & ec, std::size_t transferred)
 					{
 						if(ec)
 						{


### PR DESCRIPTION
Fixed the following warning:
```
libi2pd/NTCP2.cpp:1522:7: warning: lambda capture 'this' is not used [-Wunused-lambda-capture]
                                        [this, readbuff, timer, conn] (const boost::system::error_code & ec, std::size_t transferred)
                                         ^~~~~
1 warning generated.
```