### PR TITLE
fix HashedStorage::Init exceptions in ios simulator.

### DIFF
--- a/libi2pd/FS.cpp
+++ b/libi2pd/FS.cpp
@@ -256,7 +256,7 @@ namespace fs {
 			auto p = root + i2p::fs::dirSep + prefix1 + chars[i];
 			if (boost::filesystem::exists(p))
 				continue;
-#ifdef TARGET_OS_SIMULATOR
+#if TARGET_OS_SIMULATOR
             // ios simulator fs says it is case sensitive, but it is not
             boost::system::error_code ec;
             if (boost::filesystem::create_directory(p, ec))


### PR DESCRIPTION
On iOS simulator `HashedStorage::Init` throws an exception `file exists` cause FS is case insensitive.
In order to fix this we use non-throwing variant of `boost::filesystem::create_directory` and ignore `boost::system::errc::file_exists` error code.