### PR TITLE
Webconsole: decorative changes of Transports page

### DIFF
--- a/daemon/HTTPServer.cpp
+++ b/daemon/HTTPServer.cpp
@@ -979,7 +979,7 @@ namespace http {
 			  << "</b> ( " << cnt << " )</label>\r\n"
 			  << "<input type=\"checkbox\" id=\"slide_" << boost::algorithm::to_lower_copy(name) << "\" />\r\n"
 			  << "<div class=\"slidecontent list\">\r\n\r\n"
-			  << tmp_s.str () << "</div>\r\n</br>\r\n</div>\r\n";
+			  << tmp_s.str () << "</div>\r\n<br>\r\n</div>\r\n";
 		}
 		if (!tmp_s6.str ().empty ())
 		{
@@ -987,7 +987,7 @@ namespace http {
 			  << "v6</b> ( " << cnt6 << " )</label>\r\n"
 			  << "<input type=\"checkbox\" id=\"slide_" << boost::algorithm::to_lower_copy(name) << "v6\" />\r\n"
 			  << "<div class=\"slidecontent list\">\r\n\r\n"
-			  << tmp_s6.str () << "</div>\r\n</br>\r\n</div>\r\n";
+			  << tmp_s6.str () << "</div>\r\n<br>\r\n</div>\r\n";
 		}
 	}
 

--- a/daemon/HTTPServer.cpp
+++ b/daemon/HTTPServer.cpp
@@ -979,7 +979,10 @@ namespace http {
 			  << "</b> ( " << cnt << " )</label>\r\n"
 			  << "<input type=\"checkbox\" id=\"slide_" << boost::algorithm::to_lower_copy(name) << "\" />\r\n"
 			  << "<div class=\"slidecontent list\">\r\n\r\n"
-			  << tmp_s.str () << "</div>\r\n<br>\r\n</div>\r\n";
+			  << tmp_s.str ()
+			  << "<div class=\"listitem\">\r\n"
+			  << "&nbsp; </div>\r\n" << std::endl
+			  << "</div>\r\n</div>\r\n\r\n";
 		}
 		if (!tmp_s6.str ().empty ())
 		{
@@ -987,7 +990,10 @@ namespace http {
 			  << "v6</b> ( " << cnt6 << " )</label>\r\n"
 			  << "<input type=\"checkbox\" id=\"slide_" << boost::algorithm::to_lower_copy(name) << "v6\" />\r\n"
 			  << "<div class=\"slidecontent list\">\r\n\r\n"
-			  << tmp_s6.str () << "</div>\r\n<br>\r\n</div>\r\n";
+			  << tmp_s6.str ()
+			  << "<div class=\"listitem\">\r\n"
+			  << "&nbsp; </div>\r\n" << std::endl
+			  << "</div>\r\n</div>\r\n\r\n";
 		}
 	}
 


### PR DESCRIPTION
Firefox doesn't draw properly with non-standart `</br>`
`</br>`  -->  `<br>`  in two places

https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/br
https://stackoverflow.com/questions/1946426/html-5-is-it-br-br-or-br
Google AI:
Self-Closing: It is an empty (or "void") element, meaning it does not have a closing tag (e.g., `</br>`). In HTML5, you can simply write `<br>`, though `<br />` (common in XHTML) is also valid and supported by all modern browsers.

