### PR TITLE
debian/changelog: Add leading space

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ i2pd (2.54.0-1) unstable; urgency=medium
 
   * updated to version 2.54.0/0.9.64
 
--- orignal <orignal@i2pmail.org>  Sun, 6 Oct 2024 16:00:00 +0000
+ -- orignal <orignal@i2pmail.org>  Sun, 6 Oct 2024 16:00:00 +0000
 
 i2pd (2.53.1-1) unstable; urgency=medium
 


### PR DESCRIPTION
Fix deb package build warnings
```
$ debuild --no-tgz-check -us -uc -b -j2
debuild: warning:     debian/changelog(l5): badly formatted heading line
LINE: -- orignal <orignal@i2pmail.org>  Sun, 6 Oct 2024 16:00:00 +0000
debuild: warning:     debian/changelog(l7): found start of entry where expected more change data or trailer
LINE: i2pd (2.53.1-1) unstable; urgency=medium
debuild: warning:     debian/changelog(l7): found end of file where expected more change data or trailer
```

