### PR TITLE
libi2pd: mark additional ipv6 addresses/nets as reserved

### DIFF
--- a/libi2pd/util.cpp
+++ b/libi2pd/util.cpp
@@ -555,7 +555,10 @@ namespace net
 			static const std::vector< std::pair<boost::asio::ip::address_v6::bytes_type, boost::asio::ip::address_v6::bytes_type> > reservedIPv6Ranges {
 				address_pair_v6("2001:db8::", "2001:db8:ffff:ffff:ffff:ffff:ffff:ffff"),
 				address_pair_v6("fc00::",     "fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"),
-				address_pair_v6("fe80::",     "febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff")
+				address_pair_v6("fe80::",     "febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff"),
+				address_pair_v6("ff00::",     "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"),
+				address_pair_v6("::",         "::"),
+				address_pair_v6("::1",        "::1")
 			};
 
 			boost::asio::ip::address_v6::bytes_type ipv6_address = host.to_v6 ().to_bytes ();


### PR DESCRIPTION
This adds :: (undefined address), ::1 (loopback address) as well as
ff00::/8 (multicast prefix) to reservedIPv6Ranges.

A bunch of nodes seem to be publishing bogus addresses (mostly ::1)
in the netDB, resulting in unnecessary tunnel build failures.