### PR TITLE
feat: change published port if full-cone

### DIFF
--- a/libi2pd/SSU2Session.cpp
+++ b/libi2pd/SSU2Session.cpp
@@ -2444,7 +2444,9 @@ namespace transport
 												session->SendPeerTest (6, buf + offset, len - offset, addr, true);
 											}	
 											SetTestingState (false);
-											if (GetRouterStatus () != eRouterStatusFirewalled && addr->IsPeerTesting ())
+											if (i2p::context.GetError () == eRouterErrorFullConeNAT)
+												SetRouterStatus (eRouterStatusOK);
+											else if (GetRouterStatus () != eRouterStatusFirewalled && addr->IsPeerTesting ())
 											{
 												SetRouterStatus (eRouterStatusFirewalled);
 												session->SetStatusChanged ();

--- a/libi2pd/SSU2Session.cpp
+++ b/libi2pd/SSU2Session.cpp
@@ -1831,7 +1831,8 @@ namespace transport
 				bool isV4 = ep.address ().is_v4 ();
 				if (ep.port () != m_Server.GetPort (isV4))
 				{
-					LogPrint (eLogInfo, "SSU2: Our port ", ep.port (), " received from ", m_RemoteEndpoint, " is different from ", m_Server.GetPort (isV4));
+					// TODO: External port detected incorrectly.
+					// LogPrint (eLogInfo, "SSU2: Our port ", ep.port (), " received from ", m_RemoteEndpoint, " is different from ", m_Server.GetPort (isV4));
 					if (isV4)
 					{
 						if (i2p::context.GetTesting ())

--- a/libi2pd/SSU2Session.cpp
+++ b/libi2pd/SSU2Session.cpp
@@ -1838,14 +1838,20 @@ namespace transport
 						if (i2p::context.GetTesting ())
 							i2p::context.SetError (eRouterErrorSymmetricNAT);
 						else if (m_State == eSSU2SessionStatePeerTest)
+						{
 							i2p::context.SetError (eRouterErrorFullConeNAT);
+							i2p::context.UpdatePort((int)ep.port ());
+						}
 					}
 					else
 					{
 						if (i2p::context.GetTestingV6 ())
 							i2p::context.SetErrorV6 (eRouterErrorSymmetricNAT);
 						else if (m_State == eSSU2SessionStatePeerTest)
+						{
 							i2p::context.SetErrorV6 (eRouterErrorFullConeNAT);
+							i2p::context.UpdatePort((int)ep.port ());
+						}
 					}
 				}
 				else


### PR DESCRIPTION
If we're behind full-cone NAT; update our published port number while keeping our listening port number same, so other peers can connect us when we're behind NAT.

Depends on: #2243 #2273