### PR TITLE
 Add network error and testing metrics to i2pcontrol

### DIFF
--- a/daemon/I2PControlHandlers.cpp
+++ b/daemon/I2PControlHandlers.cpp
@@ -40,6 +40,8 @@ namespace client
 		m_RouterInfoHandlers["i2p.router.net.status.v6"]             = &I2PControlHandlers::NetStatusV6Handler;
 		m_RouterInfoHandlers["i2p.router.net.error"]                 = &I2PControlHandlers::NetErrorHandler;
 		m_RouterInfoHandlers["i2p.router.net.error.v6"]              = &I2PControlHandlers::NetErrorV6Handler;
+		m_RouterInfoHandlers["i2p.router.net.testing"]               = &I2PControlHandlers::NetTestingHandler;
+		m_RouterInfoHandlers["i2p.router.net.testing.v6"]            = &I2PControlHandlers::NetTestingV6Handler;
 		m_RouterInfoHandlers["i2p.router.net.tunnels.participating"] = &I2PControlHandlers::TunnelsParticipatingHandler;
 		m_RouterInfoHandlers["i2p.router.net.tunnels.successrate"]   = &I2PControlHandlers::TunnelsSuccessRateHandler;
 		m_RouterInfoHandlers["i2p.router.net.total.received.bytes"]  = &I2PControlHandlers::NetTotalReceivedBytes;
@@ -153,6 +155,16 @@ namespace client
 	void I2PControlHandlers::NetErrorV6Handler (std::ostringstream& results)
 	{
 		InsertParam (results, "i2p.router.net.error.v6", (int)i2p::context.GetErrorV6 ());
+	}
+
+	void I2PControlHandlers::NetTestingHandler (std::ostringstream& results)
+	{
+		InsertParam (results, "i2p.router.net.testing", (int)i2p::context.GetTesting ());
+	}
+
+	void I2PControlHandlers::NetTestingV6Handler (std::ostringstream& results)
+	{
+		InsertParam (results, "i2p.router.net.testing.v6", (int)i2p::context.GetTestingV6 ());
 	}
 
 	void I2PControlHandlers::TunnelsParticipatingHandler (std::ostringstream& results)

--- a/daemon/I2PControlHandlers.h
+++ b/daemon/I2PControlHandlers.h
@@ -50,6 +50,8 @@ namespace client
 			void NetStatusV6Handler (std::ostringstream& results);
 			void NetErrorHandler (std::ostringstream& results);
 			void NetErrorV6Handler (std::ostringstream& results);
+			void NetTestingHandler (std::ostringstream& results);
+			void NetTestingV6Handler (std::ostringstream& results);
 			void TunnelsParticipatingHandler (std::ostringstream& results);
 			void TunnelsSuccessRateHandler (std::ostringstream& results);
 			void InboundBandwidth1S (std::ostringstream& results);


### PR DESCRIPTION
The "Network Status" label in the web console is composed of three underlying metrics:

1. Status (e.g., OK, Firewalled)
2. Error (e.g., SymmetricNAT, ClockSkew)
3. Testing (Is a test currently running?)

https://github.com/PurpleI2P/i2pd/blob/7bc7cdec36f721bffdd7047fb3957891ca1abb44/daemon/HTTPServer.cpp#L294-L296

Currently, out of the three underlying metrics, the i2pcontrol API only exposes the status. This PR adds the missing error and testing metrics (and their IPv6 variants).

