### PR TITLE
build/CMakeLists.txt: enable C language

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -25,7 +25,7 @@ project(
   i2pd
   VERSION ${PROJECT_VERSION}
   HOMEPAGE_URL "https://i2pd.website/"
-  LANGUAGES CXX
+  LANGUAGES C CXX
 )
 
 # configurable options


### PR DESCRIPTION
Detection of libatomic is broken since version 2.47.0 and https://github.com/PurpleI2P/i2pd/commit/b7f0d87dafa8957131b496c38fbe65d8cb378a9d because C language is not enabled anymore:

```
-- Looking for __atomic_fetch_add_4 in atomic
-- Looking for __atomic_fetch_add_4 in atomic - not found CMake Error at cmake_modules/CheckAtomic.cmake:59 (message):
  Host compiler appears to require libatomic, but cannot find it.
Call Stack (most recent call first):
  CMakeLists.txt:54 (include)
```

Indeed if C language is not enabled, the test will be run with the C++ compiler resulting in the following error:

```
Building CXX object CMakeFiles/cmTC_03d01.dir/CheckFunctionExists.cxx.o
        /home/fabrice/buildroot/output/host/bin/x86_64-linux-g++ --sysroot=/home/fabrice/buildroot/output/host/x86_64-buildroot-linux-gnu/sysroot   -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -O1 -g0 -D_FORTIFY_SOURCE=2 -DCHECK_FUNCTION_EXISTS=__atomic_fetch_add_4  -DNDEBUG -o CMakeFiles/cmTC_03d01.dir/CheckFunctionExists.cxx.o -c /home/fabrice/buildroot/output/build/i2pd-2.49.0/build/CMakeFiles/CMakeScratch/TryCompile-NApnv9/CheckFunctionExists.cxx
        <command-line>: error: new declaration ‘char __atomic_fetch_add_4()’ ambiguates built-in declaration ‘unsigned int __atomic_fetch_add_4(volatile void*, unsigned int, int)’ [-fpermissive]
```

whereas with a C compiler, we'll get:

```
Building C object CMakeFiles/cmTC_7e47b.dir/CheckFunctionExists.c.o
        /home/fabrice/buildroot/output/host/bin/x86_64-linux-gcc --sysroot=/home/fabrice/buildroot/output/host/x86_64-buildroot-linux-gnu/sysroot   -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -O1 -g0 -D_FORTIFY_SOURCE=2 -DCHECK_FUNCTION_EXISTS=__atomic_fetch_add_4  -DNDEBUG -o CMakeFiles/cmTC_7e47b.dir/CheckFunctionExists.c.o -c /home/fabrice/buildroot/output/build/i2pd-2.49.0/build/CMakeFiles/CMakeScratch/TryCompile-e0zFMG/CheckFunctionExists.c
        <command-line>: warning: conflicting types for built-in function ‘__atomic_fetch_add_4’; expected ‘unsigned int(volatile void *, unsigned int,  int)’ [-Wbuiltin-declaration-mismatch]
```

Fix #1908