### PR TITLE
Use offset from Identity::signingKey instead of Identity::certificate for key.

### DIFF
--- a/libi2pd/Identity.cpp
+++ b/libi2pd/Identity.cpp
@@ -581,7 +581,7 @@ namespace data
 		if (keyType == SIGNING_KEY_TYPE_DSA_SHA1)
 			m_Signer.reset (new i2p::crypto::DSASigner (m_SigningPrivateKey, m_Public->GetStandardIdentity ().signingKey));
 		else if (keyType == SIGNING_KEY_TYPE_EDDSA_SHA512_ED25519 && !IsOfflineSignature ())
-			m_Signer.reset (new i2p::crypto::EDDSA25519Signer (m_SigningPrivateKey, m_Public->GetStandardIdentity ().certificate - i2p::crypto::EDDSA25519_PUBLIC_KEY_LENGTH)); // TODO: remove public key check
+			m_Signer.reset (new i2p::crypto::EDDSA25519Signer (m_SigningPrivateKey, m_Public->GetStandardIdentity ().signingKey + (sizeof(Identity::signingKey) - i2p::crypto::EDDSA25519_PUBLIC_KEY_LENGTH))); // TODO: remove public key check
 		else
 		{
 			// public key is not required


### PR DESCRIPTION
Error found during fuzzing.
```
/projects/i2pd/libi2pd/Identity.cpp:584:121: runtime error: index 18446744073709551584 out of bounds for type 'const uint8_t[3]' (aka 'const unsigned char[3]')
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /projects/i2pd/libi2pd/Identity.cpp:584:121 in
```
Calculating signing key offset (aka padding) from Identity::signingKey is more portable than using a negative offset from Identity::certificate.

While the generated binary should be effectively identical, more testing is advised to be sure.
