### PR TITLE
Fix test-aeadchacha20poly1305

### DIFF
--- a/tests/test-aeadchacha20poly1305.cpp
+++ b/tests/test-aeadchacha20poly1305.cpp
@@ -54,7 +54,8 @@ int main ()
 	// test encryption of multiple buffers
 	memcpy (buf, text, 114);
 	std::vector<std::pair<uint8_t*, std::size_t> > bufs{ std::make_pair (buf, 20), std::make_pair (buf + 20, 10), std::make_pair (buf + 30, 70), std::make_pair (buf + 100, 14) };
-	i2p::crypto::AEADChaCha20Poly1305Encrypt (bufs, key, nonce, buf + 114);
+	i2p::crypto::AEADChaCha20Poly1305Encryptor encryptor;
+	encryptor.Encrypt (bufs, key, nonce, buf + 114);
 	i2p::crypto::AEADChaCha20Poly1305 (buf, 114, nullptr, 0, key, nonce, buf1, 114, false);
 	assert (memcmp (buf1, text, 114) == 0);
 }


### PR DESCRIPTION
The function `i2pd::crypto::AEADChaCha20Poly1305Encrypt()` was [changed](https://github.com/PurpleI2P/i2pd/commit/3534b9c499f3d0e3ae699232f6a21de5285a49cb) to the overloaded method `Encrypt()` in a new class object named `i2pd::crypto::AEADChaCha20Poly1305Encrypt`.

test-aeadchacha20poly1305 needs to be updated for this.

Fixes #2143.
