### PR TITLE
Convert raw x86_64 assembly to intrinsics, e2k hardware acceleration support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,10 @@ ifneq (, $(DESTDIR))
 	PREFIX = $(DESTDIR)
 endif
 
+ifneq (, $(findstring e2k, $(SYS)))
+	CXX_DEBUG += -Wno-deprecated-declarations
+endif
+
 ifneq (, $(findstring darwin, $(SYS)))
 	DAEMON_SRC += $(DAEMON_SRC_DIR)/UnixDaemon.cpp
 	ifeq ($(HOMEBREW),1)

--- a/libi2pd/CPU.cpp
+++ b/libi2pd/CPU.cpp
@@ -50,7 +50,9 @@ namespace cpu
 			}
 		}
 #endif // defined(__x86_64__) || defined(__i386__)
-#ifdef __e2k__
+#ifdef __e2k__ // The reason this kind of static config is ok for Elbrus is because there are
+	       // much less hardware revisions than x86, and a binary compiled
+	       // on a newer Elbrus CPU will outright not work on a older model anyway.
 #ifdef __AES__
 		aesni = true;
 #endif

--- a/libi2pd/CPU.cpp
+++ b/libi2pd/CPU.cpp
@@ -50,6 +50,14 @@ namespace cpu
 			}
 		}
 #endif // defined(__x86_64__) || defined(__i386__)
+#ifdef __e2k__
+#ifdef __AES__
+		aesni = true;
+#endif
+#ifdef __AVX__
+		avx = true;
+#endif
+#endif
 
 		LogPrint(eLogInfo, "AESNI ", (aesni ? "enabled" : "disabled"));
 		LogPrint(eLogInfo, "AVX ", (avx ? "enabled" : "disabled"));

--- a/libi2pd/CPU.cpp
+++ b/libi2pd/CPU.cpp
@@ -54,10 +54,10 @@ namespace cpu
 	       // much less hardware revisions than x86, and a binary compiled
 	       // on a newer Elbrus CPU will outright not work on a older model anyway.
 #ifdef __AES__
-		aesni = true;
+		if (AesSwitch) aesni = true;
 #endif
 #ifdef __AVX__
-		avx = true;
+		if (AvxSwitch) avx = true;
 #endif
 #endif
 

--- a/libi2pd/Crypto.cpp
+++ b/libi2pd/Crypto.cpp
@@ -574,12 +574,13 @@ namespace crypto
 	_mm_store_ps((float*)(sched + round0), xmm_1); \
 	xmm_4 = _mm_aeskeygenassist_si128((__m128i)xmm_1, 0); \
 	xmm_2 = _mm_shuffle_epi32(xmm_4, 0xaa); \
-	xmm_3 = _mm_load_ps((float const*)&xmm_4); \
+	xmm_4 = (__m128i)_mm_load_ps((float const*)&xmm_3); \
 	xmm_4 = _mm_slli_si128(xmm_4, 4); \
 	xmm_3 = (__m128)_mm_xor_si128((__m128i)xmm_3, xmm_2); \
 	xmm_4 = _mm_slli_si128(xmm_4, 4); \
 	xmm_3 = (__m128)_mm_xor_si128((__m128i)xmm_3, xmm_2); \
 	xmm_4 = _mm_slli_si128(xmm_4, 4); \
+	xmm_3 = (__m128)_mm_xor_si128((__m128i)xmm_3, xmm_4); \
 	xmm_3 = (__m128)_mm_xor_si128((__m128i)xmm_3, xmm_2); \
 	_mm_store_ps((float*)(sched + round1), xmm_3);
 
@@ -616,7 +617,7 @@ namespace crypto
 		xmm_1 = (__m128)_mm_xor_si128((__m128i)xmm_1, xmm_4); 
 		xmm_4 = _mm_slli_si128(xmm_4, 4);
 		xmm_1 = (__m128)_mm_xor_si128((__m128i)xmm_1, xmm_4); 
-		xmm_2 = _mm_xor_si128((__m128i)xmm_1, xmm_2);
+		xmm_1 = (__m128)_mm_xor_si128((__m128i)xmm_1, xmm_2);
 		_mm_storeu_ps((float*)(sched + 224), xmm_1);
 	}
 #endif

--- a/libi2pd/Crypto.cpp
+++ b/libi2pd/Crypto.cpp
@@ -574,9 +574,9 @@ namespace crypto
 	xmm_2 = _mm_shuffle_epi32(xmm_4, 0xaa); \
 	xmm_4 = (__m128i)_mm_load_ps((float const*)&xmm_3); \
 	xmm_4 = _mm_slli_si128(xmm_4, 4); \
-	xmm_3 = (__m128)_mm_xor_si128((__m128i)xmm_3, xmm_2); \
+	xmm_3 = (__m128)_mm_xor_si128((__m128i)xmm_3, xmm_4); \
 	xmm_4 = _mm_slli_si128(xmm_4, 4); \
-	xmm_3 = (__m128)_mm_xor_si128((__m128i)xmm_3, xmm_2); \
+	xmm_3 = (__m128)_mm_xor_si128((__m128i)xmm_3, xmm_4); \
 	xmm_4 = _mm_slli_si128(xmm_4, 4); \
 	xmm_3 = (__m128)_mm_xor_si128((__m128i)xmm_3, xmm_4); \
 	xmm_3 = (__m128)_mm_xor_si128((__m128i)xmm_3, xmm_2); \

--- a/libi2pd/Crypto.cpp
+++ b/libi2pd/Crypto.cpp
@@ -749,7 +749,8 @@ namespace crypto
 #ifdef __AES__
 		if(i2p::cpu::aesni)
 		{
-			__m128 xmm_1 = _mm_loadu_ps((float const*)(uint8_t const*)m_LastBlock);
+			uint8_t *iv = m_LastBlock;
+			__m128 xmm_1 = _mm_loadu_ps((float const*)iv);
 			uint8_t *sched = m_ECBEncryption.GetKeySchedule();
 			__m128 xmm_0;
 			for (int i = 0; i < numBlocks; i++) {
@@ -761,7 +762,7 @@ namespace crypto
 				in = (ChipherBlock const*)((uint8_t const*)in + 16);
 				out = (ChipherBlock *)((uint8_t *)out + 16);
 			}
-			_mm_storeu_ps((float*)(uint8_t *)m_LastBlock, xmm_1);
+			_mm_storeu_ps((float*)iv, xmm_1);
 		}
 		else
 #endif
@@ -788,13 +789,14 @@ namespace crypto
 #ifdef __AES__
 		if(i2p::cpu::aesni)
 		{
-			__m128 xmm_1 = _mm_loadu_ps((float const*)(uint8_t const*)m_LastBlock);
+			uint8_t *iv = m_LastBlock;
+			__m128 xmm_1 = _mm_loadu_ps((float const*)iv);
 			__m128 xmm_0 = _mm_loadu_ps((float const*)in);
 			xmm_0 = (__m128)_mm_xor_si128((__m128i)xmm_0, (__m128i)xmm_1);
 			uint8_t *sched = m_ECBEncryption.GetKeySchedule();
 			EncryptAES256(sched)
 			_mm_storeu_ps((float *)out, xmm_0);
-			_mm_storeu_ps((float *)(uint8_t *)m_LastBlock, xmm_0);
+			_mm_storeu_ps((float *)iv, xmm_0);
 		}
 		else
 #endif
@@ -806,7 +808,8 @@ namespace crypto
 #ifdef __AES__
 		if(i2p::cpu::aesni)
 		{
-			__m128 xmm_1 = _mm_loadu_ps((float const*)(uint8_t const*)m_IV);
+			uint8_t *iv = m_IV;
+			__m128 xmm_1 = _mm_loadu_ps((float const*)iv);
 			__m128 xmm_0, xmm_2;
 			uint8_t *sched = m_ECBDecryption.GetKeySchedule();
 			for (int i = 0; i < numBlocks; i++) {
@@ -819,7 +822,7 @@ namespace crypto
 				in = (ChipherBlock const*)((uint8_t const*)in + 16);
 				out = (ChipherBlock *)((uint8_t *)out + 16);
 			}
-			_mm_storeu_ps((float*)(uint8_t*)m_IV, xmm_1);
+			_mm_storeu_ps((float*)iv, xmm_1);
 		}
 		else
 #endif
@@ -846,9 +849,10 @@ namespace crypto
 #ifdef __AES__
 		if(i2p::cpu::aesni)
 		{
-			__m128 xmm_1 = _mm_load_ps((float const*)(uint8_t const*)m_IV);
+			uint8_t *iv = m_IV;
+			__m128 xmm_1 = _mm_load_ps((float const*)iv);
 			__m128 xmm_0 = _mm_load_ps((float const*)in);
-			_mm_store_ps((float*)(uint8_t*)m_IV, xmm_0);
+			_mm_store_ps((float*)iv, xmm_0);
 			uint8_t *sched = m_ECBDecryption.GetKeySchedule();
 			DecryptAES256(sched)
 			xmm_0 = (__m128)_mm_xor_si128((__m128i)xmm_0, (__m128i)xmm_1);

--- a/libi2pd/Crypto.cpp
+++ b/libi2pd/Crypto.cpp
@@ -637,7 +637,7 @@ namespace crypto
 		xmm_0 = (__m128)_mm_aesenc_si128((__m128i)xmm_0, *(__m128i*)(sched + 0xb0)); \
 		xmm_0 = (__m128)_mm_aesenc_si128((__m128i)xmm_0, *(__m128i*)(sched + 0xc0)); \
 		xmm_0 = (__m128)_mm_aesenc_si128((__m128i)xmm_0, *(__m128i*)(sched + 0xd0)); \
-		xmm_0 = (__m128)_mm_aesenclast_si128((__m128i)xmm_0, *(__m128i*)(sched + 0xf0));
+		xmm_0 = (__m128)_mm_aesenclast_si128((__m128i)xmm_0, *(__m128i*)(sched + 0xe0));
 #endif
 
 	void ECBEncryption::Encrypt (const ChipherBlock * in, ChipherBlock * out)
@@ -659,7 +659,7 @@ namespace crypto
 
 #ifdef __AES__
 	#define DecryptAES256(sched) \
-		xmm_0 = (__m128)_mm_xor_si128((__m128i)xmm_0, *(__m128i*)(sched + 0xf0)); \
+		xmm_0 = (__m128)_mm_xor_si128((__m128i)xmm_0, *(__m128i*)(sched + 0xe0)); \
 		xmm_0 = (__m128)_mm_aesdec_si128((__m128i)xmm_0, *(__m128i*)(sched + 0xd0)); \
 		xmm_0 = (__m128)_mm_aesdec_si128((__m128i)xmm_0, *(__m128i*)(sched + 0xc0)); \
 		xmm_0 = (__m128)_mm_aesdec_si128((__m128i)xmm_0, *(__m128i*)(sched + 0xb0)); \

--- a/libi2pd/Crypto.cpp
+++ b/libi2pd/Crypto.cpp
@@ -560,7 +560,7 @@ namespace crypto
 	}
 
 // AES
-#if defined(__AES__)
+#ifdef __AES__
 #define KeyExpansion256(round0, round1) \
 	xmm_2 = _mm_shuffle_epi32(xmm_2, 0xff); \
 	xmm_4 = (__m128i)_mm_load_ps((float const*)&xmm_1);   \
@@ -585,7 +585,7 @@ namespace crypto
 
 #endif
 
-#if defined(__AES__)
+#ifdef __AES__
 	void ECBCryptoAESNI::ExpandKey (const AESKey& key)
 	{
 		uint8_t* sched = GetKeySchedule();
@@ -622,7 +622,7 @@ namespace crypto
 #endif
 
 
-#if defined(__AES__) && defined(__x86_64__)
+#ifdef __AES__
 	#define EncryptAES256(sched) \
 		xmm_0 = (__m128)_mm_xor_si128((__m128i)xmm_0, *(__m128i*)sched); \
 		xmm_0 = (__m128)_mm_aesenc_si128((__m128i)xmm_0, *(__m128i*)(sched + 0x10)); \
@@ -643,7 +643,7 @@ namespace crypto
 
 	void ECBEncryption::Encrypt (const ChipherBlock * in, ChipherBlock * out)
 	{
-#if defined(__AES__)
+#ifdef __AES__
 		if(i2p::cpu::aesni)
 		{
 			__m128 xmm_0 = _mm_loadu_ps((float const*)in);
@@ -658,7 +658,7 @@ namespace crypto
 		}
 	}
 
-#if defined(__AES__) && defined(__x86_64__)
+#ifdef __AES__
 	#define DecryptAES256(sched) \
 		xmm_0 = (__m128)_mm_xor_si128((__m128i)xmm_0, *(__m128i*)(sched + 0xf0)); \
 		xmm_0 = (__m128)_mm_aesdec_si128((__m128i)xmm_0, *(__m128i*)(sched + 0xd0)); \
@@ -679,7 +679,7 @@ namespace crypto
 
 	void ECBDecryption::Decrypt (const ChipherBlock * in, ChipherBlock * out)
 	{
-#if defined(__AES__)
+#ifdef __AES__
 		if(i2p::cpu::aesni)
 		{
 			__m128 xmm_0 = _mm_loadu_ps((float const*)in);
@@ -694,7 +694,7 @@ namespace crypto
 		}
 	}
 
-#if defined(__AES__) && defined(__x86_64__)
+#ifdef __AES__
 	#define CallAESIMC(offset) \
 		xmm_0 = _mm_load_ps((float const*)(sched + offset)); \
 		xmm_0 = (__m128)_mm_aesimc_si128((__m128i)xmm_0); \
@@ -703,7 +703,7 @@ namespace crypto
 
 	void ECBEncryption::SetKey (const AESKey& key)
 	{
-#if defined(__AES__)
+#ifdef __AES__
 		if(i2p::cpu::aesni)
 		{
 			ExpandKey (key);
@@ -717,7 +717,7 @@ namespace crypto
 
 	void ECBDecryption::SetKey (const AESKey& key)
 	{
-#if defined(__AES__)
+#ifdef __AES__
 		if(i2p::cpu::aesni)
 		{
 			ExpandKey (key); // expand encryption key first
@@ -747,7 +747,7 @@ namespace crypto
 
 	void CBCEncryption::Encrypt (int numBlocks, const ChipherBlock * in, ChipherBlock * out)
 	{
-#if defined(__AES__)
+#ifdef __AES__
 		if(i2p::cpu::aesni)
 		{
 			__m128 xmm_1 = _mm_loadu_ps((float const*)&m_LastBlock);
@@ -786,7 +786,7 @@ namespace crypto
 
 	void CBCEncryption::Encrypt (const uint8_t * in, uint8_t * out)
 	{
-#if defined(__AES__)
+#ifdef __AES__
 		if(i2p::cpu::aesni)
 		{
 			__m128 xmm_1 = _mm_loadu_ps((float const*)&m_LastBlock);
@@ -804,7 +804,7 @@ namespace crypto
 
 	void CBCDecryption::Decrypt (int numBlocks, const ChipherBlock * in, ChipherBlock * out)
 	{
-#if defined(__AES__)
+#ifdef __AES__
 		if(i2p::cpu::aesni)
 		{
 			__m128 xmm_1 = _mm_loadu_ps((float const*)&m_IV);
@@ -844,7 +844,7 @@ namespace crypto
 
 	void CBCDecryption::Decrypt (const uint8_t * in, uint8_t * out)
 	{
-#if defined(__AES__)
+#ifdef __AES__
 		if(i2p::cpu::aesni)
 		{
 			__m128 xmm_1 = _mm_load_ps((float const*)&m_IV);
@@ -862,7 +862,7 @@ namespace crypto
 
 	void TunnelEncryption::Encrypt (const uint8_t * in, uint8_t * out)
 	{
-#if defined(__AES__)
+#ifdef __AES__
 		if(i2p::cpu::aesni)
 		{
 			__m128 xmm_0 = _mm_loadu_ps((float const*)in);
@@ -893,7 +893,7 @@ namespace crypto
 
 	void TunnelDecryption::Decrypt (const uint8_t * in, uint8_t * out)
 	{
-#if defined(__AES__)
+#ifdef __AES__
 		if(i2p::cpu::aesni)
 		{
 			__m128 xmm_0 = _mm_loadu_ps((float const*)in);

--- a/libi2pd/Crypto.cpp
+++ b/libi2pd/Crypto.cpp
@@ -806,7 +806,7 @@ namespace crypto
 #ifdef __AES__
 		if(i2p::cpu::aesni)
 		{
-			__m128 xmm_1 = _mm_loadu_ps((float const*)&m_IV);
+			__m128 xmm_1 = _mm_loadu_ps((float const*)(uint8_t const*)m_IV);
 			__m128 xmm_0, xmm_2;
 			uint8_t *sched = m_ECBDecryption.GetKeySchedule();
 			for (int i = 0; i < numBlocks; i++) {
@@ -819,7 +819,7 @@ namespace crypto
 				in = (ChipherBlock const*)((uint8_t const*)in + 16);
 				out = (ChipherBlock *)((uint8_t *)out + 16);
 			}
-			_mm_storeu_ps((float*)&m_IV, xmm_1);
+			_mm_storeu_ps((float*)(uint8_t*)m_IV, xmm_1);
 		}
 		else
 #endif
@@ -846,9 +846,9 @@ namespace crypto
 #ifdef __AES__
 		if(i2p::cpu::aesni)
 		{
-			__m128 xmm_1 = _mm_load_ps((float const*)&m_IV);
+			__m128 xmm_1 = _mm_load_ps((float const*)(uint8_t const*)m_IV);
 			__m128 xmm_0 = _mm_load_ps((float const*)in);
-			_mm_store_ps((float*)&m_IV, xmm_0);
+			_mm_store_ps((float*)(uint8_t*)m_IV, xmm_0);
 			uint8_t *sched = m_ECBDecryption.GetKeySchedule();
 			DecryptAES256(sched)
 			xmm_0 = (__m128)_mm_xor_si128((__m128i)xmm_0, (__m128i)xmm_1);
@@ -906,7 +906,7 @@ namespace crypto
 			for (int i = 0; i < 63/*blocks = 1008 bytes*/; i++) {
 				in += 16, out += 16;
 				xmm_0 = _mm_loadu_ps((float const*)in);
-				_mm_store_ps((float*)&xmm_2, xmm_0);
+				xmm_2 = _mm_load_ps((float const*)&xmm_0);
 				DecryptAES256(sched_l)
 				xmm_0 = (__m128)_mm_xor_si128((__m128i)xmm_0, (__m128i)xmm_1);
 				_mm_storeu_ps((float*)out, xmm_0);

--- a/libi2pd/Crypto.cpp
+++ b/libi2pd/Crypto.cpp
@@ -6,8 +6,6 @@
 * See full license text in LICENSE file at top of project tree
 */
 
-#include <stdio.h>
-
 #include <string.h>
 #include <string>
 #include <vector>

--- a/libi2pd/Crypto.cpp
+++ b/libi2pd/Crypto.cpp
@@ -749,7 +749,7 @@ namespace crypto
 #ifdef __AES__
 		if(i2p::cpu::aesni)
 		{
-			__m128 xmm_1 = _mm_loadu_ps((float const*)&m_LastBlock);
+			__m128 xmm_1 = _mm_loadu_ps((float const*)(uint8_t const*)m_LastBlock);
 			uint8_t *sched = m_ECBEncryption.GetKeySchedule();
 			__m128 xmm_0;
 			for (int i = 0; i < numBlocks; i++) {
@@ -761,7 +761,7 @@ namespace crypto
 				in = (ChipherBlock const*)((uint8_t const*)in + 16);
 				out = (ChipherBlock *)((uint8_t *)out + 16);
 			}
-			_mm_storeu_ps((float*)&m_LastBlock, xmm_1);
+			_mm_storeu_ps((float*)(uint8_t *)m_LastBlock, xmm_1);
 		}
 		else
 #endif
@@ -788,13 +788,13 @@ namespace crypto
 #ifdef __AES__
 		if(i2p::cpu::aesni)
 		{
-			__m128 xmm_1 = _mm_loadu_ps((float const*)&m_LastBlock);
+			__m128 xmm_1 = _mm_loadu_ps((float const*)(uint8_t const*)m_LastBlock);
 			__m128 xmm_0 = _mm_loadu_ps((float const*)in);
 			xmm_0 = (__m128)_mm_xor_si128((__m128i)xmm_0, (__m128i)xmm_1);
 			uint8_t *sched = m_ECBEncryption.GetKeySchedule();
 			EncryptAES256(sched)
 			_mm_storeu_ps((float *)out, xmm_0);
-			_mm_storeu_ps((float *)&m_LastBlock, xmm_0);
+			_mm_storeu_ps((float *)(uint8_t *)m_LastBlock, xmm_0);
 		}
 		else
 #endif

--- a/libi2pd/Crypto.cpp
+++ b/libi2pd/Crypto.cpp
@@ -587,11 +587,11 @@ namespace crypto
 #ifdef __AES__
 	void ECBCryptoAESNI::ExpandKey (const AESKey& key)
 	{
-		uint8_t* sched = GetKeySchedule();
-		__m128 xmm_1 = _mm_loadu_ps((float const*)&key);
-		__m128 xmm_3 = _mm_loadu_ps((float const*)(
-		                              (uint8_t*)&key + 0x10));
-		_mm_store_ps((float*)(sched), xmm_1);
+		uint8_t *sched = GetKeySchedule();
+		auto key_ = (uint8_t const*)key;
+		__m128 xmm_1 = _mm_loadu_ps((float const*)key_);
+		__m128 xmm_3 = _mm_loadu_ps((float const*)(key_ + 0x10));
+		_mm_store_ps((float*)sched, xmm_1);
 		_mm_store_ps((float*)(sched + 0x10), xmm_3);
 		__m128i xmm_2 = _mm_aeskeygenassist_si128((__m128i)xmm_3, 1);
 		__m128i xmm_4;

--- a/libi2pd/Identity.cpp
+++ b/libi2pd/Identity.cpp
@@ -809,10 +809,10 @@ namespace data
 #if defined(__AVX__) // not all X86 targets supports AVX (like old Pentium, see #1600)
 		if(i2p::cpu::avx)
 		{
-			__m256 ymm_0 = _mm256_loadu_ps((float const*)&key1);
-			__m256 ymm_1 = _mm256_loadu_ps((float const*)&key2);
+			__m256 ymm_0 = _mm256_loadu_ps((float const*)*key1);
+			__m256 ymm_1 = _mm256_loadu_ps((float const*)*key2);
 			ymm_1 = _mm256_xor_ps(ymm_1, ymm_0);
-			_mm256_storeu_ps((float*)m.metric, ymm_1);
+			_mm256_storeu_ps((float*)*m.metric, ymm_1);
 		}
 		else
 #endif


### PR DESCRIPTION
After talking with @makise-homura I've found out that Elbrus-8SV does in fact have hardware acceleration for AES-NI and AVX. As a result I have ported the raw x86_64 assembly to Intel intrinsics as Elbrus supports it. I have tested the code and it seems like I am not getting any checksum errors or packet corruptions.