### PR TITLE
Remove "X-Requested-With"

### DIFF
--- a/libi2pd_client/HTTPProxy.cpp
+++ b/libi2pd_client/HTTPProxy.cpp
@@ -252,6 +252,7 @@ namespace proxy {
 		req.RemoveHeader("From");
 		req.RemoveHeader("Forwarded");
 		req.RemoveHeader("DNT"); // Useless DoNotTrack flag
+		req.RemoveHeader("X-Requested-With"); // Android Webview send this with the value set to the application ID
 		req.RemoveHeader("Accept", "Accept-Encoding"); // Accept*, but Accept-Encoding
 		/* drop proxy-disclosing headers */
 		req.RemoveHeader("X-Forwarded");


### PR DESCRIPTION
When any app uses Android’s WebView to load a web page, WebView attaches an extra header, named X-Requested-With, with the value set to the application ID.  That include Lightning-I2P browser by R4SAS and any browser based on Android Webview. 
Google doesn’t want to make it easy to get rid of the X-Requested-With header. However, there is a mechanism for replacing header information but anyway doesn’t allow a program to stop sending the X-Requested-With header.

More info on: https://www.stoutner.com/the-x-requested-with-header/