### PR TITLE
Webconsole: a little decoration of page 'Transports'

### DIFF
--- a/daemon/HTTPServer.cpp
+++ b/daemon/HTTPServer.cpp
@@ -936,9 +936,11 @@ namespace http {
 			{
 				tmp_s << "<div class=\"listitem\">\r\n";
 				if (it->IsOutgoing ()) tmp_s << " &#8658; ";
+				else tmp_s << " &nbsp; ";
 				tmp_s << i2p::data::GetIdentHashAbbreviation (it->GetRemoteIdentity ()->GetIdentHash ()) << ": "
 					<< endpoint.address ().to_string () << ":" << endpoint.port ();
 				if (!it->IsOutgoing ()) tmp_s << " &#8658; ";
+				else tmp_s << " &nbsp; ";
 				tmp_s << " [" << it->GetNumSentBytes () << ":" << it->GetNumReceivedBytes () << "]";
 				if (it->GetRelayTag ())
 					tmp_s << " [itag:" << it->GetRelayTag () << "]";
@@ -952,9 +954,11 @@ namespace http {
 			{
 				tmp_s6 << "<div class=\"listitem\">\r\n";
 				if (it->IsOutgoing ()) tmp_s6 << " &#8658; ";
+				else tmp_s << " &nbsp; ";
 				tmp_s6 << i2p::data::GetIdentHashAbbreviation (it->GetRemoteIdentity ()->GetIdentHash ()) << ": "
 					<< "[" << endpoint.address ().to_string () << "]:" << endpoint.port ();
 				if (!it->IsOutgoing ()) tmp_s6 << " &#8658; ";
+				else tmp_s << " &nbsp; ";
 				tmp_s6 << " [" << it->GetNumSentBytes () << ":" << it->GetNumReceivedBytes () << "]";
 				if (it->GetRelayTag ())
 					tmp_s6 << " [itag:" << it->GetRelayTag () << "]";


### PR DESCRIPTION
Улучшение картинки минимальными изменениями кода.
<img width="371" height="385" alt="image" src="https://github.com/user-attachments/assets/e8eda835-4fdc-4791-8f94-482939210b85" />

В CSS написано `font-family: monospace;` но стрелочки особенные, занимают более 100% ширины символа.  Раздел 'Transports' в отличие от 'Transit tunnels' оформлен не в виде html-таблицы, здесь просто строчки. Этот список можно переделать в html-таблицу, но на функциональность вероятно не повлияет, скорее по эстетических соображениям.

