### PR TITLE
make floodfill enabled by default

### DIFF
--- a/contrib/i2pd.conf
+++ b/contrib/i2pd.conf
@@ -84,7 +84,7 @@ ipv6 = false
 # notransit = true
 
 ## Router will be floodfill
-# floodfill = true
+floodfill = true
 
 [http]
 ## Web Console settings


### PR DESCRIPTION
since it is year of 2021,most of devices run i2pd should have more than enough compute power to enable this feature,maybe we should consider enable it by default?