### PR TITLE
Fix CheckAtomic.cmake

### DIFF
--- a/build/cmake_modules/CheckAtomic.cmake
+++ b/build/cmake_modules/CheckAtomic.cmake
@@ -1,18 +1,23 @@
 # atomic builtins are required for threading support.
 
 INCLUDE(CheckCXXSourceCompiles)
+INCLUDE(CheckLibraryExists)
 
 # Sometimes linking against libatomic is required for atomic ops, if
 # the platform doesn't support lock-free atomics.
 
 function(check_working_cxx_atomics varname)
   set(OLD_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
-  set(CMAKE_REQUIRED_FLAGS "-std=c++11")
+  set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -std=c++11")
   CHECK_CXX_SOURCE_COMPILES("
 #include <atomic>
 std::atomic<int> x;
+std::atomic<short> y;
+std::atomic<char> z;
 int main() {
-  return x;
+  ++z;
+  ++y;
+  return ++x;
 }
 " ${varname})
   set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})
@@ -27,6 +32,7 @@ function(check_working_cxx_atomics64 varname)
 std::atomic<uint64_t> x (0);
 int main() {
   uint64_t i = x.load(std::memory_order_relaxed);
+  (void)i;
   return 0;
 }
 " ${varname})
@@ -34,15 +40,16 @@ int main() {
 endfunction(check_working_cxx_atomics64)
 
 
-# This isn't necessary on MSVC, so avoid command-line switch annoyance
-# by only running on GCC-like hosts.
-if (LLVM_COMPILER_IS_GCC_COMPATIBLE)
+# Check for (non-64-bit) atomic operations.
+if(MSVC)
+  set(HAVE_CXX_ATOMICS_WITHOUT_LIB True)
+else()
   # First check if atomics work without the library.
   check_working_cxx_atomics(HAVE_CXX_ATOMICS_WITHOUT_LIB)
   # If not, check if the library exists, and atomics work with it.
   if(NOT HAVE_CXX_ATOMICS_WITHOUT_LIB)
     check_library_exists(atomic __atomic_fetch_add_4 "" HAVE_LIBATOMIC)
-    if( HAVE_LIBATOMIC )
+    if(HAVE_LIBATOMIC)
       list(APPEND CMAKE_REQUIRED_LIBRARIES "atomic")
       check_working_cxx_atomics(HAVE_CXX_ATOMICS_WITH_LIB)
       if (NOT HAVE_CXX_ATOMICS_WITH_LIB)
@@ -58,20 +65,20 @@ endif()
 if(MSVC)
   set(HAVE_CXX_ATOMICS64_WITHOUT_LIB True)
 else()
+  # First check if atomics work without the library.
   check_working_cxx_atomics64(HAVE_CXX_ATOMICS64_WITHOUT_LIB)
-endif()
-
-# If not, check if the library exists, and atomics work with it.
-if(NOT HAVE_CXX_ATOMICS64_WITHOUT_LIB)
-  check_library_exists(atomic __atomic_load_8 "" HAVE_CXX_LIBATOMICS64)
-  if(HAVE_CXX_LIBATOMICS64)
-    list(APPEND CMAKE_REQUIRED_LIBRARIES "atomic")
-    check_working_cxx_atomics64(HAVE_CXX_ATOMICS64_WITH_LIB)
-    if (NOT HAVE_CXX_ATOMICS64_WITH_LIB)
-      message(FATAL_ERROR "Host compiler must support std::atomic!")
+  # If not, check if the library exists, and atomics work with it.
+  if(NOT HAVE_CXX_ATOMICS64_WITHOUT_LIB)
+    check_library_exists(atomic __atomic_load_8 "" HAVE_CXX_LIBATOMICS64)
+    if(HAVE_CXX_LIBATOMICS64)
+      list(APPEND CMAKE_REQUIRED_LIBRARIES "atomic")
+      check_working_cxx_atomics64(HAVE_CXX_ATOMICS64_WITH_LIB)
+      if (NOT HAVE_CXX_ATOMICS64_WITH_LIB)
+        message(FATAL_ERROR "Host compiler must support 64-bit std::atomic!")
+      endif()
+    else()
+      message(FATAL_ERROR "Host compiler appears to require libatomic for 64-bit operations, but cannot find it.")
     endif()
-  else()
-    message(FATAL_ERROR "Host compiler appears to require libatomic, but cannot find it.")
   endif()
 endif()
 
@@ -80,7 +87,6 @@ endif()
 ## assumes C++11 <atomic> works.
 CHECK_CXX_SOURCE_COMPILES("
 #ifdef _MSC_VER
-#include <Intrin.h> /* Workaround for PR19898. */
 #include <windows.h>
 #endif
 int main() {


### PR DESCRIPTION
This replaces the outdated LLVM CheckAtomic.cmake with [the new one](https://github.com/llvm/llvm-project/blob/main/llvm/cmake/modules/CheckAtomic.cmake). Old CheckAtomic had false positives on RISC-V, where atomics of smaller sizes does not exist while larger ones do, which is fixed in a [commit](https://github.com/llvm/llvm-project/commit/cef85193b2cc1817ca43199a0ae9c6f25723997d).

This fixes build on riscv64 when testing on my QEMU machine.