### PR TITLE
Handle all lowercase `content-length` header in I2PControl

### DIFF
--- a/daemon/I2PControl.cpp
+++ b/daemon/I2PControl.cpp
@@ -15,6 +15,7 @@
 // Use global placeholders from boost introduced when local_time.hpp is loaded
 #define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/property_tree/json_parser.hpp>
+#include <boost/algorithm/string.hpp>
 
 #include "FS.h"
 #include "Log.h"
@@ -247,12 +248,8 @@ namespace client
 					{
 						std::getline(ss, header);
 						auto colon = header.find (':');
-						if (colon != std::string::npos)
-						{
-							auto name = header.substr (0, colon);
-							if (name == "Content-Length" || name == "content-length")
-								contentLength = std::stoi (header.substr (colon + 1));
-						}
+						if (colon != std::string::npos && boost::iequals (header.substr (0, colon), "Content-Length"))
+							contentLength = std::stoi (header.substr (colon + 1));
 					}
 					if (ss.eof ())
 					{

--- a/daemon/I2PControl.cpp
+++ b/daemon/I2PControl.cpp
@@ -247,8 +247,12 @@ namespace client
 					{
 						std::getline(ss, header);
 						auto colon = header.find (':');
-						if (colon != std::string::npos && header.substr (0, colon) == "Content-Length")
-							contentLength = std::stoi (header.substr (colon + 1));
+						if (colon != std::string::npos)
+						{
+							auto name = header.substr (0, colon);
+							if (name == "Content-Length" || name == "content-length")
+								contentLength = std::stoi (header.substr (colon + 1));
+						}
 					}
 					if (ss.eof ())
 					{


### PR DESCRIPTION
It now accepts both "Content-Length" and "content-length" header names.

The previous code only matched "Content-Length" exactly, so requests with lowercase "content-length" failed with JSON parse errors when payloads exceeded the initial 1024-byte buffer. Small payloads worked because if the entire request fit in the 1024-byte buffer, no additional read was needed and "content-length" was never checked. The bug only appeared when additional reads were required.

I encountered this issue while testing larger payloads using the Rust `reqwest` library. There is no way to control this header with `reqwest`.