### PR TITLE
Использование скользящего среднего для рассчета tunnel creation success rate

### DIFF
--- a/libi2pd/Tunnel.cpp
+++ b/libi2pd/Tunnel.cpp
@@ -332,8 +332,7 @@ namespace tunnel
 	Tunnels tunnels;
 
 	Tunnels::Tunnels (): m_IsRunning (false), m_Thread (nullptr),
-		m_NumSuccesiveTunnelCreations (0), m_NumFailedTunnelCreations (0)
-	{
+		m_TunnelCreationSuccessRate (TCSR_START_VALUE), m_TunnelCreationAttemptsNum(0) {
 	}
 
 	Tunnels::~Tunnels ()
@@ -630,7 +629,7 @@ namespace tunnel
 						}
 						// delete
 						it = pendingTunnels.erase (it);
-						m_NumFailedTunnelCreations++;
+						FailedTunnelCreation();
 					}
 					else
 						++it;
@@ -638,7 +637,7 @@ namespace tunnel
 				case eTunnelStateBuildFailed:
 					LogPrint (eLogDebug, "Tunnel: Pending build request ", it->first, " failed, deleted");
 					it = pendingTunnels.erase (it);
-					m_NumFailedTunnelCreations++;
+					FailedTunnelCreation();
 				break;
 				case eTunnelStateBuildReplyReceived:
 					// intermediate state, will be either established of build failed
@@ -647,7 +646,7 @@ namespace tunnel
 				default:
 					// success
 					it = pendingTunnels.erase (it);
-					m_NumSuccesiveTunnelCreations++;
+					SuccesiveTunnelCreation();
 			}
 		}
 	}


### PR DESCRIPTION
Текущий алгоритм рассчета tunnel creation success rate (TCSR) берет количество успешных попыток создания тоннеля и делит на общее количество попыток. Получается, что этот показатель зависит от аптайма роутера => чем больше аптайм, тем неохотнее меняется TCSR. Через месяц показатель практически полностью перестает меняться.
Для решения этой проблемы можно использовать [экспоненциально взвешенное скользящее среднее (EWMA)](https://ru.wikipedia.org/wiki/Скользящая_средняя) которое учитывает только последние данные и значения TCSR остаются актуальными.
![image](https://user-images.githubusercontent.com/28982688/210286628-3984f65c-9b7b-42f0-839a-f5bc1f436b8d.png)
Протестировав, я понял, что при использовании этого алгоритма с использованием максимально возможного коэффициента сглаживания, при котором значение не начинает скакать, TCSR очень медленно сходится к реальному значению после старта роутера, поэтому я модицифировал алгоритм. В нем коэффициент сглаживания на старте больше стандартного и со временем падает до него. Это дает быстрое схождение после старта.
График схождения на примере массива `[0, 0, 1]*100`:
![1](https://user-images.githubusercontent.com/28982688/211201979-e26e7a7c-be1d-4ec4-8298-2314a157e936.png)
![2](https://user-images.githubusercontent.com/28982688/211201982-aa724fd9-f62b-4fb8-8f64-df24539e7b19.png)
График схождения на примере случаной последовательности 0 и 1:
![3](https://user-images.githubusercontent.com/28982688/211207254-3fc9ace1-5e8a-484a-94ee-0327952b9892.png)

