### PR TITLE
Add space in log message

### DIFF
--- a/libi2pd/SSU2.cpp
+++ b/libi2pd/SSU2.cpp
@@ -475,7 +475,7 @@ namespace transport
 				m_ReceivedPacketsQueue.splice (m_ReceivedPacketsQueue.end (), packets);
 			else
 			{
-				LogPrint (eLogError, "SSU2: Received queue size ", queueSize, " exceeds max size", SSU2_MAX_RECEIVED_QUEUE_SIZE);
+				LogPrint (eLogError, "SSU2: Received queue size ", queueSize, " exceeds max size ", SSU2_MAX_RECEIVED_QUEUE_SIZE);
 				m_PacketsPool.ReleaseMt (packets);
 				queueSize = 0; // invoke processing just in case
 			}		


### PR DESCRIPTION
Попалось в логах
<img width="602" height="43" alt="image" src="https://github.com/user-attachments/assets/48e21cd3-698b-4c87-a400-dfad7af48d42" />
добавил
