### PR TITLE
Add VERSION override for release builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,11 @@ INCFLAGS += -I$(LIB_SRC_DIR) -I$(LIB_CLIENT_SRC_DIR) -I$(LANG_SRC_DIR)
 NEEDED_CXXFLAGS += -MMD -MP
 
 ifeq ($(USE_GIT_VERSION),yes)
+ifdef VERSION
+	GIT_VERSION := $(VERSION)
+else
 	GIT_VERSION := $(shell git describe --tags)
+endif
 	DEFINES += -DGITVER=$(GIT_VERSION)
 endif
 


### PR DESCRIPTION
Allow overriding version string when USE_GIT_VERSION=yes.

Use: \make VERSION=2.59.0 USE_GIT_VERSION=yes ...\ for release builds.

Without VERSION, git describe is used as before.

Made with [Cursor](https://cursor.com)