### PR TITLE
Fix language selection

### DIFF
--- a/daemon/HTTPServer.cpp
+++ b/daemon/HTTPServer.cpp
@@ -189,6 +189,10 @@ namespace http {
 		// Page language
 		std::string currLang = i2p::client::context.GetLanguage ()->GetLanguage(); // get current used language
 		auto it = i2p::i18n::languages.find(currLang);
+		// fallback to default English, if language is not supported
+		if (it == i2p::i18n::languages.end()) {
+			it = i2p::i18n::languages.find("english");
+		}
 		std::string langCode = it->second.ShortCode;
 
 		// Right to Left language option


### PR DESCRIPTION
https://github.com/PurpleI2P/i2pd/issues/2283
Unchecked Iterator Dereference (Lines 185-186)

Реально в имеющемся сегодня коде UB здесь не возникнет. Произвольный язык подсунуть не получается, если в i2pd.conf написать lang=zxcv, веб-интерфейс отображается на английском языке.
В нужном месте есть проверка на наличие требуемого языка в I18N_langs.h 
I18N.cpp  line 18
```
	void SetLanguage(const std::string &lang)
	{
		const auto it = i2p::i18n::languages.find(lang);
		if (it == i2p::i18n::languages.end()) // fallback
		{
			i2p::client::context.SetLanguage (i2p::i18n::english::GetLocale());
			setlocale(LC_NUMERIC, "english");
		}
		else
		{
			i2p::client::context.SetLanguage (it->second.LocaleFunc());
			setlocale(LC_NUMERIC, lang.c_str()); // set decimal point based on language
		}
	}
```
Но пускай будет, если что-то в I18N.cpp изменится.
