### PR TITLE
Do not show 'Address registration' line if leaseset is encrypted

### DIFF
--- a/daemon/HTTPServer.cpp
+++ b/daemon/HTTPServer.cpp
@@ -419,7 +419,7 @@ namespace http {
 			s << "</div>\r\n</div>\r\n";
 		}
 
-		if (dest->IsPublic() && token)
+		if (dest->IsPublic() && token && !dest->IsEncryptedLeaseSet ())
 		{
 			std::string webroot; i2p::config::GetOption("http.webroot", webroot);
 			auto base32 = dest->GetIdentHash ().ToBase32 ();


### PR DESCRIPTION
Если к адресу типа bb32 нельзя привязать короткий домен в зоне «i2p», то нет смысла это предлагать.