### PR TITLE
Eliminate undefined behavior of bit shifting signed int.

### DIFF
--- a/libi2pd/Base.cpp
+++ b/libi2pd/Base.cpp
@@ -298,7 +298,7 @@ namespace data
 	size_t ByteStreamToBase32 (const uint8_t * inBuf, size_t len, char * outBuf, size_t outLen)
 	{
 		size_t ret = 0, pos = 1;
-		int bits = 8, tmp = inBuf[0];
+		unsigned int bits = 8, tmp = inBuf[0];
 		while (ret < outLen && (bits > 0 || pos < len))
 		{
 			if (bits < 5)


### PR DESCRIPTION
Fix undefined behavior found while fuzzing.
```
/projects/i2pd/libi2pd/Base.cpp:315:10: runtime error: left shift of negative value -1720975601
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /projects/i2pd/libi2pd/Base.cpp:315:10 in

/projects/i2pd/libi2pd/Base.cpp:308:10: runtime error: left shift of 522165279 by 8 places cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /projects/i2pd/libi2pd/Base.cpp:308:10 in
```
