### PR TITLE
Fix buffer overflow in HTTPServer.cpp

### DIFF
--- a/daemon/HTTPServer.cpp
+++ b/daemon/HTTPServer.cpp
@@ -1138,8 +1138,14 @@ namespace http {
 				Terminate (ecode);
 			return;
 		}
-		m_Buffer[bytes_transferred] = '\0';
-		m_BufferLen = bytes_transferred;
+		if (bytes_transferred <= HTTP_CONNECTION_BUFFER_SIZE) {
+			m_Buffer[bytes_transferred] = '\0';
+			m_BufferLen = bytes_transferred;
+		}
+		else {
+			m_Buffer[HTTP_CONNECTION_BUFFER_SIZE] = '\0';
+			m_BufferLen = HTTP_CONNECTION_BUFFER_SIZE;
+		}
 		RunRequest();
 		Receive ();
 	}


### PR DESCRIPTION
https://github.com/PurpleI2P/i2pd/issues/2283
1.Buffer Overflow (Line 1141)

Либо принудительно завершать, как парой строк выше, либо обрезать по размеру буфера?
И там переполнение будет в случае  (bytes_transferred > HTTP_CONNECTION_BUFFER_SIZE) ,
т.к. байтик для '\0' имеется 
HTTPServer.h Line 53
char m_Buffer[HTTP_CONNECTION_BUFFER_SIZE + 1];
