### PR TITLE
select maximum SSU2 queue size depending on RTT value

### DIFF
--- a/libi2pd/I2NPProtocol.h
+++ b/libi2pd/I2NPProtocol.h
@@ -152,7 +152,9 @@ namespace tunnel
 	const size_t I2NP_MAX_MESSAGE_SIZE = 62708;
 	const size_t I2NP_MAX_SHORT_MESSAGE_SIZE = 4096;
 	const size_t I2NP_MAX_MEDIUM_MESSAGE_SIZE = 16384;
-	const unsigned int I2NP_MESSAGE_LOCAL_EXPIRATION_TIMEOUT = 2000000; // in microseconds
+	const unsigned int I2NP_MESSAGE_LOCAL_EXPIRATION_TIMEOUT_FACTOR = 3; // multiples of RTT
+	const unsigned int I2NP_MESSAGE_LOCAL_EXPIRATION_TIMEOUT_MIN = 200000; // in microseconds
+	const unsigned int I2NP_MESSAGE_LOCAL_EXPIRATION_TIMEOUT_MAX = 2000000; // in microseconds
 	const unsigned int I2NP_MESSAGE_EXPIRATION_TIMEOUT = 8000; // in milliseconds (as initial RTT)
 	const unsigned int I2NP_MESSAGE_CLOCK_SKEW = 60*1000; // 1 minute in milliseconds
 
@@ -162,10 +164,10 @@ namespace tunnel
 		size_t len, offset, maxLen;
 		std::shared_ptr<i2p::tunnel::InboundTunnel> from;
 		std::function<void ()> onDrop;
-		uint64_t localExpiration; // monotonic microseconds
+		uint64_t enqueueTime; // monotonic microseconds
 
 		I2NPMessage (): buf (nullptr), len (I2NP_HEADER_SIZE + 2),
-			offset(2), maxLen (0), from (nullptr), localExpiration(0) {}; // reserve 2 bytes for NTCP header
+			offset(2), maxLen (0), from (nullptr), enqueueTime (0) {}; // reserve 2 bytes for NTCP header
 
 		// header accessors
 		uint8_t * GetHeader () { return GetBuffer (); };
@@ -175,8 +177,9 @@ namespace tunnel
 		void SetMsgID (uint32_t msgID) { htobe32buf (GetHeader () + I2NP_HEADER_MSGID_OFFSET, msgID); };
 		uint32_t GetMsgID () const { return bufbe32toh (GetHeader () + I2NP_HEADER_MSGID_OFFSET); };
 		void SetExpiration (uint64_t expiration) { htobe64buf (GetHeader () + I2NP_HEADER_EXPIRATION_OFFSET, expiration); };
-		void SetLocalExpiration (uint64_t expiration) { localExpiration = expiration; };
+		void SetEnqueueTime (uint64_t mts) { enqueueTime = mts; };
 		uint64_t GetExpiration () const { return bufbe64toh (GetHeader () + I2NP_HEADER_EXPIRATION_OFFSET); };
+		uint64_t GetEnqueueTime () const { return enqueueTime; };
 		void SetSize (uint16_t size) { htobe16buf (GetHeader () + I2NP_HEADER_SIZE_OFFSET, size); };
 		uint16_t GetSize () const { return bufbe16toh (GetHeader () + I2NP_HEADER_SIZE_OFFSET); };
 		void UpdateSize () { SetSize (GetPayloadLength ()); };
@@ -267,8 +270,6 @@ namespace tunnel
 		void RenewI2NPMessageHeader ();
 		bool IsExpired () const;
 		bool IsExpired (uint64_t ts) const; // in milliseconds
-		bool IsLocalExpired (uint64_t mts) const { return mts > localExpiration; }; // monotonic microseconds
-		bool IsLocalSemiExpired (uint64_t mts) const { return mts > localExpiration - I2NP_MESSAGE_LOCAL_EXPIRATION_TIMEOUT / 2; }; // monotonic microseconds
 
 		void Drop () { if (onDrop) { onDrop (); onDrop = nullptr; }; }
 	};

--- a/libi2pd/SSU2Session.h
+++ b/libi2pd/SSU2Session.h
@@ -359,6 +359,8 @@ namespace transport
 			i2p::I2NPMessagesHandler m_Handler;
 			bool m_IsDataReceived;
 			double m_RTT;
+			int m_MsgLocalExpirationTimeout;
+			int m_MsgLocalSemiExpirationTimeout;
 			size_t m_WindowSize, m_RTO;
 			uint32_t m_RelayTag; // between Bob and Charlie
 			OnEstablished m_OnEstablished; // callback from Established


### PR DESCRIPTION
This allows to set up to 10 times lower SSU2 message queue limit.