### PR TITLE
Added bounds checking.

### DIFF
--- a/libi2pd/LeaseSet.cpp
+++ b/libi2pd/LeaseSet.cpp
@@ -394,6 +394,10 @@ namespace data
 	size_t LeaseSet2::ReadStandardLS2TypeSpecificPart (const uint8_t * buf, size_t len)
 	{
 		size_t offset = 0;
+
+		if(offset + 2 > len) // AKA (len < 2)
+			return 0;
+
 		// properties
 		uint16_t propertiesLen = bufbe16toh (buf + offset); offset += 2;
 		offset += propertiesLen; // skip for now. TODO: implement properties
@@ -448,6 +452,10 @@ namespace data
 	size_t LeaseSet2::ReadMetaLS2TypeSpecificPart (const uint8_t * buf, size_t len)
 	{
 		size_t offset = 0;
+
+		if(offset + 2 > len) // AKA (len < 2)
+			return 0;
+
 		// properties
 		uint16_t propertiesLen = bufbe16toh (buf + offset); offset += 2;
 		offset += propertiesLen; // skip for now. TODO: implement properties

--- a/libi2pd/NetDb.cpp
+++ b/libi2pd/NetDb.cpp
@@ -922,6 +922,10 @@ namespace data
 		else if(!m_FloodfillBootstrap)
 			LogPrint (eLogWarning, "NetDb: Requested destination for ", key, " not found");
 
+		// All peers hashs in buffer?
+		if(msg->GetPayloadLength() < (size_t) (33 + num * 32))
+			return;
+
 		// try responses
 		for (int i = 0; i < num; i++)
 		{


### PR DESCRIPTION
Found multiple buffer over-reads while fuzzing.
```
==23556==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x614000000dcc at pc 0x000000dd8ce7 bp 0x7fffffffc3f0 sp 0x7fffffffbbc0
READ of size 2 at 0x614000000dcc thread T0
    #0 0xdd8ce6 in __asan_memcpy /usr/src/contrib/llvm-project/compiler-rt/lib/asan/asan_interceptors_memintrinsics.cpp:22:3
    #1 0xf6bdbf in buf16toh(void const*) /projects/i2pd/build/../libi2pd/I2PEndian.h:96:2
    #2 0xf39d6a in bufbe16toh(void const*) /projects/i2pd/build/../libi2pd/I2PEndian.h:116:9
    #3 0x11c59b7 in i2p::data::LeaseSet2::ReadMetaLS2TypeSpecificPart(unsigned char const*, unsigned long) /projects/i2pd/libi2pd/LeaseSet.cpp:452:28
    #4 0x11be7a5 in i2p::data::LeaseSet2::ReadFromBuffer(unsigned char const*, unsigned long, bool, bool) /projects/i2pd/libi2pd/LeaseSet.cpp:355:9
    #5 0x11b8026 in i2p::data::LeaseSet2::LeaseSet2(unsigned char, unsigned char const*, unsigned long, bool, unsigned short) /projects/i2pd/libi2pd/LeaseSet.cpp:290:4
    #6 0xe0eb34 in LLVMFuzzerTestOneInput /projects/i2pd/fuzz/fuzz-LeaseSet2.cc:33:11
    #7 0xd59593 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /usr/src/contrib/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:611:15
    #8 0xd458e2 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) /usr/src/contrib/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:324:6
    #9 0xd4a942 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /usr/src/contrib/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:860:9
    #10 0xd5f192 in main /usr/src/contrib/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
```

--------------------

```
==23615==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x614002291fcc at pc 0x000000dd8ce7 bp 0x7fffffffbf30 sp 0x7fffffffb700
READ of size 2 at 0x614002291fcc thread T0
    #0 0xdd8ce6 in __asan_memcpy /usr/src/contrib/llvm-project/compiler-rt/lib/asan/asan_interceptors_memintrinsics.cpp:22:3
    #1 0xf6bdbf in buf16toh(void const*) /projects/i2pd/build/../libi2pd/I2PEndian.h:96:2
    #2 0xf39d6a in bufbe16toh(void const*) /projects/i2pd/build/../libi2pd/I2PEndian.h:116:9
    #3 0x11c3f4d in i2p::data::LeaseSet2::ReadStandardLS2TypeSpecificPart(unsigned char const*, unsigned long) /projects/i2pd/libi2pd/LeaseSet.cpp:398:28
    #4 0x11be598 in i2p::data::LeaseSet2::ReadFromBuffer(unsigned char const*, unsigned long, bool, bool) /projects/i2pd/libi2pd/LeaseSet.cpp:352:9
    #5 0x11b8026 in i2p::data::LeaseSet2::LeaseSet2(unsigned char, unsigned char const*, unsigned long, bool, unsigned short) /projects/i2pd/libi2pd/LeaseSet.cpp:290:4
    #6 0xe0eb34 in LLVMFuzzerTestOneInput /projects/i2pd/fuzz/fuzz-LeaseSet2.cc:33:11
    #7 0xd59593 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /usr/src/contrib/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:611:15
    #8 0xd58d7a in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool, bool*) /usr/src/contrib/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:514:3
    #9 0xd59ee9 in fuzzer::Fuzzer::MutateAndTestOne() /usr/src/contrib/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:757:19
    #10 0xd5a8a5 in fuzzer::Fuzzer::Loop(std::__1::vector<fuzzer::SizedFile, std::__1::allocator<fuzzer::SizedFile> >&) /usr/src/contrib/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:895:5
    #11 0xd4a825 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /usr/src/contrib/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:912:6
    #12 0xd5f192 in main /usr/src/contrib/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
```

--------------------
```
==23578==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x621000068d68 at pc 0x0000010c1f12 bp 0x7fffffffbdf0 sp 0x7fffffffbde8
READ of size 1 at 0x621000068d68 thread T0
    #0 0x10c1f11 in i2p::data::ByteStreamToBase64(unsigned char const*, unsigned long, char*, unsigned long) /projects/i2pd/libi2pd/Base.cpp:113:12
    #1 0x11ee19f in i2p::data::NetDb::HandleDatabaseSearchReplyMsg(std::__1::shared_ptr<i2p::I2NPMessage const>) /projects/i2pd/libi2pd/NetDb.cpp:930:13
    #2 0xe0ecdf in LLVMFuzzerTestOneInput /projects/i2pd/fuzz/fuzz-NetDb-HandleDatabaseSearchReplyMsg.cc:29:19
    #3 0xd596d3 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /usr/src/contrib/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:611:15
    #4 0xd45a22 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) /usr/src/contrib/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:324:6
    #5 0xd4aa82 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /usr/src/contrib/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:860:9
    #6 0xd5f2d2 in main /usr/src/contrib/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
```
