### PR TITLE
Please disable LibreSSL workaround when LibreSSL version >= 4.0.0

### DIFF
--- a/libi2pd/Crypto.cpp
+++ b/libi2pd/Crypto.cpp
@@ -997,7 +997,7 @@ namespace crypto
 		}
 		else
 		{
-#if defined(LIBRESSL_VERSION_NUMBER)
+#if defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x4000000fL
 			std::vector<uint8_t> m(msgLen + 16);
 			if (msg == buf)
 			{	


### PR DESCRIPTION
Hello,

Commit 0c924836cf9ae04cd12e2647e6edd5c0f896ff7b allowed to compile i2pd with LibreSSL >= 3.9, but this workaround is not necessary anymore with LibreSSL 4.0.0, and could needlessly leave copies of secrets in memory.

LibreSSL 4.0.0 has been released last month and is now the version used by OpenBSD `-stable` (7.6, which was released recently).

This pull request simply disables this workaround when LibreSSL version is equal to, or greater than 4.0.0. In fact, it is just a copy from the patch introduced by Theo Buehler, from the OpenBSD project, when he updated the `net/i2pd` port to the latest version : https://github.com/openbsd/ports/commit/17578402f47dff36dde0f975e9df1c7e2830b95f
