### PR TITLE
Removes workaround for passing string arguments from Go

### DIFF
--- a/libi2pd_wrapper/api.go
+++ b/libi2pd_wrapper/api.go
@@ -6,10 +6,10 @@ package api
 * This file is part of Purple i2pd project and licensed under BSD3
 *
 * See full license text in LICENSE file at top of project tree
-*/
+ */
 
 /*
 #cgo CXXFLAGS: -I${SRCDIR}/../i18n -I${SRCDIR}/../libi2pd_client -I${SRCDIR}/../libi2pd -g -Wall -Wextra -Wno-unused-parameter -pedantic -Wno-psabi -fPIC -D__AES__ -maes
-#cgo LDFLAGS: -L${SRCDIR}/../ -l:libi2pd.a -l:libi2pdlang.a -latomic -lcrypto -lssl -lz -lboost_system -lboost_date_time -lboost_filesystem -lboost_program_options -lpthread -lstdc++
+#cgo LDFLAGS: -L${SRCDIR}/ -l:../libi2pdwrapper.a -l:../libi2pd.a -l:../libi2pdlang.a -latomic -lcrypto -lssl -lz -lboost_system -lboost_date_time -lboost_filesystem -lboost_program_options -lpthread -lstdc++
 */
 import "C"

--- a/libi2pd_wrapper/capi.cpp
+++ b/libi2pd_wrapper/capi.cpp
@@ -6,7 +6,7 @@
 * See full license text in LICENSE file at top of project tree
 */
 
-#include "api.h"
+#include "../libi2pd/api.h"
 #include "capi.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -14,70 +14,14 @@
 #include <assert.h>
 
 
-// Uses the example from: https://stackoverflow.com/a/9210560
-// See also https://stackoverflow.com/questions/9210528/split-string-with-delimiters-in-c/9210560#
-// Does not handle consecutive delimiters, this is only for passing
-// lists of arguments by value to InitI2P from C_InitI2P
-char** str_split(char* a_str, const char a_delim)
-{
-    char** result    = 0;
-    size_t count     = 0;
-    char* tmp        = a_str;
-    char* last_comma = 0;
-    char delim[2];
-    delim[0] = a_delim;
-    delim[1] = 0;
-
-    /* Count how many elements will be extracted. */
-    while (*tmp)
-    {
-        if (a_delim == *tmp)
-        {
-            count++;
-            last_comma = tmp;
-        }
-        tmp++;
-    }
-
-    /* Add space for trailing token. */
-    count += last_comma < (a_str + strlen(a_str) - 1);
-
-    /* Add space for terminating null string so caller
-       knows where the list of returned strings ends. */
-    count++;
-
-    result = (char**) malloc(sizeof(char*) * count);
-
-    if (result)
-    {
-        size_t idx  = 0;
-        char* token = strtok(a_str, delim);
-
-        while (token)
-        {
-            assert(idx < count);
-            *(result + idx++) = strdup(token);
-            token = strtok(0, delim);
-        }
-        assert(idx == count - 1);
-        *(result + idx) = 0;
-    }
-
-    return result;
-}
-
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void C_InitI2P (int argc, char argv[], const char * appName)
+void C_InitI2P (int argc, char *argv[], const char * appName)
 {
-	const char* delim = " ";
-	char* vargs = strdup(argv);
-	char** args = str_split(vargs, *delim);
 	std::cout << argv;
-	return i2p::api::InitI2P(argc, args, appName);
+	return i2p::api::InitI2P(argc, argv, appName);
 }
 
 void C_TerminateI2P ()

--- a/libi2pd_wrapper/capi.h
+++ b/libi2pd_wrapper/capi.h
@@ -14,7 +14,7 @@ extern "C" {
 #endif
 
 // initialization start and stop
-void C_InitI2P (int argc, char argv[], const char * appName);
+void C_InitI2P (int argc, char *argv[], const char * appName);
 //void C_InitI2P (int argc, char** argv, const char * appName);
 void C_TerminateI2P ();
 void C_StartI2P ();


### PR DESCRIPTION
This PR removes some unnecessary elements from the SWIG binding and moves them to the correct place on the non-C++ side. It was only necessary for Go, and it is no longer necessary there anymore and so it should be safe to remove. Removing it will also make the binding more straightforward to use for languages other than Go.