### PR TITLE
change exec path to /usr/bin in i2pd.service

### DIFF
--- a/contrib/i2pd.service
+++ b/contrib/i2pd.service
@@ -11,7 +11,7 @@ RuntimeDirectoryMode=0700
 LogsDirectory=i2pd
 LogsDirectoryMode=0700
 Type=forking
-ExecStart=/usr/sbin/i2pd --conf=/etc/i2pd/i2pd.conf --tunconf=/etc/i2pd/tunnels.conf --tunnelsdir=/etc/i2pd/tunnels.conf.d --pidfile=/run/i2pd/i2pd.pid --logfile=/var/log/i2pd/i2pd.log --daemon --service
+ExecStart=/usr/bin/i2pd --conf=/etc/i2pd/i2pd.conf --tunconf=/etc/i2pd/tunnels.conf --tunnelsdir=/etc/i2pd/tunnels.conf.d --pidfile=/run/i2pd/i2pd.pid --logfile=/var/log/i2pd/i2pd.log --daemon --service
 ExecReload=/bin/sh -c "kill -HUP $MAINPID"
 PIDFile=/run/i2pd/i2pd.pid
 ### Uncomment, if auto restart needed


### PR DESCRIPTION
CMakeLists.txt already installs i2pd to CMAKE_INSTALL_BINDIR, which is normally /usr/bin.

Change i2pd.service to match the behavior of cmake build script.