### PR TITLE
Increase PID string length

### DIFF
--- a/daemon/UnixDaemon.cpp
+++ b/daemon/UnixDaemon.cpp
@@ -178,8 +178,8 @@ namespace i2p
 					return false;
 				}
 
-				char pid[10];
-				sprintf(pid, "%d\n", getpid());
+				char pid[16];
+				snprintf(pid, 16, "%d\n", getpid());
 				ftruncate(pidFH, 0);
 				if (write(pidFH, pid, strlen(pid)) < 0)
 				{


### PR DESCRIPTION
Сегодня в Linux PID_MAX_LIMIT 4194304 
https://github.com/torvalds/linux/blob/master/include/linux/threads.h  Line 35 (4 * 1024 * 1024) 
10 байтов хватает, но если завтра сделают 31 или 32 битный счетчик, не влезет.
В Haiku, если ИИ Google не соврал, а врет он нестабильно, 2 147 483 647 , нужно не менее 11 байт. 
Что еще экзотическое бывает?
