### PR TITLE
Add 'reservedrange' config option check before IsInReservedRange()

### DIFF
--- a/libi2pd/NTCP2.h
+++ b/libi2pd/NTCP2.h
@@ -286,6 +286,8 @@ namespace transport
 			std::unique_ptr<boost::asio::ip::tcp::endpoint> m_ProxyEndpoint;
 			std::shared_ptr<boost::asio::ip::tcp::endpoint> m_Address4, m_Address6, m_YggdrasilAddress;
 
+			bool m_CheckReserved;
+
 		public:
 
 			// for HTTP/I2PControl

--- a/libi2pd/Reseed.cpp
+++ b/libi2pd/Reseed.cpp
@@ -523,6 +523,7 @@ namespace data
 	{
 		i2p::http::URL proxyUrl;
 		std::string proxy; i2p::config::GetOption("reseed.proxy", proxy);
+		bool checkInReserved; i2p::config::GetOption("reservedrange", checkInReserved);
 		// check for proxy url
 		if(proxy.size()) {
 			// parse
@@ -689,7 +690,7 @@ namespace data
 					boost::asio::ip::tcp::endpoint ep = *it;
 					if (
 						(
-							!i2p::util::net::IsInReservedRange(ep.address ()) && (
+							!( checkInReserved && i2p::util::net::IsInReservedRange(ep.address ())) && (
 								(ep.address ().is_v4 () && i2p::context.SupportsV4 ()) ||
 								(ep.address ().is_v6 () && i2p::context.SupportsV6 ())
 							)

--- a/libi2pd/RouterInfo.cpp
+++ b/libi2pd/RouterInfo.cpp
@@ -24,6 +24,7 @@
 #include "NetDb.hpp"
 #include "RouterContext.h"
 #include "RouterInfo.h"
+#include "Config.h"
 
 namespace i2p
 {
@@ -204,6 +205,7 @@ namespace data
 		m_Caps = 0; m_Congestion = eLowCongestion;
 		s.read ((char *)&m_Timestamp, sizeof (m_Timestamp));
 		m_Timestamp = be64toh (m_Timestamp);
+		bool checkInReserved; i2p::config::GetOption("reservedrange", checkInReserved);
 		// read addresses
 		auto addresses = NewAddresses ();
 		uint8_t numAddresses;
@@ -253,7 +255,7 @@ namespace data
 					address->host = boost::asio::ip::address::from_string (value, ecode);
 					if (!ecode && !address->host.is_unspecified ())
 					{
-						if (!i2p::util::net::IsInReservedRange (address->host) ||
+						if (!(checkInReserved && i2p::util::net::IsInReservedRange (address->host)) ||
 						    i2p::util::net::IsYggdrasilAddress (address->host))
 							isHost = true;
 						else

--- a/libi2pd/SSU2.h
+++ b/libi2pd/SSU2.h
@@ -103,6 +103,8 @@ namespace transport
 			i2p::util::MemoryPool<SSU2IncompleteMessage>& GetIncompleteMessagesPool () { return m_IncompleteMessagesPool; };
 			i2p::util::MemoryPool<SSU2IncompleteMessage::Fragment>& GetFragmentsPool () { return m_FragmentsPool; };
 
+			bool GetCheckInReserved() { return m_CheckReserved; };
+
 		private:
 
 			boost::asio::ip::udp::socket& OpenSocket (const boost::asio::ip::udp::endpoint& localEndpoint);
@@ -171,6 +173,8 @@ namespace transport
 			std::unique_ptr<boost::asio::ip::tcp::socket> m_UDPAssociateSocket;
 			std::unique_ptr<boost::asio::ip::udp::endpoint> m_ProxyRelayEndpoint;
 			std::unique_ptr<boost::asio::deadline_timer> m_ProxyConnectRetryTimer;
+
+			bool m_CheckReserved;
 
 		public:
 

--- a/libi2pd/SSU2Session.cpp
+++ b/libi2pd/SSU2Session.cpp
@@ -1471,7 +1471,7 @@ namespace transport
 				ResendHandshakePacket (); // assume we receive
 			return;
 		}
-		if (from != m_RemoteEndpoint && !i2p::util::net::IsInReservedRange (from.address ()))
+		if (from != m_RemoteEndpoint && !(m_Server.GetCheckInReserved() && i2p::util::net::IsInReservedRange (from.address ())))
 		{
 			LogPrint (eLogInfo, "SSU2: Remote endpoint update ", m_RemoteEndpoint, "->", from);
 			m_RemoteEndpoint = from;
@@ -1753,7 +1753,7 @@ namespace transport
 		if (ExtractEndpoint (buf, len, ep))
 		{
 			LogPrint (eLogInfo, "SSU2: Our external address is ", ep);
-			if (!i2p::util::net::IsInReservedRange (ep.address ()))
+			if (!(m_Server.GetCheckInReserved() && i2p::util::net::IsInReservedRange (ep.address ())))
 			{
 				i2p::context.UpdateAddress (ep.address ());
 				// check our port


### PR DESCRIPTION
## Background
While I was testing i2pd within a [test network](https://github.com/h-phil/i2pd-testnet-kubernetes), I tried using the `reservedrange`  option.  But it was not working as expected and after a code search it became apparent that this option is not consistently checked across all components.

## Change
I have added the `reservedrange` option check before any `IsInReservedRange()` call. This implies that i2pd will now verify whether the router is in a private range only if the `reservedrange` option is set to `true` (default).

I compiled and tested my change using the provided [Dockerfile](./contrib/docker/Dockerfile) by changing the `REPO_URL` to my fork (amd64). 

## Notes
- I dont really know the idea behind the existing `reservedrange` option. Maybe it is supposed to only be checked in Transport.cpp?
- While I have some familiarity with programming, my experience with C++ is limited, and I am not actively coding in this language. So I don't know if there are any issues with my changes.
- The change in `libi2pd/RouterInfo.cpp` does not seem very efficient, but I don't know if there is a better solution.

