### PR TITLE
limit aes-ni assembly to x86

### DIFF
--- a/libi2pd/Crypto.cpp
+++ b/libi2pd/Crypto.cpp
@@ -555,7 +555,7 @@ namespace crypto
 	}
 
 // AES
-#ifdef __AES__
+#ifdef __AES__ && (defined(__x86_64__) || defined(__i386__))
 	#define KeyExpansion256(round0,round1) \
 		"pshufd $0xff, %%xmm2, %%xmm2 \n" \
 		"movaps %%xmm1, %%xmm4 \n" \
@@ -580,7 +580,7 @@ namespace crypto
 		"movaps %%xmm3, "#round1"(%[sched]) \n"
 #endif
 
-#ifdef __AES__
+#ifdef __AES__ && (defined(__x86_64__) || defined(__i386__))
 	void ECBCryptoAESNI::ExpandKey (const AESKey& key)
 	{
 		__asm__
@@ -621,7 +621,7 @@ namespace crypto
 #endif
 
 
-#ifdef __AES__
+#ifdef __AES__ && (defined(__x86_64__) || defined(__i386__))
 	#define EncryptAES256(sched) \
 		"pxor (%["#sched"]), %%xmm0 \n" \
 		"aesenc	16(%["#sched"]), %%xmm0 \n" \
@@ -642,7 +642,7 @@ namespace crypto
 
 	void ECBEncryption::Encrypt (const ChipherBlock * in, ChipherBlock * out)
 	{
-#ifdef __AES__
+#ifdef __AES__ && (defined(__x86_64__) || defined(__i386__))
 		if(i2p::cpu::aesni)
 		{
 			__asm__
@@ -660,7 +660,7 @@ namespace crypto
 		}
 	}
 
-#ifdef __AES__
+#ifdef __AES__ && (defined(__x86_64__) || defined(__i386__))
 	#define DecryptAES256(sched) \
 		"pxor 224(%["#sched"]), %%xmm0 \n" \
 		"aesdec	208(%["#sched"]), %%xmm0 \n" \
@@ -681,7 +681,7 @@ namespace crypto
 
 	void ECBDecryption::Decrypt (const ChipherBlock * in, ChipherBlock * out)
 	{
-#ifdef __AES__
+#ifdef __AES__ && (defined(__x86_64__) || defined(__i386__))
 		if(i2p::cpu::aesni)
 		{
 			__asm__
@@ -699,7 +699,7 @@ namespace crypto
 		}
 	}
 
-#ifdef __AES__
+#ifdef __AES__ && (defined(__x86_64__) || defined(__i386__))
 	#define CallAESIMC(offset) \
 		"movaps "#offset"(%[shed]), %%xmm0 \n" \
 		"aesimc %%xmm0, %%xmm0 \n" \
@@ -708,7 +708,7 @@ namespace crypto
 
 	void ECBEncryption::SetKey (const AESKey& key)
 	{
-#ifdef __AES__
+#ifdef __AES__ && (defined(__x86_64__) || defined(__i386__))
 		if(i2p::cpu::aesni)
 		{
 			ExpandKey (key);
@@ -722,7 +722,7 @@ namespace crypto
 
 	void ECBDecryption::SetKey (const AESKey& key)
 	{
-#ifdef __AES__
+#ifdef __AES__ && (defined(__x86_64__) || defined(__i386__))
 		if(i2p::cpu::aesni)
 		{
 			ExpandKey (key); // expand encryption key first
@@ -754,7 +754,7 @@ namespace crypto
 
 	void CBCEncryption::Encrypt (int numBlocks, const ChipherBlock * in, ChipherBlock * out)
 	{
-#ifdef __AES__
+#ifdef __AES__ && (defined(__x86_64__) || defined(__i386__))
 		if(i2p::cpu::aesni)
 		{
 			__asm__
@@ -799,7 +799,7 @@ namespace crypto
 
 	void CBCEncryption::Encrypt (const uint8_t * in, uint8_t * out)
 	{
-#ifdef __AES__
+#ifdef __AES__ && (defined(__x86_64__) || defined(__i386__))
 		if(i2p::cpu::aesni)
 		{
 			__asm__
@@ -823,7 +823,7 @@ namespace crypto
 
 	void CBCDecryption::Decrypt (int numBlocks, const ChipherBlock * in, ChipherBlock * out)
 	{
-#ifdef __AES__
+#ifdef __AES__ && (defined(__x86_64__) || defined(__i386__))
 		if(i2p::cpu::aesni)
 		{
 			__asm__
@@ -869,7 +869,7 @@ namespace crypto
 
 	void CBCDecryption::Decrypt (const uint8_t * in, uint8_t * out)
 	{
-#ifdef __AES__
+#ifdef __AES__ && (defined(__x86_64__) || defined(__i386__))
 		if(i2p::cpu::aesni)
 		{
 			__asm__
@@ -893,7 +893,7 @@ namespace crypto
 
 	void TunnelEncryption::Encrypt (const uint8_t * in, uint8_t * out)
 	{
-#ifdef __AES__
+#ifdef __AES__ && (defined(__x86_64__) || defined(__i386__))
 		if(i2p::cpu::aesni)
 		{
 			__asm__
@@ -934,7 +934,7 @@ namespace crypto
 
 	void TunnelDecryption::Decrypt (const uint8_t * in, uint8_t * out)
 	{
-#ifdef __AES__
+#ifdef __AES__ && (defined(__x86_64__) || defined(__i386__))
 		if(i2p::cpu::aesni)
 		{
 			__asm__

--- a/libi2pd/Crypto.cpp
+++ b/libi2pd/Crypto.cpp
@@ -555,7 +555,7 @@ namespace crypto
 	}
 
 // AES
-#ifdef __AES__ && (defined(__x86_64__) || defined(__i386__))
+#if defined(__AES__) && (defined(__x86_64__) || defined(__i386__))
 	#define KeyExpansion256(round0,round1) \
 		"pshufd $0xff, %%xmm2, %%xmm2 \n" \
 		"movaps %%xmm1, %%xmm4 \n" \
@@ -580,7 +580,7 @@ namespace crypto
 		"movaps %%xmm3, "#round1"(%[sched]) \n"
 #endif
 
-#ifdef __AES__ && (defined(__x86_64__) || defined(__i386__))
+#if defined(__AES__) && (defined(__x86_64__) || defined(__i386__))
 	void ECBCryptoAESNI::ExpandKey (const AESKey& key)
 	{
 		__asm__
@@ -621,7 +621,7 @@ namespace crypto
 #endif
 
 
-#ifdef __AES__ && (defined(__x86_64__) || defined(__i386__))
+#if defined(__AES__) && (defined(__x86_64__) || defined(__i386__))
 	#define EncryptAES256(sched) \
 		"pxor (%["#sched"]), %%xmm0 \n" \
 		"aesenc	16(%["#sched"]), %%xmm0 \n" \
@@ -642,7 +642,7 @@ namespace crypto
 
 	void ECBEncryption::Encrypt (const ChipherBlock * in, ChipherBlock * out)
 	{
-#ifdef __AES__ && (defined(__x86_64__) || defined(__i386__))
+#if defined(__AES__) && (defined(__x86_64__) || defined(__i386__))
 		if(i2p::cpu::aesni)
 		{
 			__asm__
@@ -660,7 +660,7 @@ namespace crypto
 		}
 	}
 
-#ifdef __AES__ && (defined(__x86_64__) || defined(__i386__))
+#if defined(__AES__) && (defined(__x86_64__) || defined(__i386__))
 	#define DecryptAES256(sched) \
 		"pxor 224(%["#sched"]), %%xmm0 \n" \
 		"aesdec	208(%["#sched"]), %%xmm0 \n" \
@@ -681,7 +681,7 @@ namespace crypto
 
 	void ECBDecryption::Decrypt (const ChipherBlock * in, ChipherBlock * out)
 	{
-#ifdef __AES__ && (defined(__x86_64__) || defined(__i386__))
+#if defined(__AES__) && (defined(__x86_64__) || defined(__i386__))
 		if(i2p::cpu::aesni)
 		{
 			__asm__
@@ -699,7 +699,7 @@ namespace crypto
 		}
 	}
 
-#ifdef __AES__ && (defined(__x86_64__) || defined(__i386__))
+#if defined(__AES__) && (defined(__x86_64__) || defined(__i386__))
 	#define CallAESIMC(offset) \
 		"movaps "#offset"(%[shed]), %%xmm0 \n" \
 		"aesimc %%xmm0, %%xmm0 \n" \
@@ -708,7 +708,7 @@ namespace crypto
 
 	void ECBEncryption::SetKey (const AESKey& key)
 	{
-#ifdef __AES__ && (defined(__x86_64__) || defined(__i386__))
+#if defined(__AES__) && (defined(__x86_64__) || defined(__i386__))
 		if(i2p::cpu::aesni)
 		{
 			ExpandKey (key);
@@ -722,7 +722,7 @@ namespace crypto
 
 	void ECBDecryption::SetKey (const AESKey& key)
 	{
-#ifdef __AES__ && (defined(__x86_64__) || defined(__i386__))
+#if defined(__AES__) && (defined(__x86_64__) || defined(__i386__))
 		if(i2p::cpu::aesni)
 		{
 			ExpandKey (key); // expand encryption key first
@@ -754,7 +754,7 @@ namespace crypto
 
 	void CBCEncryption::Encrypt (int numBlocks, const ChipherBlock * in, ChipherBlock * out)
 	{
-#ifdef __AES__ && (defined(__x86_64__) || defined(__i386__))
+#if defined(__AES__) && (defined(__x86_64__) || defined(__i386__))
 		if(i2p::cpu::aesni)
 		{
 			__asm__
@@ -799,7 +799,7 @@ namespace crypto
 
 	void CBCEncryption::Encrypt (const uint8_t * in, uint8_t * out)
 	{
-#ifdef __AES__ && (defined(__x86_64__) || defined(__i386__))
+#if defined(__AES__) && (defined(__x86_64__) || defined(__i386__))
 		if(i2p::cpu::aesni)
 		{
 			__asm__
@@ -823,7 +823,7 @@ namespace crypto
 
 	void CBCDecryption::Decrypt (int numBlocks, const ChipherBlock * in, ChipherBlock * out)
 	{
-#ifdef __AES__ && (defined(__x86_64__) || defined(__i386__))
+#if defined(__AES__) && (defined(__x86_64__) || defined(__i386__))
 		if(i2p::cpu::aesni)
 		{
 			__asm__
@@ -869,7 +869,7 @@ namespace crypto
 
 	void CBCDecryption::Decrypt (const uint8_t * in, uint8_t * out)
 	{
-#ifdef __AES__ && (defined(__x86_64__) || defined(__i386__))
+#if defined(__AES__) && (defined(__x86_64__) || defined(__i386__))
 		if(i2p::cpu::aesni)
 		{
 			__asm__
@@ -893,7 +893,7 @@ namespace crypto
 
 	void TunnelEncryption::Encrypt (const uint8_t * in, uint8_t * out)
 	{
-#ifdef __AES__ && (defined(__x86_64__) || defined(__i386__))
+#if defined(__AES__) && (defined(__x86_64__) || defined(__i386__))
 		if(i2p::cpu::aesni)
 		{
 			__asm__
@@ -934,7 +934,7 @@ namespace crypto
 
 	void TunnelDecryption::Decrypt (const uint8_t * in, uint8_t * out)
 	{
-#ifdef __AES__ && (defined(__x86_64__) || defined(__i386__))
+#if defined(__AES__) && (defined(__x86_64__) || defined(__i386__))
 		if(i2p::cpu::aesni)
 		{
 			__asm__


### PR DESCRIPTION
Couldn't build on e2k because elbrus-8s has SSE, AVX and AES-NI as intrinsics in immintrin.h but with different opcodes(AES-NI seems to be implemented in a very slow way so there's no point in porting over the raw asm to intrinsics) and reports `__AES__` in the preprocessor.