### PR TITLE
Fix definitions for Darwin PPC; do not use pthread_setname_np on unsupported OS versions

### DIFF
--- a/build/cmake_modules/TargetArch.cmake
+++ b/build/cmake_modules/TargetArch.cmake
@@ -61,7 +61,7 @@ set(archdetect_c_code "
     #else
         #error cmake_ARCH mips
     #endif
-#elif defined(__ppc__) || defined(__ppc) || defined(__powerpc__) \\
+#elif defined(__ppc__) || defined(__ppc) || defined(__powerpc__) || defined(__POWERPC__) \\
       || defined(_ARCH_COM) || defined(_ARCH_PWR) || defined(_ARCH_PPC)  \\
       || defined(_M_MPPC) || defined(_M_PPC)
     #if defined(__ppc64__) || defined(__powerpc64__) || defined(__64BIT__)

--- a/libi2pd/util.cpp
+++ b/libi2pd/util.cpp
@@ -22,6 +22,9 @@
 #include <pthread_np.h>
 #endif
 
+#if defined(__APPLE__)
+# include <AvailabilityMacros.h>
+#endif
 
 #ifdef _WIN32
 #include <stdlib.h>
@@ -143,8 +146,15 @@ namespace util
 	}
 
 	void SetThreadName (const char *name) {
-#if defined(__APPLE__) && !defined(__POWERPC__)
+#if defined(__APPLE__)
+# if (!defined(MAC_OS_X_VERSION_10_6) || \
+		(MAC_OS_X_VERSION_MAX_ALLOWED < 1060) || \
+		defined(__POWERPC__))
+		/* pthread_setname_np is not there on <10.6 and all PPC.
+		So do nothing. */
+# else
 		pthread_setname_np((char*)name);
+# endif
 #elif defined(__FreeBSD__) || defined(__OpenBSD__)
 		pthread_set_name_np(pthread_self(), name);
 #elif defined(__NetBSD__)

--- a/libi2pd/util.cpp
+++ b/libi2pd/util.cpp
@@ -143,7 +143,7 @@ namespace util
 	}
 
 	void SetThreadName (const char *name) {
-#if defined(__APPLE__) && !defined(__powerpc__)
+#if defined(__APPLE__) && !defined(__POWERPC__)
 		pthread_setname_np((char*)name);
 #elif defined(__FreeBSD__) || defined(__OpenBSD__)
 		pthread_set_name_np(pthread_self(), name);


### PR DESCRIPTION
Darwin PPC has a define for both ppc and ppc64 which is `__POWERPC__`. Currently used one fails to apply and does nothing.

P. S. This is a necessary fix, however not sufficient. With correct defines in place, code in `util.cpp` uses a fallback, and build fails: https://github.com/PurpleI2P/i2pd/issues/1726#issuecomment-1296342335

@r4sas I will look for a suitable solution, we have this missing `pthread_*` problem recurring with multiple ports.