### PR TITLE
Fix UPnP: error 2

### DIFF
--- a/daemon/UPnP.cpp
+++ b/daemon/UPnP.cpp
@@ -112,7 +112,7 @@ namespace transport
 
 		err = UPNP_GetValidIGD (m_Devlist, &m_upnpUrls, &m_upnpData, m_NetworkAddr, sizeof (m_NetworkAddr));
 		m_upnpUrlsInitialized=err!=0;
-		if (err == UPNP_IGD_VALID_CONNECTED)
+		if (err == UPNP_IGD_VALID_CONNECTED || err == UPNP_IGD_VALID_NOT_CONNECTED)
 		{
 			err = UPNP_GetExternalIPAddress (m_upnpUrls.controlURL, m_upnpData.first.servicetype, m_externalIPAddress);
 			if(err != UPNPCOMMAND_SUCCESS)


### PR DESCRIPTION
Проблема: 
UPnP: Unable to find valid Internet Gateway Device: error 2

Подробнее:
Предположительно, проблема в нестандартном IGD - https://github.com/dappnode/DNP_DAPPMANAGER/issues/312 

Ручной форвард в miniupnpc выдает "Not connected IGD":

```
$ upnpc -r 11111 11111 UDP
upnpc : miniupnpc library test client, version .
...
List of UPNP devices found on the network :
 desc: http://192.168.31.1:5351/rootDesc.xml
 st: urn:schemas-upnp-org:device:InternetGatewayDevice:1

Found a (not connected?) IGD : http://192.168.31.1:5351/ctl/IPConn
No valid UPNP Internet Gateway Device found.
```
Однако с флагом -i (игнор) все корректно форвардится:

```
$ upnpc -i -r 11111 11111 UDP

upnpc : miniupnpc library test client, version .
...
List of UPNP devices found on the network :
 desc: http://192.168.31.1:5351/rootDesc.xml
 st: urn:schemas-upnp-org:device:InternetGatewayDevice:1

Found a (not connected?) IGD : http://192.168.31.1:5351/ctl/IPConn
Trying to continue anyway
Local LAN ip address : 192.168.31.*
ExternalIPAddress = *.*.*.*
InternalIP:Port = 192.168.31.*:11111
external *.*.*.*:11111 UDP is redirected to internal 192.168.31.*:11111 (duration=0)
```

В [i2pd/daemon/UPnP.h](https://github.com/PurpleI2P/i2pd/blob/46c72a7137cfddafee5aaf46fc0243498f39b4ca/daemon/UPnP.h#L36) случай с not connected соответствует:
`
UPNP_IGD_VALID_NOT_CONNECTED = 2`

Лог i2pd до фикса:

```
22:01:33@480/none - i2pd v2.53.1 (0.9.63) starting...
22:01:35@827/warn - Transports: 15 ephemeral keys generated at the time
22:01:35@106/error - UPnP: Unable to find valid Internet Gateway Device: error 2
```

После:
```
$ ./i2pd 
22:02:51@613/none - i2pd v2.53.1 (0.9.63) starting...
success022:02:54@33/warn - Transports: 15 ephemeral keys generated at the time
22:02:54@581/error - UPnP: Found Internet Gateway Device http://192.168.31.1:5351/ctl/IPConn
```
Форвард проходит.
