### PR TITLE
Added SAM UDP port parameter

### DIFF
--- a/contrib/i2pd.conf
+++ b/contrib/i2pd.conf
@@ -168,9 +168,10 @@ port = 4447
 [sam]
 ## Comment or set to 'false' to disable SAM Bridge
 enabled = true
-## Address and port service will listen on
+## Address and ports service will listen on
 # address = 127.0.0.1
 # port = 7656
+# portudp = 7655
 
 [bob]
 ## Uncomment and set to 'true' to enable BOB command channel

--- a/libi2pd/Config.cpp
+++ b/libi2pd/Config.cpp
@@ -149,7 +149,8 @@ namespace config {
 		sam.add_options()
 			("sam.enabled", value<bool>()->default_value(true),               "Enable or disable SAM Application bridge")
 			("sam.address", value<std::string>()->default_value("127.0.0.1"), "SAM listen address")
-			("sam.port", value<uint16_t>()->default_value(7656),              "SAM listen port")
+			("sam.port", value<uint16_t>()->default_value(7656),              "SAM listen TCP port")
+			("sam.portudp", value<uint16_t>()->default_value(0),              "SAM listen UDP port")
 			("sam.singlethread", value<bool>()->default_value(true),          "Sessions run in the SAM bridge's thread")
 		;
 

--- a/libi2pd_client/ClientContext.cpp
+++ b/libi2pd_client/ClientContext.cpp
@@ -63,18 +63,19 @@ namespace client
 		if (sam)
 		{
 			std::string samAddr; i2p::config::GetOption("sam.address", samAddr);
-			uint16_t    samPort; i2p::config::GetOption("sam.port",    samPort);
+			uint16_t samPortTCP; i2p::config::GetOption("sam.port", samPortTCP);
+			uint16_t samPortUDP; i2p::config::GetOption("sam.portudp", samPortUDP);
 			bool singleThread; i2p::config::GetOption("sam.singlethread", singleThread);
-			LogPrint(eLogInfo, "Clients: Starting SAM bridge at ", samAddr, ":", samPort);
+			LogPrint(eLogInfo, "Clients: Starting SAM bridge at ", samAddr, ":[", samPortTCP, "|", samPortUDP, "]");
 			try
 			{
-				m_SamBridge = new SAMBridge (samAddr, samPort, singleThread);
+				m_SamBridge = new SAMBridge (samAddr, samPortTCP, samPortUDP, singleThread);
 				m_SamBridge->Start ();
 			}
 			catch (std::exception& e)
 			{
 				LogPrint(eLogError, "Clients: Exception in SAM bridge: ", e.what());
-				ThrowFatal ("Unable to start SAM bridge at ", samAddr, ":", samPort, ": ", e.what ());
+				ThrowFatal ("Unable to start SAM bridge at ", samAddr, ":[", samPortTCP, "|", samPortUDP,"]: ", e.what ());
 			}
 		}
 

--- a/libi2pd_client/SAM.cpp
+++ b/libi2pd_client/SAM.cpp
@@ -1244,10 +1244,10 @@ namespace client
 		// TODO: implement datagrams
 	}
 
-	SAMBridge::SAMBridge (const std::string& address, int port, bool singleThread):
+	SAMBridge::SAMBridge (const std::string& address, int portTCP, int portUDP, bool singleThread):
 		RunnableService ("SAM"), m_IsSingleThread (singleThread),
-		m_Acceptor (GetIOService (), boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string(address), port)),
-		m_DatagramEndpoint (boost::asio::ip::address::from_string(address), port-1), m_DatagramSocket (GetIOService (), m_DatagramEndpoint),
+		m_Acceptor (GetIOService (), boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string(address), portTCP)),
+		m_DatagramEndpoint (boost::asio::ip::address::from_string(address), (!portUDP) ? portTCP-1 : portUDP), m_DatagramSocket (GetIOService (), m_DatagramEndpoint),
 		m_SignatureTypes
 		{
 			{"DSA_SHA1", i2p::data::SIGNING_KEY_TYPE_DSA_SHA1},

--- a/libi2pd_client/SAM.h
+++ b/libi2pd_client/SAM.h
@@ -233,7 +233,7 @@ namespace client
 	{
 		public:
 
-			SAMBridge (const std::string& address, int port, bool singleThread);
+			SAMBridge (const std::string& address, int portTCP, int portUDP, bool singleThread);
 			~SAMBridge ();
 
 			void Start ();


### PR DESCRIPTION
## SAM UDP port parameter (attempt 2)

Selecting UDP port for listening based in TCP port (`port - 1`) is a pretty ambiguous.
Added a separate backwards compatible option to specify UDP port in the config file.

```ini
[sam]
enabled = true
address = 127.0.0.1
port = 7656
portudp = 7655
```

### Behavior

If `portudp` is **not specified** - set default `0` and will use old logic with `port - 1`
If `portudp` is **specified to `0`** value - use old logic with `port - 1`
If `portudp` is **specified to non-zero** value - use this value