### PR TITLE
fix uninitialized variable block.tunnelID

### DIFF
--- a/libi2pd/Tunnel.cpp
+++ b/libi2pd/Tunnel.cpp
@@ -300,22 +300,28 @@ namespace tunnel
 	void OutboundTunnel::SendTunnelDataMsgTo (const uint8_t * gwHash, uint32_t gwTunnel, std::shared_ptr<i2p::I2NPMessage> msg)
 	{
 		TunnelMessageBlock block;
+		block.tunnelID = 0; // Initialize tunnelID to a default value
+	
 		if (gwHash)
 		{
 			block.hash = gwHash;
 			if (gwTunnel)
 			{
 				block.deliveryType = eDeliveryTypeTunnel;
-				block.tunnelID = gwTunnel;
+				block.tunnelID = gwTunnel; // Set tunnelID only if gwTunnel is non-zero
 			}
 			else
+			{
 				block.deliveryType = eDeliveryTypeRouter;
+			}
 		}
 		else
+		{
 			block.deliveryType = eDeliveryTypeLocal;
+		}
+	
 		block.data = msg;
-
-		SendTunnelDataMsgs ({block});
+		SendTunnelDataMsgs({block});
 	}
 
 	void OutboundTunnel::SendTunnelDataMsgs (const std::vector<TunnelMessageBlock>& msgs)


### PR DESCRIPTION
Fixes
```
libi2pd/Tunnel.cpp:318:24: warning: Uninitialized variable: block.tunnelID [uninitvar]
```