### PR TITLE
memory leak and concurrency fixes

### DIFF
--- a/libi2pd/Tunnel.h
+++ b/libi2pd/Tunnel.h
@@ -68,7 +68,7 @@ namespace tunnel
 		public:
 
 			Tunnel (std::shared_ptr<const TunnelConfig> config);
-			~Tunnel ();
+			virtual ~Tunnel ();
 
 			void Build (uint32_t replyMsgID, std::shared_ptr<OutboundTunnel> outboundTunnel = nullptr);
 

--- a/libi2pd/Tunnel.h
+++ b/libi2pd/Tunnel.h
@@ -254,12 +254,18 @@ namespace tunnel
 			bool m_IsRunning;
 			std::thread * m_Thread;
 			std::map<uint32_t, std::shared_ptr<InboundTunnel> > m_PendingInboundTunnels; // by replyMsgID
+			mutable std::mutex m_PendingInboundTunnelsMutex;
 			std::map<uint32_t, std::shared_ptr<OutboundTunnel> > m_PendingOutboundTunnels; // by replyMsgID
+			mutable std::mutex m_PendingOutboundTunnelsMutex;
 			std::list<std::shared_ptr<InboundTunnel> > m_InboundTunnels;
+			mutable std::recursive_mutex m_InboundTunnelsMutex;
 			std::list<std::shared_ptr<OutboundTunnel> > m_OutboundTunnels;
+			mutable std::recursive_mutex m_OutboundTunnelsMutex;
 			std::list<std::shared_ptr<TransitTunnel> > m_TransitTunnels;
+			mutable std::mutex m_TransitTunnelsMutex;
 			std::unordered_map<uint32_t, std::shared_ptr<TunnelBase> > m_Tunnels; // tunnelID->tunnel known by this id
-			std::mutex m_PoolsMutex;
+			mutable std::recursive_mutex m_TunnelsMutex;
+			mutable std::mutex m_PoolsMutex;
 			std::list<std::shared_ptr<TunnelPool>> m_Pools;
 			std::shared_ptr<TunnelPool> m_ExploratoryPool;
 			i2p::util::Queue<std::shared_ptr<I2NPMessage> > m_Queue;

--- a/libi2pd/TunnelConfig.h
+++ b/libi2pd/TunnelConfig.h
@@ -99,7 +99,7 @@ namespace tunnel
 				m_LastHop->SetReplyHop (replyTunnelID, replyIdent);
 			}
 
-			~TunnelConfig ()
+			virtual ~TunnelConfig ()
 			{
 				TunnelHopConfig * hop = m_FirstHop;
 

--- a/libi2pd/TunnelPool.h
+++ b/libi2pd/TunnelPool.h
@@ -64,8 +64,8 @@ namespace tunnel
 			TunnelPool (int numInboundHops, int numOutboundHops, int numInboundTunnels, int numOutboundTunnels);
 			~TunnelPool ();
 
-			std::shared_ptr<i2p::garlic::GarlicDestination> GetLocalDestination () const { return m_LocalDestination; };
-			void SetLocalDestination (std::shared_ptr<i2p::garlic::GarlicDestination> destination) { m_LocalDestination = destination; };
+			std::shared_ptr<i2p::garlic::GarlicDestination> GetLocalDestination () const;
+			void SetLocalDestination (std::shared_ptr<i2p::garlic::GarlicDestination> destination);
 			void SetExplicitPeers (std::shared_ptr<std::vector<i2p::data::IdentHash> > explicitPeers);
 
 			void CreateTunnels ();
@@ -126,8 +126,10 @@ namespace tunnel
 
 		private:
 
+			mutable std::mutex m_LocalDestinationMutex;
 			std::shared_ptr<i2p::garlic::GarlicDestination> m_LocalDestination;
 			int m_NumInboundHops, m_NumOutboundHops, m_NumInboundTunnels, m_NumOutboundTunnels;
+			mutable std::mutex m_ExplicitPeersMutex;
 			std::shared_ptr<std::vector<i2p::data::IdentHash> > m_ExplicitPeers;
 			mutable std::mutex m_InboundTunnelsMutex;
 			std::set<std::shared_ptr<InboundTunnel>, TunnelCreationTimeCmp> m_InboundTunnels; // recent tunnel appears first


### PR DESCRIPTION
This fixes a few memory leaks (destructors not being virtual) and concurrency issues (missing locks) in Tunnel, TunnelPool and TunnelConfig classes.