### PR TITLE
Rebuild docker images every 2 days

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,8 @@ on:
     - docker
     tags:
     - '*'
+  schedule:
+    - cron:  '0 4 */2 * *'
 
 jobs:
   build:


### PR DESCRIPTION
`latest` tag is already 9 days old, `latest-release` is 2 weeks old.
To keep the images secure, I would suggest rebuilding them regularly.