### PR TITLE
fix: update ports separately for NTCP2 and SSU2

### DIFF
--- a/libi2pd/SSU2Session.cpp
+++ b/libi2pd/SSU2Session.cpp
@@ -1838,8 +1838,9 @@ namespace transport
 							i2p::context.SetError (eRouterErrorSymmetricNAT);
 						else if (m_State == eSSU2SessionStatePeerTest)
 						{
-							i2p::context.SetError (eRouterErrorFullConeNAT);
-							i2p::context.UpdatePort((int)ep.port ());
+							i2p::context.SetError (eRouterErrorFullConeNAT); // TODO: Full-Cone NAT detection isn't working.
+							// i2p::context.PublishNTCP2Address (TCP_PORT, true, true, false, false); // TODO: TCP_PORT to be filled similar to ep.port()
+							i2p::context.PublishSSU2Address (ep.port(), true, true, false);
 						}
 					}
 					else
@@ -1849,7 +1850,8 @@ namespace transport
 						else if (m_State == eSSU2SessionStatePeerTest)
 						{
 							i2p::context.SetErrorV6 (eRouterErrorFullConeNAT);
-							i2p::context.UpdatePort((int)ep.port ());
+							// i2p::context.PublishNTCP2Address (TCP_PORT, true, false, true, false); // TODO: TCP_PORT to be filled similar to ep.port()
+							i2p::context.PublishSSU2Address (ep.port(), true, false, true);
 						}
 					}
 				}

--- a/libi2pd/SSU2Session.cpp
+++ b/libi2pd/SSU2Session.cpp
@@ -1831,8 +1831,7 @@ namespace transport
 				bool isV4 = ep.address ().is_v4 ();
 				if (ep.port () != m_Server.GetPort (isV4))
 				{
-					// TODO: External port detected incorrectly.
-					// LogPrint (eLogInfo, "SSU2: Our port ", ep.port (), " received from ", m_RemoteEndpoint, " is different from ", m_Server.GetPort (isV4));
+					LogPrint (eLogInfo, "SSU2: Our port ", ep.port (), " received from ", m_RemoteEndpoint, " is different from ", m_Server.GetPort (isV4));
 					if (isV4)
 					{
 						if (i2p::context.GetTesting ())


### PR DESCRIPTION
Continuation of #2272:

Ensures the correct port numbers in case the TCP and UDP mappings
differ. Updating the ports for NTCP2 hasn't been implemented yet.

I assume that ``PublishSSU2Address`` and ``PublishNTCP2Address`` are the correct ways to change the ports individually.

Also reverting back the logprint function