### PR TITLE
Fix uninitialized variables

### DIFF
--- a/libi2pd/Destination.cpp
+++ b/libi2pd/Destination.cpp
@@ -195,7 +195,7 @@ namespace client
 			m_IsPublic = itr->second != "true";
 		}
 
-		int inLen, outLen, inQuant, outQuant, numTags, minLatency, maxLatency;
+		int inLen = 0, outLen = 0, inQuant = 0, outQuant = 0, numTags = 0, minLatency = 0, maxLatency = 0;
 		std::map<std::string, int&> intOpts = {
 			{I2CP_PARAM_INBOUND_TUNNEL_LENGTH, inLen},
 			{I2CP_PARAM_OUTBOUND_TUNNEL_LENGTH, outLen},


### PR DESCRIPTION
Fixes

```
libi2pd/Destination.cpp:200:39: error: Uninitialized variable: inLen [uninitvar]
   {I2CP_PARAM_INBOUND_TUNNEL_LENGTH, inLen},
                                      ^
libi2pd/Destination.cpp:201:40: error: Uninitialized variable: outLen [uninitvar]
   {I2CP_PARAM_OUTBOUND_TUNNEL_LENGTH, outLen},
                                       ^
libi2pd/Destination.cpp:202:42: error: Uninitialized variable: inQuant [uninitvar]
   {I2CP_PARAM_INBOUND_TUNNELS_QUANTITY, inQuant},
                                         ^
libi2pd/Destination.cpp:203:43: error: Uninitialized variable: outQuant [uninitvar]
   {I2CP_PARAM_OUTBOUND_TUNNELS_QUANTITY, outQuant},
                                          ^
libi2pd/Destination.cpp:204:30: error: Uninitialized variable: numTags [uninitvar]
   {I2CP_PARAM_TAGS_TO_SEND, numTags},
                             ^
libi2pd/Destination.cpp:205:36: error: Uninitialized variable: minLatency [uninitvar]
   {I2CP_PARAM_MIN_TUNNEL_LATENCY, minLatency},
                                   ^
libi2pd/Destination.cpp:206:36: error: Uninitialized variable: maxLatency [uninitvar]
   {I2CP_PARAM_MAX_TUNNEL_LATENCY, maxLatency}
                                   ^
```