### PR TITLE
Fix more clang warnings

### DIFF
--- a/daemon/HTTPServer.cpp
+++ b/daemon/HTTPServer.cpp
@@ -123,8 +123,8 @@ namespace http {
 	const char HTTP_COMMAND_LOGLEVEL[] = "set_loglevel";
 	const char HTTP_COMMAND_KILLSTREAM[] = "closestream";
 	const char HTTP_COMMAND_LIMITTRANSIT[] = "limittransit";
-	const char HTTP_PARAM_SAM_SESSION_ID[] = "id";
-	const char HTTP_PARAM_ADDRESS[] = "address";
+	const char HTTP_PARAM_SAM_SESSION_ID[] __attribute__((unused)) = "id";
+	const char HTTP_PARAM_ADDRESS[] __attribute__((unused)) = "address";
 
 	static std::string ConvertTime (uint64_t time);
 	std::map<uint32_t, uint32_t> HTTPConnection::m_Tokens;

--- a/libi2pd/Blinding.cpp
+++ b/libi2pd/Blinding.cpp
@@ -135,7 +135,7 @@ namespace data
 //----------------------------------------------------------
 
 	const uint8_t B33_TWO_BYTES_SIGTYPE_FLAG = 0x01;
-	const uint8_t B33_PER_SECRET_FLAG = 0x02; // not used for now
+	const uint8_t B33_PER_SECRET_FLAG __attribute__((unused)) = 0x02; // not used for now
 	const uint8_t B33_PER_CLIENT_AUTH_FLAG = 0x04;
 
 	BlindedPublicKey::BlindedPublicKey (std::shared_ptr<const IdentityEx> identity, bool clientAuth):

--- a/libi2pd/Crypto.cpp
+++ b/libi2pd/Crypto.cpp
@@ -160,7 +160,7 @@ namespace crypto
 // DH/ElGamal
 
 	const int ELGAMAL_SHORT_EXPONENT_NUM_BITS = 226;
-	const int ELGAMAL_SHORT_EXPONENT_NUM_BYTES = ELGAMAL_SHORT_EXPONENT_NUM_BITS/8+1;
+	const int ELGAMAL_SHORT_EXPONENT_NUM_BYTES __attribute__((unused)) = ELGAMAL_SHORT_EXPONENT_NUM_BITS/8+1;
 	const int ELGAMAL_FULL_EXPONENT_NUM_BITS = 2048;
 	const int ELGAMAL_FULL_EXPONENT_NUM_BYTES = ELGAMAL_FULL_EXPONENT_NUM_BITS/8;
 
@@ -631,8 +631,8 @@ namespace crypto
 	const uint64_t OPAD = 0x5C5C5C5C5C5C5C5C;
 
 
-	static const uint64_t ipads[] = { IPAD, IPAD, IPAD, IPAD };
-	static const uint64_t opads[] = { OPAD, OPAD, OPAD, OPAD };
+	static const uint64_t ipads[] __attribute__((unused)) = { IPAD, IPAD, IPAD, IPAD };
+	static const uint64_t opads[] __attribute__((unused)) = { OPAD, OPAD, OPAD, OPAD };
 
 	void HMACMD5Digest (uint8_t * msg, size_t len, const MACKey& key, uint8_t * digest)
 	// key is 32 bytes

--- a/libi2pd_client/SOCKS.cpp
+++ b/libi2pd_client/SOCKS.cpp
@@ -27,7 +27,7 @@ namespace proxy
 	static const size_t socks_buffer_size = 8192;
 	static const size_t max_socks_hostname_size = 255; // Limit for socks5 and bad idea to traverse
 
-	static const size_t SOCKS_FORWARDER_BUFFER_SIZE = 8192;
+	static const size_t SOCKS_FORWARDER_BUFFER_SIZE __attribute__((unused)) = 8192;
 
 	static const size_t SOCKS_UPSTREAM_SOCKS4A_REPLY_SIZE = 8;
 


### PR DESCRIPTION
Fixed the following warnings:
```
libi2pd/Blinding.cpp:138:16: warning: unused variable 'B33_PER_SECRET_FLAG' [-Wunused-const-variable]
        const uint8_t B33_PER_SECRET_FLAG = 0x02; // not used for now
                      ^
1 warning generated.
libi2pd/Crypto.cpp:163:12: warning: unused variable 'ELGAMAL_SHORT_EXPONENT_NUM_BYTES' [-Wunused-const-variable]
        const int ELGAMAL_SHORT_EXPONENT_NUM_BYTES = ELGAMAL_SHORT_EXPONENT_NUM_BITS/8+1;
                  ^
libi2pd/Crypto.cpp:634:24: warning: unused variable 'ipads' [-Wunused-const-variable]
        static const uint64_t ipads[] = { IPAD, IPAD, IPAD, IPAD };
                              ^
libi2pd/Crypto.cpp:635:24: warning: unused variable 'opads' [-Wunused-const-variable]
        static const uint64_t opads[] = { OPAD, OPAD, OPAD, OPAD };
                              ^
3 warnings generated.
libi2pd_client/SOCKS.cpp:30:22: warning: unused variable 'SOCKS_FORWARDER_BUFFER_SIZE' [-Wunused-const-variable]
        static const size_t SOCKS_FORWARDER_BUFFER_SIZE = 8192;
                            ^
1 warning generated.
daemon/HTTPServer.cpp:126:13: warning: unused variable 'HTTP_PARAM_SAM_SESSION_ID' [-Wunused-const-variable]
        const char HTTP_PARAM_SAM_SESSION_ID[] = "id";
                   ^
daemon/HTTPServer.cpp:127:13: warning: unused variable 'HTTP_PARAM_ADDRESS' [-Wunused-const-variable]
        const char HTTP_PARAM_ADDRESS[] = "address";
                   ^
2 warnings generated.
```