### PR TITLE
Minor fixes to comments related to PPC (no change to code)

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -178,6 +178,7 @@ endif()
 
 # Use std::atomic instead of GCC builtins on macOS PowerPC:
 # For more information refer to: https://github.com/PurpleI2P/i2pd/issues/1726#issuecomment-1306335111
+# This has been fixed in Boost 1.81, nevertheless we retain the setting for the sake of compatibility.
 if(APPLE AND CMAKE_OSX_ARCHITECTURES MATCHES "ppc")
   add_definitions(-DBOOST_SP_USE_STD_ATOMIC)
 endif()

--- a/build/cmake_modules/TargetArch.cmake
+++ b/build/cmake_modules/TargetArch.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2022, The PurpleI2P Project
+# Copyright (c) 2017-2023, The PurpleI2P Project
 # This file is part of Purple i2pd project and licensed under BSD3
 # See full license text in LICENSE file at top of project tree
 
@@ -83,13 +83,13 @@ function(target_architecture output_var)
         # First let's normalize the order of the values
 
         # Note that it's not possible to compile PowerPC applications if you are using
-        # the OS X SDK version 10.6 or later - you'll need 10.4/10.5 for that, so we
-        # disable it by default
+        # the OS X SDK version 10.7 or later - you'll need 10.4/10.5/10.6 for that, so we
+        # disable it by default. Also, ppc64 is not supported in 10.6.
         # See this page for more information:
         # http://stackoverflow.com/questions/5333490/how-can-we-restore-ppc-ppc64-as-well-as-full-10-4-10-5-sdk-support-to-xcode-4
 
         # Architecture defaults to i386 or ppc on OS X 10.5 and earlier, depending on the CPU type detected at runtime.
-        # On OS X 10.6+ the default is x86_64 if the CPU supports it, i386 otherwise.
+        # On OS X 10.6+ the default is x86_64 if the CPU supports it, i386 otherwise; 10.6 also supports ppc.
 
         foreach(osx_arch ${CMAKE_OSX_ARCHITECTURES})
             if("${osx_arch}" STREQUAL "ppc" AND ppc_support)
@@ -133,11 +133,11 @@ function(target_architecture output_var)
         enable_language(C)
 
         # Detect the architecture in a rather creative way...
-        # This compiles a small C program which is a series of ifdefs that selects a
-        # particular #error preprocessor directive whose message string contains the
-        # target architecture. The program will always fail to compile (both because
-        # file is not a valid C program, and obviously because of the presence of the
-        # #error preprocessor directives... but by exploiting the preprocessor in this
+        # This compiles a small C program which is a series of ifdefs that selects
+        # a particular #error preprocessor directive whose message string contains
+        # the target architecture. The program will always fail to compile (both because
+        # file is not a valid C program, and obviously because of the presence of
+        # the #error preprocessor directives... but by exploiting the preprocessor in this
         # way, we can detect the correct target architecture even when cross-compiling,
         # since the program itself never needs to be run (only the compiler/preprocessor)
         try_run(


### PR DESCRIPTION
1. Add a clarification re fix in the new Boost (do not change the code since many users may have older versions which are affected by the problem: Boost folks do not backport fixes).
2. Correct a wrong info re arch support: 10.6 supports building and running ppc(32) binaries – natively in early developer builds, via Rosetta in 10.6.x releases. Only ppc64 support ends with 10.5.8.
3. Unuglify a paragraph right below, those hanging articles.

No changes to code.