### PR TITLE
Fixed crash when Base64ToByteStream() is only given '=' characters.

### DIFF
--- a/libi2pd/Base.cpp
+++ b/libi2pd/Base.cpp
@@ -187,6 +187,9 @@ namespace data
 		else
 			return 0;
 
+		if(*InBuffer == P64)
+			return 0;
+
 		ps = (unsigned char *)(InBuffer + InCount - 1);
 		while ( *ps-- == P64 )
 			outCount--;


### PR DESCRIPTION
`Base64ToByteStream()` has negative buffer offset read if its input only contains '=' characters.
```
==74301==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x602000003daf at pc 0x000000e38f6f bp 0x7fffffffcb80 sp 0x7fffffffcb78
READ of size 1 at 0x602000003daf thread T0
    #0 0xe38f6e in i2p::data::Base64ToByteStream(char const*, unsigned long, unsigned char*, unsigned long) /projects/i2pd/libi2pd/Base.cpp:191:11
    #1 0xe156a2 in LLVMFuzzerTestOneInput /projects/i2pd/fuzz/fuzz-Base64ToByteStream.cc:31:2
    #2 0xd61293 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /usr/src/contrib/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:611:15
    #3 0xd4d5e2 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) /usr/src/contrib/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:324:6
    #4 0xd52642 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /usr/src/contrib/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:860:9
    #5 0xd66e92 in main /usr/src/contrib/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
```

Test input:
 - InBuffer = "============"
 - InCount = 12
 - len = 15678    (this output size not relevant to bug)
