### PR TITLE
Fix manpage typo for ipv4 flag

### DIFF
--- a/debian/i2pd.1
+++ b/debian/i2pd.1
@@ -64,7 +64,7 @@ The network interface to bind to for IPv4 connections
 The network interface to bind to for IPv6 connections
 .TP
 \fB\-\-ipv4=\fR
-Enable communication through ipv6 (\fIenabled\fR by default)
+Enable communication through ipv4 (\fIenabled\fR by default)
 .TP
 \fB\-\-ipv6\fR
 Enable communication through ipv6 (\fIdisabled\fR by default)


### PR DESCRIPTION
A typo in the manpage incorrectly suggests the `ipv4` flag enables `ipv6` communication.
```
       --ipv4=
              Enable communication through ipv6 (enabled by default)

       --ipv6 Enable communication through ipv6 (disabled by default)

```
This PR fixes this typo to be consistent with the [docs](https://i2pd.readthedocs.io/en/latest/user-guide/configuration/#general-options). All other sources of documentation contain the correct description of the `ipv4` flag.