### PR TITLE
fix typos in i2pd.conf

### DIFF
--- a/contrib/i2pd.conf
+++ b/contrib/i2pd.conf
@@ -143,8 +143,8 @@ ipv6 = false
 # address = 127.0.0.1
 # port = 4444
 ## Optional keys file for proxy local destination (default: transient-proxy)
-## "Transient" means it changes on every new app launch 
-# If you want not change address then set like http-proxy-keys.dat
+## "Transient" means it changes on every new app launch
+## If you want not change address then set like http-proxy-keys.dat
 # keys = http-proxy-keys.dat
 ## Enable address helper for adding .i2p domains with "jump URLs" (default: true)
 ## You should disable this feature if your i2pd HTTP Proxy is public,
@@ -161,8 +161,8 @@ ipv6 = false
 # address = 127.0.0.1
 # port = 4447
 ## Optional keys file for proxy local destination (default: transient-proxy)
-# "Transient" means it changes on every new app launch 
-# If you don't want the address to change, set a file name like socks-proxy-keys.dat
+## "Transient" means it changes on every new app launch
+## If you don't want the address to change, set a file name like socks-proxy-keys.dat
 # keys = socks-proxy-keys.dat
 ## Socks outproxy. Example below is set to use Tor for all connections except i2p
 ## Enable SOCKS outproxy (works only with SOCKS4, default: false)


### PR DESCRIPTION
Добавил несколько '#' для соответствия описанию: 
```
## Lines that begin with "## " try to explain what's going on. Lines
## that begin with just "#" are disabled commands: you can enable them
## by removing the "#" symbol.
```
