### PR TITLE
Fixed division by zero due to thread race condition.

### DIFF
--- a/libi2pd/NetDb.cpp
+++ b/libi2pd/NetDb.cpp
@@ -1253,7 +1253,9 @@ namespace data
 		uint16_t inds[3];
 		RAND_bytes ((uint8_t *)inds, sizeof (inds));
 		std::unique_lock<std::mutex> l(m_RouterInfosMutex);
-		inds[0] %= m_RouterInfos.size ();
+		auto count = m_RouterInfos.size ();
+		if(count == 0) return nullptr;
+		inds[0] %= count;
 		auto it = m_RouterInfos.begin ();
 		std::advance (it, inds[0]);
 		// try random router

--- a/libi2pd/Transports.cpp
+++ b/libi2pd/Transports.cpp
@@ -861,7 +861,9 @@ namespace transport
 			uint16_t inds[3];
 			RAND_bytes ((uint8_t *)inds, sizeof (inds));
 			std::unique_lock<std::mutex> l(m_PeersMutex);
-			inds[0] %= m_Peers.size ();
+			auto count = m_Peers.size ();
+			if(count == 0) return nullptr;
+			inds[0] %= count;
 			auto it = m_Peers.begin ();
 			std::advance (it, inds[0]);
 			// try random peer


### PR DESCRIPTION
Fix for issue #1942.
Also patches `NetDb::GetRandomRouter()`, which has similar susceptible code.