### PR TITLE
Remove deprecated bind_at_load from macOS

### DIFF
--- a/Makefile.osx
+++ b/Makefile.osx
@@ -5,7 +5,6 @@ DEFINES := -DMAC_OSX
 LDFLAGS := -Wl,-rpath,/usr/local/lib -L/usr/local/lib
 LDFLAGS += -Wl,-dead_strip
 LDFLAGS += -Wl,-dead_strip_dylibs
-LDFLAGS += -Wl,-bind_at_load
 
 ifeq ($(USE_STATIC),yes)
 	LDLIBS = -lz /usr/local/lib/libcrypto.a /usr/local/lib/libssl.a /usr/local/lib/libboost_system.a /usr/local/lib/libboost_date_time.a /usr/local/lib/libboost_filesystem.a /usr/local/lib/libboost_program_options.a -lpthread


### PR DESCRIPTION
Fix `ld: warning: -bind_at_load is deprecated on macOS`