### PR TITLE
manage netDb requests more frequently

### DIFF
--- a/libi2pd/NetDb.cpp
+++ b/libi2pd/NetDb.cpp
@@ -114,7 +114,7 @@ namespace data
 		{
 			try
 			{
-				auto msg = m_Queue.GetNextWithTimeout (15000); // 15 sec
+				auto msg = m_Queue.GetNextWithTimeout (1000); // 1 sec
 				if (msg)
 				{
 					int numMsgs = 0;
@@ -467,7 +467,7 @@ namespace data
 					return;
 				}
 				m_FloodfillBootstrap = ri;
-				ReseedFromFloodfill(*ri);
+				//ReseedFromFloodfill(*ri);
 				// don't try reseed servers if trying to bootstrap from floodfill
 				return;
 			}

--- a/libi2pd/NetDbRequests.h
+++ b/libi2pd/NetDbRequests.h
@@ -21,9 +21,9 @@ namespace i2p
 namespace data
 {
 	const size_t MAX_NUM_REQUEST_ATTEMPTS = 7;
-	const uint64_t MANAGE_REQUESTS_INTERVAL = 15; // in seconds
+	const uint64_t MANAGE_REQUESTS_INTERVAL = 1; // in seconds
 	const uint64_t MIN_REQUEST_TIME = 5; // in seconds
-	const uint64_t MAX_REQUEST_TIME = MAX_NUM_REQUEST_ATTEMPTS*MANAGE_REQUESTS_INTERVAL;
+	const uint64_t MAX_REQUEST_TIME = MAX_NUM_REQUEST_ATTEMPTS * (MIN_REQUEST_TIME + MANAGE_REQUESTS_INTERVAL);
 	
 	class RequestedDestination
 	{


### PR DESCRIPTION
Should produce less spiky load on network.

Before _(lookup requests per second)_:
![i2pd_lookup_reqs_pulse](https://github.com/PurpleI2P/i2pd/assets/1242858/88d0d6ae-1e2c-4953-a89d-4554c98aeeb1)

After:
![i2pd_lookup_reqs_pulse2](https://github.com/PurpleI2P/i2pd/assets/1242858/cc6a2a27-fa30-48d6-b799-6ed0aa84e970)

Commented out `ReseedFromFloodfill` is a bonus.
Surpisingly, without this call this feature works well enough, while with it - does not.