### PR TITLE
Add implementation of tests with CMake, plus a few minor fixes

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -20,12 +20,17 @@ option(WITH_UPNP            "Include support for UPnP client"         OFF)
 option(WITH_GIT_VERSION     "Use git commit info as version"          OFF)
 option(WITH_ADDRSANITIZER   "Build with address sanitizer unix only"  OFF)
 option(WITH_THREADSANITIZER "Build with thread sanitizer unix only"   OFF)
+option(BUILD_TESTING        "Build tests"                             OFF)
+
+IF(BUILD_TESTING)
+  enable_testing()
+ENDIF()
 
 # paths
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules")
 set(CMAKE_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/..")
 
-#Handle paths nicely
+# Handle paths nicely
 include(GNUInstallDirs)
 
 # architecture
@@ -275,9 +280,13 @@ if(WITH_BINARY)
     set(DL_LIB ${CMAKE_DL_LIBS})
   endif()
 
-  target_link_libraries("${PROJECT_NAME}" libi2pd libi2pdclient libi2pdlang ${DL_LIB} ${Boost_LIBRARIES} OpenSSL::SSL OpenSSL::Crypto ${MINIUPNPC_LIBRARY} ZLIB::ZLIB Threads::Threads ${DL_LIB} ${CMAKE_REQUIRED_LIBRARIES})
+  target_link_libraries("${PROJECT_NAME}" libi2pd libi2pdclient libi2pdlang ${Boost_LIBRARIES} OpenSSL::SSL OpenSSL::Crypto ${MINIUPNPC_LIBRARY} ZLIB::ZLIB Threads::Threads ${DL_LIB} ${CMAKE_REQUIRED_LIBRARIES})
 
   install(TARGETS "${PROJECT_NAME}" RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT Runtime)
   set(APPS "\${CMAKE_INSTALL_PREFIX}/bin/${PROJECT_NAME}${CMAKE_EXECUTABLE_SUFFIX}")
   set(DIRS "${Boost_LIBRARY_DIR};${OPENSSL_INCLUDE_DIR}/../bin;${ZLIB_INCLUDE_DIR}/../bin;/mingw32/bin")
+endif()
+
+if(BUILD_TESTING)
+  add_subdirectory(${CMAKE_SOURCE_DIR}/tests ${CMAKE_CURRENT_BINARY_DIR}/tests)
 endif()

--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -176,13 +176,11 @@ if(WITH_THREADSANITIZER)
   endif()
 endif()
 
-
-# Enable usage of STD's Atomic instead of Boost's on PowerPC
-# For more information refer to https://github.com/PurpleI2P/i2pd/issues/1726#issuecomment-1306335111
-if(ARCHITECTURE MATCHES "ppc")
+# Use std::atomic instead of GCC builtins on macOS PowerPC:
+# For more information refer to: https://github.com/PurpleI2P/i2pd/issues/1726#issuecomment-1306335111
+if(APPLE AND CMAKE_OSX_ARCHITECTURES MATCHES "ppc")
   add_definitions(-DBOOST_SP_USE_STD_ATOMIC)
 endif()
-
 
 # libraries
 set(THREADS_PREFER_PTHREAD_FLAG ON)

--- a/build/cmake_modules/FindCheck.cmake
+++ b/build/cmake_modules/FindCheck.cmake
@@ -1,0 +1,55 @@
+# - Try to find the CHECK libraries
+#  Once done this will define
+#
+#  CHECK_FOUND - system has check
+#  CHECK_INCLUDE_DIRS - the check include directory
+#  CHECK_LIBRARIES - check library
+#
+#  Copyright (c) 2007 Daniel Gollub <gollub@b1-systems.de>
+#  Copyright (c) 2007-2009 Bjoern Ricks  <bjoern.ricks@gmail.com>
+#
+#  Redistribution and use is allowed according to the terms of the New
+#  BSD license.
+#  For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+
+
+INCLUDE( FindPkgConfig )
+
+IF ( Check_FIND_REQUIRED )
+	SET( _pkgconfig_REQUIRED "REQUIRED" )
+ELSE( Check_FIND_REQUIRED )
+	SET( _pkgconfig_REQUIRED "" )
+ENDIF ( Check_FIND_REQUIRED )
+
+IF ( CHECK_MIN_VERSION )
+	PKG_SEARCH_MODULE( CHECK ${_pkgconfig_REQUIRED} check>=${CHECK_MIN_VERSION} )
+ELSE ( CHECK_MIN_VERSION )
+	PKG_SEARCH_MODULE( CHECK ${_pkgconfig_REQUIRED} check )
+ENDIF ( CHECK_MIN_VERSION )
+
+# Look for CHECK include dir and libraries
+IF( NOT CHECK_FOUND AND NOT PKG_CONFIG_FOUND )
+
+	FIND_PATH( CHECK_INCLUDE_DIRS check.h )
+
+	FIND_LIBRARY( CHECK_LIBRARIES NAMES check )
+
+	IF ( CHECK_INCLUDE_DIRS AND CHECK_LIBRARIES )
+		SET( CHECK_FOUND 1 )
+		IF ( NOT Check_FIND_QUIETLY )
+			MESSAGE ( STATUS "Found CHECK: ${CHECK_LIBRARIES}" )
+		ENDIF ( NOT Check_FIND_QUIETLY )
+	ELSE ( CHECK_INCLUDE_DIRS AND CHECK_LIBRARIES )
+		IF ( Check_FIND_REQUIRED )
+			MESSAGE( FATAL_ERROR "Could NOT find CHECK" )
+		ELSE ( Check_FIND_REQUIRED )
+			IF ( NOT Check_FIND_QUIETLY )
+				MESSAGE( STATUS "Could NOT find CHECK" )
+			ENDIF ( NOT Check_FIND_QUIETLY )
+		ENDIF ( Check_FIND_REQUIRED )
+	ENDIF ( CHECK_INCLUDE_DIRS AND CHECK_LIBRARIES )
+ENDIF( NOT CHECK_FOUND AND NOT PKG_CONFIG_FOUND )
+
+# Hide advanced variables from CMake GUIs
+MARK_AS_ADVANCED( CHECK_INCLUDE_DIRS CHECK_LIBRARIES )
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,138 @@
+enable_testing()
+find_package(Check 0.9.10 REQUIRED)
+include_directories(${CHECK_INCLUDE_DIRS})
+
+# Compiler flags:
+if(APPLE)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-unused-parameter -Wextra -pedantic -O0 -g -Wl,-undefined,dynamic_lookup")
+else()
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-unused-parameter -Wextra -pedantic -O0 -g -D_GLIBCXX_USE_NANOSLEEP=1 -Wl,--unresolved-symbols=ignore-in-object-files")
+endif()
+
+set(TEST_PATH ${CMAKE_CURRENT_BINARY_DIR})
+
+include_directories(
+  ../libi2pd
+  ${Boost_INCLUDE_DIRS}
+  ${OPENSSL_INCLUDE_DIR}
+)
+
+set(test-http-merge_chunked_SRCS
+  ../libi2pd/HTTP.cpp
+  test-http-merge_chunked.cpp
+)
+
+set(test-http-req_SRCS
+  ../libi2pd/HTTP.cpp
+  test-http-req.cpp
+)
+
+set(test-http-res_SRCS
+  ../libi2pd/HTTP.cpp
+  test-http-res.cpp
+)
+
+set(test-http-url_decode_SRCS
+  ../libi2pd/HTTP.cpp
+  test-http-url_decode.cpp
+)
+
+set(test-http-url_SRCS
+  ../libi2pd/HTTP.cpp
+  test-http-url.cpp
+)
+
+set(test-base-64_SRCS
+  ../libi2pd/Base.cpp
+  test-base-64.cpp
+)
+
+set(test-gost_SRCS
+  ../libi2pd/Gost.cpp
+  ../libi2pd/I2PEndian.cpp
+  test-gost.cpp
+)
+
+set(test-gost-sig_SRCS
+  ../libi2pd/Gost.cpp
+  ../libi2pd/I2PEndian.cpp
+  ../libi2pd/Crypto.cpp
+  ../libi2pd/Log.cpp
+  test-gost-sig.cpp
+)
+
+set(test-x25519_SRCS
+  ../libi2pd/Ed25519.cpp
+  ../libi2pd/I2PEndian.cpp
+  ../libi2pd/Log.cpp
+  ../libi2pd/Crypto.cpp
+  test-x25519.cpp
+)
+
+set(test-aeadchacha20poly1305_SRCS
+  ../libi2pd/Crypto.cpp
+  ../libi2pd/ChaCha20.cpp
+  ../libi2pd/Poly1305.cpp
+  test-aeadchacha20poly1305.cpp
+)
+
+set(test-blinding_SRCS
+  ../libi2pd/Crypto.cpp
+  ../libi2pd/Blinding.cpp
+  ../libi2pd/Ed25519.cpp
+  ../libi2pd/I2PEndian.cpp
+  ../libi2pd/Log.cpp
+  ../libi2pd/util.cpp
+  ../libi2pd/Identity.cpp
+  ../libi2pd/Signature.cpp
+  ../libi2pd/Timestamp.cpp
+  test-blinding.cpp
+)
+
+SET(test-elligator_SRCS
+  ../libi2pd/Elligator.cpp
+  ../libi2pd/Crypto.cpp
+  test-elligator.cpp
+)
+
+add_executable(test-http-merge_chunked ${test-http-merge_chunked_SRCS})
+add_executable(test-http-req ${test-http-req_SRCS})
+add_executable(test-http-res ${test-http-res_SRCS})
+add_executable(test-http-url_decode ${test-http-url_decode_SRCS})
+add_executable(test-http-url ${test-http-url_SRCS})
+add_executable(test-base-64 ${test-base-64_SRCS})
+add_executable(test-gost ${test-gost_SRCS})
+add_executable(test-gost-sig ${test-gost-sig_SRCS})
+add_executable(test-x25519 ${test-x25519_SRCS})
+add_executable(test-aeadchacha20poly1305 ${test-aeadchacha20poly1305_SRCS})
+add_executable(test-blinding ${test-blinding_SRCS})
+add_executable(test-elligator ${test-elligator_SRCS})
+
+set(LIBS
+  ${Boost_LIBRARIES}
+  ${CHECK_LDFLAGS}
+  ${CMAKE_REQUIRED_LIBRARIES}
+  OpenSSL::SSL
+  OpenSSL::Crypto
+  Threads::Threads
+)
+
+target_link_libraries(test-gost OpenSSL::Crypto Threads::Threads)
+target_link_libraries(test-gost-sig ${LIBS})
+target_link_libraries(test-x25519 ${LIBS})
+target_link_libraries(test-aeadchacha20poly1305 ${LIBS})
+target_link_libraries(test-blinding ${LIBS})
+target_link_libraries(test-elligator ${LIBS})
+
+add_test(test-http-merge_chunked ${TEST_PATH}/test-http-merge_chunked)
+add_test(test-http-req ${TEST_PATH}/test-http-req)
+add_test(test-http-res ${TEST_PATH}/test-http-res)
+add_test(test-http-url_decode ${TEST_PATH}/test-http-url_decode)
+add_test(test-http-url ${TEST_PATH}/test-http-url)
+add_test(test-base-64 ${TEST_PATH}/test-base-64)
+add_test(test-gost ${TEST_PATH}/test-gost)
+add_test(test-gost-sig ${TEST_PATH}/test-gost-sig)
+add_test(test-x25519 ${TEST_PATH}/test-x25519)
+add_test(test-aeadchacha20poly1305 ${TEST_PATH}/test-aeadchacha20poly1305)
+add_test(test-blinding ${TEST_PATH}/test-blinding)
+add_test(test-elligator ${TEST_PATH}/test-elligator)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -17,7 +17,7 @@ test-gost: ../libi2pd/Gost.cpp ../libi2pd/I2PEndian.cpp test-gost.cpp
 test-gost-sig: ../libi2pd/Gost.cpp ../libi2pd/I2PEndian.cpp ../libi2pd/Crypto.cpp ../libi2pd/Log.cpp test-gost-sig.cpp
 	$(CXX) $(CXXFLAGS) $(NEEDED_CXXFLAGS) $(INCFLAGS) -o $@ $^ -lcrypto -lssl -lboost_system
 
-test-x25519: ../libi2pd/Ed25519.cpp ../libi2pd/I2PEndian.cpp ../libi2pd/Log.cpp ../libi2pd/Crypto.cpp  test-x25519.cpp
+test-x25519: ../libi2pd/Ed25519.cpp ../libi2pd/I2PEndian.cpp ../libi2pd/Log.cpp ../libi2pd/Crypto.cpp test-x25519.cpp
 	$(CXX) $(CXXFLAGS) $(NEEDED_CXXFLAGS) $(INCFLAGS) -o $@ $^ -lcrypto -lssl -lboost_system
 
 test-aeadchacha20poly1305: ../libi2pd/Crypto.cpp ../libi2pd/ChaCha20.cpp ../libi2pd/Poly1305.cpp test-aeadchacha20poly1305.cpp

--- a/tests/test-http-merge_chunked.cpp
+++ b/tests/test-http-merge_chunked.cpp
@@ -1,5 +1,5 @@
 #include <cassert>
-#include "../HTTP.h"
+#include "HTTP.h"
 
 using namespace i2p::http;
 

--- a/tests/test-http-req.cpp
+++ b/tests/test-http-req.cpp
@@ -1,5 +1,5 @@
 #include <cassert>
-#include "../HTTP.h"
+#include "HTTP.h"
 
 using namespace i2p::http;
 

--- a/tests/test-http-res.cpp
+++ b/tests/test-http-res.cpp
@@ -1,5 +1,5 @@
 #include <cassert>
-#include "../HTTP.h"
+#include "HTTP.h"
 
 using namespace i2p::http;
 

--- a/tests/test-http-url.cpp
+++ b/tests/test-http-url.cpp
@@ -1,5 +1,5 @@
 #include <cassert>
-#include "../HTTP.h"
+#include "HTTP.h"
 
 using namespace i2p::http;
 

--- a/tests/test-http-url_decode.cpp
+++ b/tests/test-http-url_decode.cpp
@@ -1,5 +1,5 @@
 #include <cassert>
-#include "../HTTP.h"
+#include "HTTP.h"
 
 using namespace i2p::http;
 


### PR DESCRIPTION
@r4sas @orignal The issue re broken atomics when using GCC builtin is specific to Darwin PPC, not any PPC (size of bool is defined by ABI, not by arch). Therefore, let’s use the flag only where it is actually needed (until a fix to Boost is backported from develop to versions currently in use).

Tests build fine now.

On 10.6 PPC all tests pass but one, `test-blinding`. It fails with SIGTRAP, apparently being unable to dynamically link `__ZN3i2p6config9m_OptionsE` symbol. Not sure why – any suggestions are welcome.