### PR TITLE
Mycelium network support

### DIFF
--- a/libi2pd/util.cpp
+++ b/libi2pd/util.cpp
@@ -636,6 +636,17 @@ namespace net
 		return IsYggdrasilAddress (addr.to_v6 ().to_bytes ().data ());
 	}
 
+	static bool IsMyceliumAddress (const uint8_t addr[16])
+	{
+		return addr[0] == 0x04 || addr[0] == 0x05;
+	}
+
+	bool IsMyceliumAddress (const boost::asio::ip::address& addr)
+	{
+		if (!addr.is_v6 ()) return false;
+		return IsMyceliumAddress (addr.to_v6 ().to_bytes ().data ());
+	}
+
 	bool IsPortInReservedRange (const uint16_t port) noexcept
 	{
 		// https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers (Feb. 3, 2023) + Tor browser (9150)

--- a/libi2pd/util.h
+++ b/libi2pd/util.h
@@ -275,6 +275,7 @@ namespace util
 		bool IsLocalAddress (const boost::asio::ip::address& addr);
 		bool IsInReservedRange (const boost::asio::ip::address& host);
 		bool IsYggdrasilAddress (const boost::asio::ip::address& addr);
+		bool IsMyceliumAddress (const boost::asio::ip::address& addr);
 		bool IsPortInReservedRange (const uint16_t port) noexcept;
 	}
 }


### PR DESCRIPTION
This is just the initial commit that implements the Mycelium network condition, which is quite similar to Yggdrasil but operates in the `0400::/7` range:

https://github.com/threefoldtech/mycelium

I have a few questions:

1. does it make sense to make this contribution?
2. is the `openssl` branch the correct one to fork the upstream?

UPD. While working on the second part, I found only one issue related to supporting multiple mesh networks: the router uses a single registry called `eNTCP2V6MeshIdx`. It might make sense to rename Yggdrasil members to "Mesh" or to separate the indexes into different stacks. Configuration options would depend on this implementation, as there are too many potential networks possible to make the router extensible without increasing the codebase.