### PR TITLE
[makefile] update rules to build libraries with correct linking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ netDb
 /libi2pd.so
 /libi2pdclient.so
 /libi2pdlang.so
+/libi2pd.dll
+/libi2pdclient.dll
+/libi2pdlang.dll
 *.exe
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,20 @@
 SYS := $(shell $(CXX) -dumpmachine)
 
 ifneq (, $(findstring darwin, $(SYS)))
-	SHARED_PREFIX = dylib
+	SHARED_SUFFIX = dylib
 else ifneq (, $(findstring mingw, $(SYS))$(findstring cygwin, $(SYS)))
-	SHARED_PREFIX = dll
+	SHARED_SUFFIX = dll
 else
-	SHARED_PREFIX = so
+	SHARED_SUFFIX = so
 endif
 
-SHLIB := libi2pd.$(SHARED_PREFIX)
+SHLIB := libi2pd.$(SHARED_SUFFIX)
 ARLIB := libi2pd.a
-SHLIB_LANG := libi2pdlang.$(SHARED_PREFIX)
+SHLIB_LANG := libi2pdlang.$(SHARED_SUFFIX)
 ARLIB_LANG := libi2pdlang.a
-SHLIB_CLIENT := libi2pdclient.$(SHARED_PREFIX)
+SHLIB_CLIENT := libi2pdclient.$(SHARED_SUFFIX)
 ARLIB_CLIENT := libi2pdclient.a
-SHLIB_WRAP := libi2pdwrapper.$(SHARED_PREFIX)
+SHLIB_WRAP := libi2pdwrapper.$(SHARED_SUFFIX)
 ARLIB_WRAP := libi2pdwrapper.a
 I2PD := i2pd
 

--- a/Makefile
+++ b/Makefile
@@ -73,19 +73,17 @@ LANG_OBJS       += $(patsubst %.cpp,obj/%.o,$(LANG_SRC))
 DAEMON_OBJS     += $(patsubst %.cpp,obj/%.o,$(DAEMON_SRC))
 DEPS            += $(LIB_OBJS:.o=.d) $(LIB_CLIENT_OBJS:.o=.d) $(LANG_OBJS:.o=.d) $(DAEMON_OBJS:.o=.d)
 
-## Build all code (libi2pd, libi2pdclient, libi2pdlang), link code to .a and .so (.dll on windows) and build binary
-## Windows binary is not depending on output dlls
-all: | api_client $(I2PD)
+## Build all code (libi2pd, libi2pdclient, libi2pdlang), link it to .a and build binary
+all: mk_obj_dir $(ARLIB) $(ARLIB_CLIENT) $(ARLIB_LANG) $(I2PD)
 
 mk_obj_dir:
 	@mkdir -p obj/{Win32,$(LIB_SRC_DIR),$(LIB_CLIENT_SRC_DIR),$(LANG_SRC_DIR),$(WRAP_SRC_DIR),$(DAEMON_SRC_DIR)}
 
-api: | mk_obj_dir $(SHLIB) $(ARLIB)
-client: | mk_obj_dir $(SHLIB_CLIENT) $(ARLIB_CLIENT)
-lang: | mk_obj_dir $(SHLIB_LANG) $(ARLIB_LANG)
-api_client: | api client lang
-wrapper: | mk_obj_dir api_client $(SHLIB_WRAP) $(ARLIB_WRAP)
-
+api: mk_obj_dir $(SHLIB) $(ARLIB)
+client: mk_obj_dir $(SHLIB_CLIENT) $(ARLIB_CLIENT)
+lang: mk_obj_dir $(SHLIB_LANG) $(ARLIB_LANG)
+api_client: api client lang
+wrapper: mk_obj_dir api_client $(SHLIB_WRAP) $(ARLIB_WRAP)
 
 ## NOTE: The NEEDED_CXXFLAGS are here so that CXXFLAGS can be specified at build time
 ## **without** overwriting the CXXFLAGS which we need in order to build.
@@ -138,7 +136,7 @@ $(ARLIB_LANG): $(LANG_OBJS)
 clean:
 	$(RM) -r obj
 	$(RM) -r docs/generated
-	$(RM) $(I2PD) $(SHLIB) $(ARLIB) $(SHLIB_CLIENT) $(ARLIB_CLIENT) $(SHLIB_LANG) $(ARLIB_LANG)
+	$(RM) $(I2PD) $(SHLIB) $(ARLIB) $(SHLIB_CLIENT) $(ARLIB_CLIENT) $(SHLIB_LANG) $(ARLIB_LANG) $(SHLIB_WRAP) $(ARLIB_WRAP)
 
 strip: $(I2PD) $(SHLIB) $(SHLIB_CLIENT) $(SHLIB_LANG)
 	strip $^

--- a/Makefile
+++ b/Makefile
@@ -68,22 +68,27 @@ NEEDED_CXXFLAGS += -MMD -MP -I$(LIB_SRC_DIR) -I$(LIB_CLIENT_SRC_DIR) -I$(LANG_SR
 
 LIB_OBJS        += $(patsubst %.cpp,obj/%.o,$(LIB_SRC))
 LIB_CLIENT_OBJS += $(patsubst %.cpp,obj/%.o,$(LIB_CLIENT_SRC))
-WRAP_LIB_OBJS   += $(patsubst %.cpp,obj/%.o,$(WRAP_LIB_SRC))
 LANG_OBJS       += $(patsubst %.cpp,obj/%.o,$(LANG_SRC))
 DAEMON_OBJS     += $(patsubst %.cpp,obj/%.o,$(DAEMON_SRC))
-DEPS            += $(LIB_OBJS:.o=.d) $(LIB_CLIENT_OBJS:.o=.d) $(LANG_OBJS:.o=.d) $(DAEMON_OBJS:.o=.d)
+WRAP_LIB_OBJS   += $(patsubst %.cpp,obj/%.o,$(WRAP_LIB_SRC))
+DEPS            += $(LIB_OBJS:.o=.d) $(LIB_CLIENT_OBJS:.o=.d) $(LANG_OBJS:.o=.d) $(DAEMON_OBJS:.o=.d) $(WRAP_LIB_OBJS:.o=.d)
 
 ## Build all code (libi2pd, libi2pdclient, libi2pdlang), link it to .a and build binary
-all: mk_obj_dir $(ARLIB) $(ARLIB_CLIENT) $(ARLIB_LANG) $(I2PD)
+all: $(ARLIB) $(ARLIB_CLIENT) $(ARLIB_LANG) $(I2PD)
 
 mk_obj_dir:
-	@mkdir -p obj/{Win32,$(LIB_SRC_DIR),$(LIB_CLIENT_SRC_DIR),$(LANG_SRC_DIR),$(WRAP_SRC_DIR),$(DAEMON_SRC_DIR)}
+	@mkdir -p obj/$(LIB_SRC_DIR)
+	@mkdir -p obj/$(LIB_CLIENT_SRC_DIR)
+	@mkdir -p obj/$(LANG_SRC_DIR)
+	@mkdir -p obj/$(DAEMON_SRC_DIR)
+	@mkdir -p obj/$(WRAP_SRC_DIR)
+	@mkdir -p obj/Win32
 
-api: mk_obj_dir $(SHLIB) $(ARLIB)
-client: mk_obj_dir $(SHLIB_CLIENT) $(ARLIB_CLIENT)
-lang: mk_obj_dir $(SHLIB_LANG) $(ARLIB_LANG)
+api: $(SHLIB) $(ARLIB)
+client: $(SHLIB_CLIENT) $(ARLIB_CLIENT)
+lang:  $(SHLIB_LANG) $(ARLIB_LANG)
 api_client: api client lang
-wrapper: mk_obj_dir api_client $(SHLIB_WRAP) $(ARLIB_WRAP)
+wrapper: api_client $(SHLIB_WRAP) $(ARLIB_WRAP)
 
 ## NOTE: The NEEDED_CXXFLAGS are here so that CXXFLAGS can be specified at build time
 ## **without** overwriting the CXXFLAGS which we need in order to build.
@@ -92,7 +97,7 @@ wrapper: mk_obj_dir api_client $(SHLIB_WRAP) $(ARLIB_WRAP)
 ## -std=c++11. If you want to remove this variable please do so in a way that allows setting
 ## custom FLAGS to work at build-time.
 
-obj/%.o: %.cpp
+obj/%.o: %.cpp | mk_obj_dir
 	$(CXX) $(CXXFLAGS) $(NEEDED_CXXFLAGS) $(INCFLAGS) -c -o $@ $<
 
 # '-' is 'ignore if missing' on first run
@@ -121,7 +126,7 @@ ifneq ($(USE_STATIC),yes)
 	$(CXX) $(LDFLAGS) -shared -o $@ $^ $(LDLIBS)
 endif
 
-$(ARLIB): $(LIB_OBJS) 
+$(ARLIB): $(LIB_OBJS)
 	$(AR) -r $@ $^
 
 $(ARLIB_CLIENT): $(LIB_CLIENT_OBJS)

--- a/Makefile.mingw
+++ b/Makefile.mingw
@@ -3,9 +3,9 @@ USE_WIN32_APP := yes
 
 WINDRES = windres
 
-CXXFLAGS := $(CXX_DEBUG) -D_MT -DWIN32_LEAN_AND_MEAN -fPIC -msse
+CXXFLAGS := $(CXX_DEBUG) -DWIN32_LEAN_AND_MEAN -fPIC -msse
 INCFLAGS = -I$(DAEMON_SRC_DIR) -IWin32
-LDFLAGS := ${LD_DEBUG} -Wl,-Bstatic -static-libgcc
+LDFLAGS := ${LD_DEBUG} -static
 
 # detect proper flag for c++11 support by compilers
 CXXVER := $(shell $(CXX) -dumpversion)

--- a/build/.gitignore
+++ b/build/.gitignore
@@ -3,6 +3,7 @@
 /i2pd
 /libi2pd.a
 /libi2pdclient.a
+/libi2pdlang.a
 /cmake_install.cmake
 /CMakeCache.txt
 /CPackConfig.cmake


### PR DESCRIPTION
Should we build .so libraries (libi2pd, libi2pdclient, libi2pdlang) on default target in make?

Binary itself wouldn't depend on them.

Also work on race condition with making objects directory needed.

EDIT (06/08):
Discussion result: don't build .so/.dll at default build action (without any targets defined, like `api_client`).
