### PR TITLE
tests: fix test-base-64

### DIFF
--- a/tests/test-base-64.cpp
+++ b/tests/test-base-64.cpp
@@ -11,8 +11,7 @@ int main() {
   char out[16];
 
   /* bytes -> b64 */
-  assert(ByteStreamToBase64(NULL, 0, NULL, 0) == 0);
-  assert(ByteStreamToBase64(NULL, 0, out, sizeof(out)) == 0);
+  assert(ByteStreamToBase64(NULL, 0) == "");
 
   assert(Base64EncodingBufferSize(2)  == 4);
   assert(Base64EncodingBufferSize(4)  == 8);
@@ -23,19 +22,20 @@ int main() {
   assert(Base64EncodingBufferSize(12) == 16);
   assert(Base64EncodingBufferSize(13) == 20);
 
-  assert(ByteStreamToBase64((uint8_t *) in, in_len, out, sizeof(out)) == 8);
-  assert(memcmp(out, "dGVzdA==", 8) == 0);
+  const std::string out_str(ByteStreamToBase64((uint8_t *) in, in_len));
+  assert(out_str.size() == 8);
+  assert(out_str == "dGVzdA==");
 
   /* b64 -> bytes */
-  assert(Base64ToByteStream(NULL, 0, NULL, 0) == 0);
-  assert(Base64ToByteStream(NULL, 0, (uint8_t *) out, sizeof(out)) == 0);
+  assert(Base64ToByteStream("", NULL, 0) == 0);
+  assert(Base64ToByteStream("", (uint8_t *) out, sizeof(out)) == 0);
 
   in = "dGVzdA=="; /* valid b64 */
-  assert(Base64ToByteStream(in, strlen(in), (uint8_t *) out, sizeof(out)) == 4);
+  assert(Base64ToByteStream(in, (uint8_t *) out, sizeof(out)) == 4);
   assert(memcmp(out, "test", 4) == 0);
 
   in = "dGVzdA=";  /* invalid b64 : not padded */
-  assert(Base64ToByteStream(in, strlen(in), (uint8_t *) out, sizeof(out)) == 0);
+  assert(Base64ToByteStream(in, (uint8_t *) out, sizeof(out)) == 0);
 
   in = "dG/z.A=="; /* invalid b64 : char not from alphabet */
 //  assert(Base64ToByteStream(in, strlen(in), (uint8_t *) out, sizeof(out)) == 0);


### PR DESCRIPTION
`test-base-64` was not updated after the following commits:

https://github.com/PurpleI2P/i2pd/commit/93cc810f2987cc90b7a4f8699655af43b36c6c23
https://github.com/PurpleI2P/i2pd/commit/bbf5c1655a5f331b36cc7e16ad0bba86bb36eed4

This leads to errors like:

```
In file included from /usr/include/c++/15.1.1/cassert:46,
                 from /build/i2pd/src/i2pd-2.57.0/tests/test-base-64.cpp:1:
/build/i2pd/src/i2pd-2.57.0/tests/test-base-64.cpp: In function ‘int main()’: /build/i2pd/src/i2pd-2.57.0/tests/test-base-64.cpp:14:28: error: too many arguments to function ‘std::string i2p::data::ByteStreamToBase64(const uint8_t*, size_t)’
   14 |   assert(ByteStreamToBase64(NULL, 0, NULL, 0) == 0);
      |          ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
```

and:

```
In file included from /build/i2pd/src/i2pd-2.57.0/tests/test-base-64.cpp:4: /build/i2pd/src/i2pd-2.57.0/build/../libi2pd/Base.h:21:21: note: declared here
   21 |         std::string ByteStreamToBase64 (const uint8_t * InBuffer, size_t InCount);
      |                     ^~~~~~~~~~~~~~~~~~
/build/i2pd/src/i2pd-2.57.0/tests/test-base-64.cpp:14:47: error: no match for ‘operator==’ (operand types are ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} and ‘int’)
   14 |   assert(ByteStreamToBase64(NULL, 0, NULL, 0) == 0);
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^~ ~
      |                            |                     |
      |                            |                     int
      |                            std::string {aka std::__cxx11::basic_string<char>}
```

among others.