### PR TITLE
build c7 with boost 1.69.0

### DIFF
--- a/contrib/rpm/i2pd.spec
+++ b/contrib/rpm/i2pd.spec
@@ -10,14 +10,15 @@ Source0:       https://github.com/PurpleI2P/i2pd/archive/%{version}/%name-%versi
 
 %if 0%{?rhel} == 7
 BuildRequires: cmake3
+BuildRequires: boost169-devel
 %else
 BuildRequires: cmake
+BuildRequires: boost-devel
 %endif
 
 BuildRequires: chrpath
 BuildRequires: gcc-c++
 BuildRequires: zlib-devel
-BuildRequires: boost-devel
 BuildRequires: openssl-devel
 BuildRequires: miniupnpc-devel
 BuildRequires: systemd-units
@@ -37,6 +38,8 @@ C++ implementation of I2P.
 cd build
 %if 0%{?rhel} == 7
 %cmake3 \
+    -DBOOST_INCLUDEDIR=/usr/include/boost169 \
+    -DBOOST_LIBRARYDIR=/usr/lib64/boost169 \
     -DWITH_LIBRARY=OFF \
     -DWITH_UPNP=ON \
     -DWITH_HARDENING=ON \


### PR DESCRIPTION
build c7 with boost 1.69.0


errors with boost-devel-1.53.0-28.el7.x86_64:


```
[ 37%] Building CXX object CMakeFiles/libi2pd.dir/builddir/build/BUILD/i2pd-2.38.0/libi2pd/NetDb.cpp.o
/usr/bin/c++  -DBOOST_DATE_TIME_DYN_LINK -DBOOST_FILESYSTEM_DYN_LINK -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_REGEX_DYN_LINK -DBOOST_SYSTEM_DYN_LINK -DUSE_UPNP -D_FORTIFY_SOURCE=2 -D_GLIBCXX_USE_NANOSLEEP=1 -D__AES__ -I/builddir/build/BUILD/i2pd-2.38.0/build/../libi2pd -I/builddir/build/BUILD/i2pd-2.38.0/build/../libi2pd_client -I/builddir/build/BUILD/i2pd-2.38.0/build/../i18n -I/builddir/build/BUILD/i2pd-2.38.0/build/../daemon  -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches   -m64 -mtune=generic -Wall -Wextra -Winvalid-pch -Wno-unused-parameter -std=c++11 -pipe -Wformat -Wformat-security -Werror=format-security -fstack-protector --param ssp-buffer-size=4 -maes -pthread -fPIC   -o CMakeFiles/libi2pd.dir/builddir/build/BUILD/i2pd-2.38.0/libi2pd/NetDb.cpp.o -c /builddir/build/BUILD/i2pd-2.38.0/libi2pd/NetDb.cpp
/builddir/build/BUILD/i2pd-2.38.0/libi2pd/NTCP2.cpp: In member function 'void i2p::transport::NTCP2Server::Start()':
/builddir/build/BUILD/i2pd-2.38.0/libi2pd/NTCP2.cpp:1204:91: error: 'BOOST_ASIO_OS_DEF' was not declared in this scope
         typedef boost::asio::detail::socket_option::integer<BOOST_ASIO_OS_DEF(IPPROTO_IPV6), IPV6_ADDR_PREFERENCES> ipv6PreferAddr;
                                                                                           ^
/builddir/build/BUILD/i2pd-2.38.0/libi2pd/NTCP2.cpp:1204:115: error: template argument 1 is invalid
         typedef boost::asio::detail::socket_option::integer<BOOST_ASIO_OS_DEF(IPPROTO_IPV6), IPV6_ADDR_PREFERENCES> ipv6PreferAddr;
                                                                                                                   ^
/builddir/build/BUILD/i2pd-2.38.0/libi2pd/NTCP2.cpp:1204:131: error: invalid type in declaration before ';' token
         typedef boost::asio::detail::socket_option::integer<BOOST_ASIO_OS_DEF(IPPROTO_IPV6), IPV6_ADDR_PREFERENCES> ipv6PreferAddr;
                                                                                                                                   ^
In file included from /usr/include/boost/asio/datagram_socket_service.hpp:26:0,
                 from /usr/include/boost/asio/basic_datagram_socket.hpp:21,
                 from /usr/include/boost/asio.hpp:20,
                 from /builddir/build/BUILD/i2pd-2.38.0/libi2pd/RouterContext.h:17,
                 from /builddir/build/BUILD/i2pd-2.38.0/libi2pd/NTCP2.cpp:19:
/usr/include/boost/asio/detail/reactive_socket_service.hpp: In instantiation of 'boost::system::error_code boost::asio::detail::reactive_socket_service<Protocol>::set_option(boost::asio::detail::reactive_socket_service<Protocol>::implementation_type&, const Option&, boost::system::error_code&) [with Option = int; Protocol = boost::asio::ip::tcp]':
/usr/include/boost/asio/socket_acceptor_service.hpp:189:53:   required from 'boost::system::error_code boost::asio::socket_acceptor_service<Protocol>::set_option(boost::asio::socket_acceptor_service<Protocol>::implementation_type&, const SettableSocketOption&, boost::system::error_code&) [with SettableSocketOption = int; Protocol = boost::asio::ip::tcp; boost::asio::socket_acceptor_service<Protocol>::implementation_type = boost::asio::detail::reactive_socket_service<boost::asio::ip::tcp>::implementation_type]'
/usr/include/boost/asio/basic_socket_acceptor.hpp:521:5:   required from 'void boost::asio::basic_socket_acceptor<Protocol, SocketAcceptorService>::set_option(const SettableSocketOption&) [with SettableSocketOption = int; Protocol = boost::asio::ip::tcp; SocketAcceptorService = boost::asio::socket_acceptor_service<boost::asio::ip::tcp>]'
/builddir/build/BUILD/i2pd-2.38.0/libi2pd/NTCP2.cpp:1205:126:   required from here
/usr/include/boost/asio/detail/reactive_socket_service.hpp:143:69: error: request for member 'level' in 'option', which is of non-class type 'const int'
         option.data(impl.protocol_), option.size(impl.protocol_), ec);
                                                                     ^
/usr/include/boost/asio/detail/reactive_socket_service.hpp:143:69: error: request for member 'name' in 'option', which is of non-class type 'const int'
/usr/include/boost/asio/detail/reactive_socket_service.hpp:143:69: error: request for member 'data' in 'option', which is of non-class type 'const int'
/usr/include/boost/asio/detail/reactive_socket_service.hpp:143:69: error: request for member 'size' in 'option', which is of non-class type 'const int'
make[2]: *** [CMakeFiles/libi2pd.dir/builddir/build/BUILD/i2pd-2.38.0/libi2pd/NTCP2.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: Leaving directory `/builddir/build/BUILD/i2pd-2.38.0/build'
make[1]: *** [CMakeFiles/libi2pd.dir/all] Error 2
make[1]: Leaving directory `/builddir/build/BUILD/i2pd-2.38.0/build'
make: *** [all] Error 2
error: Bad exit status from /var/tmp/rpm-tmp.aeeBEK (%build)
````