### PR TITLE
handle 'reservedrange' param properly

### DIFF
--- a/daemon/Daemon.cpp
+++ b/daemon/Daemon.cpp
@@ -160,6 +160,10 @@ namespace util
 
 		int netID; i2p::config::GetOption("netid", netID);
 		i2p::context.SetNetID (netID);
+
+		bool checkReserved; i2p::config::GetOption("reservedrange", checkReserved);
+		i2p::transport::transports.SetCheckReserved(checkReserved);
+
 		i2p::context.Init ();
 
 		i2p::transport::InitTransports ();

--- a/libi2pd/Transports.cpp
+++ b/libi2pd/Transports.cpp
@@ -1200,9 +1200,6 @@ namespace transport
 			else
 				i2p::context.PublishSSU2Address (ssu2port, false, ipv4, ipv6); // unpublish
 		}
-
-		bool checkReserved; i2p::config::GetOption("reservedrange", checkReserved);
-		transports.SetCheckReserved (checkReserved);
 	}
 }
 }

--- a/libi2pd/api.cpp
+++ b/libi2pd/api.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2013-2023, The PurpleI2P Project
+* Copyright (c) 2013-2024, The PurpleI2P Project
 *
 * This file is part of Purple i2pd project and licensed under BSD3
 *
@@ -43,6 +43,9 @@ namespace api
 
 		int netID; i2p::config::GetOption("netid", netID);
 		i2p::context.SetNetID (netID);
+
+		bool checkReserved; i2p::config::GetOption("reservedrange", checkReserved);
+		i2p::transport::transports.SetCheckReserved(checkReserved);
 
 		i2p::context.Init ();
 	}


### PR DESCRIPTION
Initialize `m_CheckReserved` before its first use in `i2p::context.Init ()`.