### PR TITLE
Fix problem with i2pd service

### DIFF
--- a/contrib/i2pd.service
+++ b/contrib/i2pd.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=I2P Router written in C++
 Documentation=man:i2pd(1) https://i2pd.readthedocs.io/en/latest/
-After=network.target
+After=network-online.target
 
 [Service]
 User=i2pd

--- a/contrib/i2pd.service
+++ b/contrib/i2pd.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=I2P Router written in C++
 Documentation=man:i2pd(1) https://i2pd.readthedocs.io/en/latest/
-After=network-online.target
+Wants=network.target
+After=network.target network-online.target
 
 [Service]
 User=i2pd


### PR DESCRIPTION
My case: 

When changing the address of the web interface or http/socks proxy to `192.168.X.X` and after restarting the system, an error pops up: 

```
XX:XX:XX:XX@365/critical - Daemon: Failed to start Webconsole: bind: Cannot assign requested address
XX:XX:XX:XX@365/critical - Clients: Exception in HTTP Proxy: bind: Cannot assign requested address
XX:XX:XX:XX@365/critical - Clients: Exception in SOCKS Proxy: bind: Cannot assign requested address
```

This PR fixes the problem