### PR TITLE
Added example docker-compose.yml

### DIFF
--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  i2pd:
+    container_name: i2pd2
+    image: purplei2p/i2pd
+    #optional
+    entrypoint: ["./entrypoint.sh", "--loglevel error"]
+    ports:
+      - 127.0.0.1:7656:7656
+      - 127.0.0.1:7070:7070
+      - 127.0.0.1:4444:4444
+    volumes:
+      - /path/to/i2pd/data:/home/i2pd/data                 # make sure data directory and it's contents are owned by 100:65533
+      - /path/to/i2pd/i2pd_certificates:/i2pd_certificates # make sure i2pd_certificates is owned by root:root and 755 permissions on the directory


### PR DESCRIPTION
I added an example docker-compose.yml file that I used in my own setup to persist the router's data because I read "You must save the router's data (netdb, configuration, etc.) between runs of the router. I2P does not work well if you must reseed each startup, and that's a huge load on our reseed servers, and not very good for anonymity either. Even if you bundle router infos, I2P needs saved profile data for best performance. Without persistence, your users will have a poor startup experience."