### PR TITLE
Use only unique hosts & hashes for tunnels

### DIFF
--- a/contrib/i2pd.conf
+++ b/contrib/i2pd.conf
@@ -103,6 +103,10 @@ ipv6 = false
 ## For places with limited connectivity (default: false)
 # stan = true
 
+## Do not use the same router hash & host more than once
+## across all tunnels expect for the exploratory ones
+unique = true
+
 [ntcp2]
 ## Enable NTCP2 transport (default: true)
 # enabled = true

--- a/contrib/i2pd.conf
+++ b/contrib/i2pd.conf
@@ -104,7 +104,7 @@ ipv6 = false
 # stan = true
 
 ## Do not use the same router hash & host more than once
-## across all tunnels expect for the exploratory ones
+## across all tunnels expect for the transit ones
 unique = true
 
 [ntcp2]

--- a/daemon/HTTPServer.cpp
+++ b/daemon/HTTPServer.cpp
@@ -544,7 +544,6 @@ namespace http {
 			s << "<b>" << tr("Inbound tunnels") << ":</b><br>\r\n<div class=\"list\">\r\n";
 			for (auto & it : pool->GetInboundTunnels ()) {
 				s << "<div class=\"listitem\">";
-				s << it.get()->GetCreationTime() << "  ";
 				// for each tunnel hop if not zero-hop
 				if (it->GetNumHops ())
 				{
@@ -567,7 +566,6 @@ namespace http {
 			s << "<b>" << tr("Outbound tunnels") << ":</b><br>\r\n<div class=\"list\">\r\n";
 			for (auto & it : pool->GetOutboundTunnels ()) {
 				s << "<div class=\"listitem\">";
-				s << it.get()->GetCreationTime() << "  ";
 				s << it->GetTunnelID () << ":me &#8658;";
 				// for each tunnel hop if not zero-hop
 				if (it->GetNumHops ())

--- a/daemon/HTTPServer.cpp
+++ b/daemon/HTTPServer.cpp
@@ -544,6 +544,7 @@ namespace http {
 			s << "<b>" << tr("Inbound tunnels") << ":</b><br>\r\n<div class=\"list\">\r\n";
 			for (auto & it : pool->GetInboundTunnels ()) {
 				s << "<div class=\"listitem\">";
+				s << it.get()->GetCreationTime() << "  ";
 				// for each tunnel hop if not zero-hop
 				if (it->GetNumHops ())
 				{
@@ -566,6 +567,7 @@ namespace http {
 			s << "<b>" << tr("Outbound tunnels") << ":</b><br>\r\n<div class=\"list\">\r\n";
 			for (auto & it : pool->GetOutboundTunnels ()) {
 				s << "<div class=\"listitem\">";
+				s << it.get()->GetCreationTime() << "  ";
 				s << it->GetTunnelID () << ":me &#8658;";
 				// for each tunnel hop if not zero-hop
 				if (it->GetNumHops ())

--- a/libi2pd/Config.cpp
+++ b/libi2pd/Config.cpp
@@ -82,6 +82,7 @@ namespace config {
 			("close", value<std::string>()->default_value("ask"),             "Action on close: minimize, exit, ask")
 #endif
 			("stan", bool_switch()->default_value(false), 					  "Router has limited connectivity (default: false)")
+		    ("unique", bool_switch()->default_value(false),                    "Do not use same router id & host more than once across all tunnels")
 		;
 
 		options_description limits("Limits options");

--- a/libi2pd/NetDb.cpp
+++ b/libi2pd/NetDb.cpp
@@ -85,6 +85,7 @@ namespace data
 			m_Floodfills.Insert (i2p::context.GetSharedRouterInfo ());
 
 		i2p::config::GetOption("persist.profiles", m_PersistProfiles);
+		i2p::config::GetOption("unique", m_uniqueOnly);
 
 		m_IsRunning = true;
 		m_Thread = new std::thread (std::bind (&NetDb::Run, this));
@@ -1146,9 +1147,12 @@ namespace data
 		}
 	}
 
-	std::shared_ptr<RouterInfo> recheck(std::shared_ptr<RouterInfo> candidate, uint64_t currentMillis)
+	// there's some time between a router being randomly picked in NetDb::GetRandomRouter()
+	// and the same router appearing in Tunnels::GetAddressesInUse()
+	// to avoid double pick, introduce RANDOM_PICK_TIMEOUT_MS
+	std::shared_ptr<RouterInfo> NetDb::RecheckRouterTs(std::shared_ptr<RouterInfo> candidate, uint64_t currentMillis) const
 	{
-		if (candidate.get())
+		if (OnlyUniqueHosts() && candidate.get())
 			if (!candidate->RecheckTsAndUpdate(currentMillis))
 				return {nullptr};
 		return candidate;
@@ -1157,11 +1161,12 @@ namespace data
 	std::shared_ptr<RouterInfo> NetDb::GetRandomRouter (util::RoutersInUse& inUse) const
 	{
 		uint64_t currentMillis = util::GetMillisecondsSinceEpoch ();
-		return recheck(GetRandomRouter (
-			[inUse, currentMillis](std::shared_ptr<const RouterInfo> router)->bool
+		bool uniqueOnly = OnlyUniqueHosts();
+		return RecheckRouterTs(GetRandomRouter (
+			[inUse, currentMillis, uniqueOnly](const std::shared_ptr<const RouterInfo>& router)->bool
 			{
 				return !router->IsHidden () &&
-					router->LastPickTs() + RANDOM_PICK_TIMEOUT_MS < currentMillis && !router->IsMatch(inUse);
+					(!uniqueOnly || (router->LastPickTs() + RANDOM_PICK_TIMEOUT_MS < currentMillis && !router->IsMatch(inUse)));
 			}), currentMillis);
 	}
 
@@ -1171,8 +1176,9 @@ namespace data
 		bool checkIsReal = clientTunnel && i2p::tunnel::tunnels.GetPreciseTunnelCreationSuccessRate () < NETDB_TUNNEL_CREATION_RATE_THRESHOLD && // too low rate
 			context.GetUptime () > NETDB_CHECK_FOR_EXPIRATION_UPTIME; // after 10 minutes uptime
 		uint64_t currentMillis = util::GetMillisecondsSinceEpoch ();
-		return recheck(GetRandomRouter (
-			[compatibleWith, reverse, endpoint, clientTunnel, checkIsReal, inUse, currentMillis](std::shared_ptr<const RouterInfo> router)->bool
+		bool uniqueOnly = OnlyUniqueHosts();
+		return RecheckRouterTs(GetRandomRouter (
+			[compatibleWith, reverse, endpoint, clientTunnel, checkIsReal, inUse, uniqueOnly, currentMillis](const std::shared_ptr<const RouterInfo>& router)->bool
 			{
 				if (router->LastPickTs() + RANDOM_PICK_TIMEOUT_MS >= currentMillis)
 				{
@@ -1186,7 +1192,7 @@ namespace data
 					(!i2p::transport::transports.IsCheckReserved () || !router->IsSameSubnet (*compatibleWith)) &&
 					(!checkIsReal || router->GetProfile ()->IsReal ()) &&
 					(!endpoint || (router->IsV4 () && (!reverse || router->IsPublished (true)))) && // endpoint must be ipv4 and published if inbound(reverse)
-					router->LastPickTs() + RANDOM_PICK_TIMEOUT_MS < currentMillis && !router->IsMatch(inUse);
+					(!uniqueOnly || (router->LastPickTs() + RANDOM_PICK_TIMEOUT_MS < currentMillis && !router->IsMatch(inUse)));
 			}), currentMillis);
 	}
 
@@ -1216,8 +1222,9 @@ namespace data
 		bool checkIsReal = i2p::tunnel::tunnels.GetPreciseTunnelCreationSuccessRate () < NETDB_TUNNEL_CREATION_RATE_THRESHOLD && // too low rate
 			context.GetUptime () > NETDB_CHECK_FOR_EXPIRATION_UPTIME; // after 10 minutes uptime
 		uint64_t currentMillis = util::GetMillisecondsSinceEpoch ();
-		return recheck(GetRandomRouter (
-			[compatibleWith, reverse, endpoint, checkIsReal, inUse, currentMillis](std::shared_ptr<RouterInfo> router)->bool
+		bool uniqueOnly = OnlyUniqueHosts();
+		return RecheckRouterTs(GetRandomRouter (
+			[compatibleWith, reverse, endpoint, checkIsReal, inUse, uniqueOnly, currentMillis](const std::shared_ptr<RouterInfo>& router)->bool
 			{
 				if (router->LastPickTs() + RANDOM_PICK_TIMEOUT_MS >= currentMillis)
 				{
@@ -1232,8 +1239,7 @@ namespace data
 					(!i2p::transport::transports.IsCheckReserved () || !router->IsSameSubnet (*compatibleWith)) &&
 					(!checkIsReal || router->GetProfile ()->IsReal ()) &&
 					(!endpoint || (router->IsV4 () && (!reverse || router->IsPublished (true)))) && // endpoint must be ipv4 and published if inbound(reverse)
-					router->LastPickTs() + RANDOM_PICK_TIMEOUT_MS < currentMillis && !router->IsMatch(inUse);
-
+					(!uniqueOnly || (router->LastPickTs() + RANDOM_PICK_TIMEOUT_MS < currentMillis && !router->IsMatch(inUse)));
 			}), currentMillis);
 	}
 

--- a/libi2pd/NetDb.cpp
+++ b/libi2pd/NetDb.cpp
@@ -1146,17 +1146,11 @@ namespace data
 		}
 	}
 
-	const uint64_t RANDOM_PICK_TIMEOUT_MS = 30000;
-
 	std::shared_ptr<RouterInfo> recheck(std::shared_ptr<RouterInfo> candidate, uint64_t currentMillis)
 	{
 		if (candidate.get())
-		{
 			if (!candidate->RecheckTsAndUpdate(currentMillis))
-			{
 				return {nullptr};
-			}
-		}
 		return candidate;
 	}
 

--- a/libi2pd/NetDb.cpp
+++ b/libi2pd/NetDb.cpp
@@ -63,12 +63,13 @@ namespace data
 			m_Requests->Start ();
 		}
 
+		util::RoutersInUse noRouters;
 		uint16_t threshold; i2p::config::GetOption("reseed.threshold", threshold);
 		if (m_RouterInfos.size () < threshold || m_Floodfills.GetSize () < NETDB_MIN_FLOODFILLS) // reseed if # of router less than threshold or too few floodfiils
 		{
 			Reseed ();
 		}
-		else if (!GetRandomRouter (i2p::context.GetSharedRouterInfo (), false, false, false))
+		else if (!GetRandomRouter (i2p::context.GetSharedRouterInfo (), false, false, false, noRouters))
 			Reseed (); // we don't have a router we can connect to. Trying to reseed
 
 		auto it = m_RouterInfos.find (i2p::context.GetIdentHash ());
@@ -1145,23 +1146,44 @@ namespace data
 		}
 	}
 
-	std::shared_ptr<const RouterInfo> NetDb::GetRandomRouter () const
+	const uint64_t RANDOM_PICK_TIMEOUT_MS = 30000;
+
+	std::shared_ptr<RouterInfo> recheck(std::shared_ptr<RouterInfo> candidate, uint64_t currentMillis)
 	{
-		return GetRandomRouter (
-			[](std::shared_ptr<const RouterInfo> router)->bool
+		if (candidate.get())
+		{
+			if (!candidate->RecheckTsAndUpdate(currentMillis))
 			{
-				return !router->IsHidden ();
-			});
+				return {nullptr};
+			}
+		}
+		return candidate;
 	}
 
-	std::shared_ptr<const RouterInfo> NetDb::GetRandomRouter (std::shared_ptr<const RouterInfo> compatibleWith,
-		bool reverse, bool endpoint, bool clientTunnel) const
+	std::shared_ptr<RouterInfo> NetDb::GetRandomRouter (util::RoutersInUse& inUse) const
+	{
+		uint64_t currentMillis = util::GetMillisecondsSinceEpoch ();
+		return recheck(GetRandomRouter (
+			[inUse, currentMillis](std::shared_ptr<const RouterInfo> router)->bool
+			{
+				return !router->IsHidden () &&
+					router->LastPickTs() + RANDOM_PICK_TIMEOUT_MS < currentMillis && !router->IsMatch(inUse);
+			}), currentMillis);
+	}
+
+	std::shared_ptr<RouterInfo> NetDb::GetRandomRouter (std::shared_ptr<const RouterInfo> compatibleWith,
+		bool reverse, bool endpoint, bool clientTunnel, util::RoutersInUse& inUse) const
 	{
 		bool checkIsReal = clientTunnel && i2p::tunnel::tunnels.GetPreciseTunnelCreationSuccessRate () < NETDB_TUNNEL_CREATION_RATE_THRESHOLD && // too low rate
 			context.GetUptime () > NETDB_CHECK_FOR_EXPIRATION_UPTIME; // after 10 minutes uptime
-		return GetRandomRouter (
-			[compatibleWith, reverse, endpoint, clientTunnel, checkIsReal](std::shared_ptr<const RouterInfo> router)->bool
+		uint64_t currentMillis = util::GetMillisecondsSinceEpoch ();
+		return recheck(GetRandomRouter (
+			[compatibleWith, reverse, endpoint, clientTunnel, checkIsReal, inUse, currentMillis](std::shared_ptr<const RouterInfo> router)->bool
 			{
+				if (router->LastPickTs() + RANDOM_PICK_TIMEOUT_MS >= currentMillis)
+				{
+					LogPrint(eLogDebug, "(unique_only) Filtered by pick time ", router.get()->GetIdentHashBase64().substr(0, 4));
+				}
 				return !router->IsHidden () && router != compatibleWith &&
 					(reverse ? (compatibleWith->IsReachableFrom (*router) && router->GetCompatibleTransports (true)):
 						router->IsReachableFrom (*compatibleWith)) && !router->IsNAT2NATOnly (*compatibleWith) &&
@@ -1169,11 +1191,12 @@ namespace data
 					router->IsECIES () && !router->IsHighCongestion (clientTunnel) &&
 					(!i2p::transport::transports.IsCheckReserved () || !router->IsSameSubnet (*compatibleWith)) &&
 					(!checkIsReal || router->GetProfile ()->IsReal ()) &&
-					(!endpoint || (router->IsV4 () && (!reverse || router->IsPublished (true)))); // endpoint must be ipv4 and published if inbound(reverse)
-			});
+					(!endpoint || (router->IsV4 () && (!reverse || router->IsPublished (true)))) && // endpoint must be ipv4 and published if inbound(reverse)
+					router->LastPickTs() + RANDOM_PICK_TIMEOUT_MS < currentMillis && !router->IsMatch(inUse);
+			}), currentMillis);
 	}
 
-	std::shared_ptr<const RouterInfo> NetDb::GetRandomSSU2PeerTestRouter (bool v4, const std::unordered_set<IdentHash>& excluded) const
+	std::shared_ptr<RouterInfo> NetDb::GetRandomSSU2PeerTestRouter (bool v4, const std::unordered_set<IdentHash>& excluded) const
 	{
 		return GetRandomRouter (
 			[v4, &excluded](std::shared_ptr<const RouterInfo> router)->bool
@@ -1183,7 +1206,7 @@ namespace data
 			});
 	}
 
-	std::shared_ptr<const RouterInfo> NetDb::GetRandomSSU2Introducer (bool v4, const std::unordered_set<IdentHash>& excluded) const
+	std::shared_ptr<RouterInfo> NetDb::GetRandomSSU2Introducer (bool v4, const std::unordered_set<IdentHash>& excluded) const
 	{
 		return GetRandomRouter (
 			[v4, &excluded](std::shared_ptr<const RouterInfo> router)->bool
@@ -1193,14 +1216,19 @@ namespace data
 			});
 	}
 
-	std::shared_ptr<const RouterInfo> NetDb::GetHighBandwidthRandomRouter (std::shared_ptr<const RouterInfo> compatibleWith,
-		bool reverse, bool endpoint) const
+	std::shared_ptr<RouterInfo> NetDb::GetHighBandwidthRandomRouter (std::shared_ptr<const RouterInfo> compatibleWith,
+		bool reverse, bool endpoint, util::RoutersInUse& inUse) const
 	{
 		bool checkIsReal = i2p::tunnel::tunnels.GetPreciseTunnelCreationSuccessRate () < NETDB_TUNNEL_CREATION_RATE_THRESHOLD && // too low rate
 			context.GetUptime () > NETDB_CHECK_FOR_EXPIRATION_UPTIME; // after 10 minutes uptime
-		return GetRandomRouter (
-			[compatibleWith, reverse, endpoint, checkIsReal](std::shared_ptr<const RouterInfo> router)->bool
+		uint64_t currentMillis = util::GetMillisecondsSinceEpoch ();
+		return recheck(GetRandomRouter (
+			[compatibleWith, reverse, endpoint, checkIsReal, inUse, currentMillis](std::shared_ptr<RouterInfo> router)->bool
 			{
+				if (router->LastPickTs() + RANDOM_PICK_TIMEOUT_MS >= currentMillis)
+				{
+					LogPrint(eLogDebug, "(unique_only) Filtered by pick time ", router.get()->GetIdentHashBase64().substr(0, 4));
+				}
 				return !router->IsHidden () && router != compatibleWith &&
 					(reverse ? (compatibleWith->IsReachableFrom (*router) && router->GetCompatibleTransports (true)) :
 						router->IsReachableFrom (*compatibleWith)) && !router->IsNAT2NATOnly (*compatibleWith) &&
@@ -1209,13 +1237,14 @@ namespace data
 					router->IsECIES () && !router->IsHighCongestion (true) &&
 					(!i2p::transport::transports.IsCheckReserved () || !router->IsSameSubnet (*compatibleWith)) &&
 					(!checkIsReal || router->GetProfile ()->IsReal ()) &&
-					(!endpoint || (router->IsV4 () && (!reverse || router->IsPublished (true)))); // endpoint must be ipv4 and published if inbound(reverse)
+					(!endpoint || (router->IsV4 () && (!reverse || router->IsPublished (true)))) && // endpoint must be ipv4 and published if inbound(reverse)
+					router->LastPickTs() + RANDOM_PICK_TIMEOUT_MS < currentMillis && !router->IsMatch(inUse);
 
-			});
+			}), currentMillis);
 	}
 
 	template<typename Filter>
-	std::shared_ptr<const RouterInfo> NetDb::GetRandomRouter (Filter filter) const
+	std::shared_ptr<RouterInfo> NetDb::GetRandomRouter (Filter filter) const
 	{
 		if (m_RouterInfos.empty())
 			return nullptr;
@@ -1285,7 +1314,7 @@ namespace data
 			m_Requests->PostDatabaseSearchReplyMsg (msg);
 	}
 
-	std::shared_ptr<const RouterInfo> NetDb::GetClosestFloodfill (const IdentHash& destination,
+	std::shared_ptr<RouterInfo> NetDb::GetClosestFloodfill (const IdentHash& destination,
 		const std::unordered_set<IdentHash>& excluded, bool nextDay) const
 	{
 		IdentHash destKey = CreateRoutingKey (destination, nextDay);
@@ -1323,7 +1352,7 @@ namespace data
 		return res;
 	}
 
-	std::shared_ptr<const RouterInfo> NetDb::GetRandomRouterInFamily (FamilyID fam) const
+	std::shared_ptr<RouterInfo> NetDb::GetRandomRouterInFamily (FamilyID fam) const
 	{
 		return GetRandomRouter(
 			[fam](std::shared_ptr<const RouterInfo> router)->bool

--- a/libi2pd/NetDb.cpp
+++ b/libi2pd/NetDb.cpp
@@ -1180,10 +1180,6 @@ namespace data
 		return RecheckRouterTs(GetRandomRouter (
 			[compatibleWith, reverse, endpoint, clientTunnel, checkIsReal, inUse, uniqueOnly, currentMillis](const std::shared_ptr<const RouterInfo>& router)->bool
 			{
-				if (router->LastPickTs() + RANDOM_PICK_TIMEOUT_MS >= currentMillis)
-				{
-					LogPrint(eLogDebug, "(unique_only) Filtered by pick time ", router.get()->GetIdentHashBase64().substr(0, 4));
-				}
 				return !router->IsHidden () && router != compatibleWith &&
 					(reverse ? (compatibleWith->IsReachableFrom (*router) && router->GetCompatibleTransports (true)):
 						router->IsReachableFrom (*compatibleWith)) && !router->IsNAT2NATOnly (*compatibleWith) &&
@@ -1196,7 +1192,7 @@ namespace data
 			}), currentMillis);
 	}
 
-	std::shared_ptr<RouterInfo> NetDb::GetRandomSSU2PeerTestRouter (bool v4, const std::unordered_set<IdentHash>& excluded) const
+	std::shared_ptr<const RouterInfo> NetDb::GetRandomSSU2PeerTestRouter (bool v4, const std::unordered_set<IdentHash>& excluded) const
 	{
 		return GetRandomRouter (
 			[v4, &excluded](std::shared_ptr<const RouterInfo> router)->bool
@@ -1206,7 +1202,7 @@ namespace data
 			});
 	}
 
-	std::shared_ptr<RouterInfo> NetDb::GetRandomSSU2Introducer (bool v4, const std::unordered_set<IdentHash>& excluded) const
+	std::shared_ptr<const RouterInfo> NetDb::GetRandomSSU2Introducer (bool v4, const std::unordered_set<IdentHash>& excluded) const
 	{
 		return GetRandomRouter (
 			[v4, &excluded](std::shared_ptr<const RouterInfo> router)->bool
@@ -1226,10 +1222,6 @@ namespace data
 		return RecheckRouterTs(GetRandomRouter (
 			[compatibleWith, reverse, endpoint, checkIsReal, inUse, uniqueOnly, currentMillis](const std::shared_ptr<RouterInfo>& router)->bool
 			{
-				if (router->LastPickTs() + RANDOM_PICK_TIMEOUT_MS >= currentMillis)
-				{
-					LogPrint(eLogDebug, "(unique_only) Filtered by pick time ", router.get()->GetIdentHashBase64().substr(0, 4));
-				}
 				return !router->IsHidden () && router != compatibleWith &&
 					(reverse ? (compatibleWith->IsReachableFrom (*router) && router->GetCompatibleTransports (true)) :
 						router->IsReachableFrom (*compatibleWith)) && !router->IsNAT2NATOnly (*compatibleWith) &&
@@ -1314,7 +1306,7 @@ namespace data
 			m_Requests->PostDatabaseSearchReplyMsg (msg);
 	}
 
-	std::shared_ptr<RouterInfo> NetDb::GetClosestFloodfill (const IdentHash& destination,
+	std::shared_ptr<const RouterInfo> NetDb::GetClosestFloodfill (const IdentHash& destination,
 		const std::unordered_set<IdentHash>& excluded, bool nextDay) const
 	{
 		IdentHash destKey = CreateRoutingKey (destination, nextDay);
@@ -1352,7 +1344,7 @@ namespace data
 		return res;
 	}
 
-	std::shared_ptr<RouterInfo> NetDb::GetRandomRouterInFamily (FamilyID fam) const
+	std::shared_ptr<const RouterInfo> NetDb::GetRandomRouterInFamily (FamilyID fam) const
 	{
 		return GetRandomRouter(
 			[fam](std::shared_ptr<const RouterInfo> router)->bool

--- a/libi2pd/NetDb.hpp
+++ b/libi2pd/NetDb.hpp
@@ -142,6 +142,8 @@ namespace data
 			std::shared_ptr<IdentityEx> NewIdentity (const uint8_t * buf, size_t len) { return m_IdentitiesPool.AcquireSharedMt (buf, len); };
 			std::shared_ptr<RouterProfile> NewRouterProfile () { return m_RouterProfilesPool.AcquireSharedMt (); };
 
+			bool OnlyUniqueHosts () const { return m_uniqueOnly; };
+
 		private:
 
 			void Load ();
@@ -200,6 +202,9 @@ namespace data
 			std::vector<std::shared_ptr<const RouterInfo> > m_ExploratorySelection;
 			uint64_t m_LastExploratorySelectionUpdateTime; // in monotonic seconds
 			std::mt19937 m_Rng;
+
+		    bool m_uniqueOnly;
+			std::shared_ptr<RouterInfo> RecheckRouterTs(std::shared_ptr<RouterInfo> candidate, uint64_t currentMillis) const;
 	};
 
 	extern NetDb netdb;

--- a/libi2pd/NetDb.hpp
+++ b/libi2pd/NetDb.hpp
@@ -90,16 +90,16 @@ namespace data
 
 			void RequestDestination (const IdentHash& destination, RequestedDestination::RequestComplete requestComplete = nullptr, bool direct = true);
 
-			std::shared_ptr<const RouterInfo> GetRandomRouter () const;
-			std::shared_ptr<const RouterInfo> GetRandomRouter (std::shared_ptr<const RouterInfo> compatibleWith, bool reverse, bool endpoint, bool clientTunnel) const;
-			std::shared_ptr<const RouterInfo> GetHighBandwidthRandomRouter (std::shared_ptr<const RouterInfo> compatibleWith, bool reverse, bool endpoint) const;
-			std::shared_ptr<const RouterInfo> GetRandomSSU2PeerTestRouter (bool v4, const std::unordered_set<IdentHash>& excluded) const;
-			std::shared_ptr<const RouterInfo> GetRandomSSU2Introducer (bool v4, const std::unordered_set<IdentHash>& excluded) const;
-			std::shared_ptr<const RouterInfo> GetClosestFloodfill (const IdentHash& destination, const std::unordered_set<IdentHash>& excluded, bool nextDay = false) const;
+			std::shared_ptr<RouterInfo> GetRandomRouter (util::RoutersInUse& inUse) const;
+			std::shared_ptr<RouterInfo> GetRandomRouter (std::shared_ptr<const RouterInfo> compatibleWith, bool reverse, bool endpoint, bool clientTunnel, util::RoutersInUse& inUse) const;
+			std::shared_ptr<RouterInfo> GetHighBandwidthRandomRouter (std::shared_ptr<const RouterInfo> compatibleWith, bool reverse, bool endpoint, util::RoutersInUse& inUse) const;
+			std::shared_ptr<RouterInfo> GetRandomSSU2PeerTestRouter (bool v4, const std::unordered_set<IdentHash>& excluded) const;
+			std::shared_ptr<RouterInfo> GetRandomSSU2Introducer (bool v4, const std::unordered_set<IdentHash>& excluded) const;
+			std::shared_ptr<RouterInfo> GetClosestFloodfill (const IdentHash& destination, const std::unordered_set<IdentHash>& excluded, bool nextDay = false) const;
 			std::vector<IdentHash> GetClosestFloodfills (const IdentHash& destination, size_t num,
 				std::unordered_set<IdentHash>& excluded, bool closeThanUsOnly = false) const;
 			std::vector<IdentHash> GetExploratoryNonFloodfill (const IdentHash& destination, size_t num, const std::unordered_set<IdentHash>& excluded);
-			std::shared_ptr<const RouterInfo> GetRandomRouterInFamily (FamilyID fam) const;
+			std::shared_ptr<RouterInfo> GetRandomRouterInFamily (FamilyID fam) const;
 			void SetUnreachable (const IdentHash& ident, bool unreachable);
 			void ExcludeReachableTransports (const IdentHash& ident, RouterInfo::CompatibleTransports transports);
 
@@ -161,7 +161,7 @@ namespace data
 			std::shared_ptr<const RouterInfo> AddRouterInfo (const IdentHash& ident, const uint8_t * buf, int len, bool& updated);
 
 			template<typename Filter>
-			std::shared_ptr<const RouterInfo> GetRandomRouter (Filter filter) const;
+			std::shared_ptr<RouterInfo> GetRandomRouter (Filter filter) const;
 
 			void HandleDatabaseStoreMsg (std::shared_ptr<const I2NPMessage> msg);
 			void HandleDatabaseLookupMsg (std::shared_ptr<const I2NPMessage> msg);

--- a/libi2pd/NetDb.hpp
+++ b/libi2pd/NetDb.hpp
@@ -93,13 +93,13 @@ namespace data
 			std::shared_ptr<RouterInfo> GetRandomRouter (util::RoutersInUse& inUse) const;
 			std::shared_ptr<RouterInfo> GetRandomRouter (std::shared_ptr<const RouterInfo> compatibleWith, bool reverse, bool endpoint, bool clientTunnel, util::RoutersInUse& inUse) const;
 			std::shared_ptr<RouterInfo> GetHighBandwidthRandomRouter (std::shared_ptr<const RouterInfo> compatibleWith, bool reverse, bool endpoint, util::RoutersInUse& inUse) const;
-			std::shared_ptr<RouterInfo> GetRandomSSU2PeerTestRouter (bool v4, const std::unordered_set<IdentHash>& excluded) const;
-			std::shared_ptr<RouterInfo> GetRandomSSU2Introducer (bool v4, const std::unordered_set<IdentHash>& excluded) const;
-			std::shared_ptr<RouterInfo> GetClosestFloodfill (const IdentHash& destination, const std::unordered_set<IdentHash>& excluded, bool nextDay = false) const;
+			std::shared_ptr<const RouterInfo> GetRandomSSU2PeerTestRouter (bool v4, const std::unordered_set<IdentHash>& excluded) const;
+			std::shared_ptr<const RouterInfo> GetRandomSSU2Introducer (bool v4, const std::unordered_set<IdentHash>& excluded) const;
+			std::shared_ptr<const RouterInfo> GetClosestFloodfill (const IdentHash& destination, const std::unordered_set<IdentHash>& excluded, bool nextDay = false) const;
 			std::vector<IdentHash> GetClosestFloodfills (const IdentHash& destination, size_t num,
 				std::unordered_set<IdentHash>& excluded, bool closeThanUsOnly = false) const;
 			std::vector<IdentHash> GetExploratoryNonFloodfill (const IdentHash& destination, size_t num, const std::unordered_set<IdentHash>& excluded);
-			std::shared_ptr<RouterInfo> GetRandomRouterInFamily (FamilyID fam) const;
+			std::shared_ptr<const RouterInfo> GetRandomRouterInFamily (FamilyID fam) const;
 			void SetUnreachable (const IdentHash& ident, bool unreachable);
 			void ExcludeReachableTransports (const IdentHash& ident, RouterInfo::CompatibleTransports transports);
 
@@ -203,7 +203,7 @@ namespace data
 			uint64_t m_LastExploratorySelectionUpdateTime; // in monotonic seconds
 			std::mt19937 m_Rng;
 
-		    bool m_uniqueOnly;
+			bool m_uniqueOnly;
 			std::shared_ptr<RouterInfo> RecheckRouterTs(std::shared_ptr<RouterInfo> candidate, uint64_t currentMillis) const;
 	};
 

--- a/libi2pd/RouterInfo.cpp
+++ b/libi2pd/RouterInfo.cpp
@@ -39,7 +39,7 @@ namespace data
 		m_BufferLen = len;
 	}
 
-	RouterInfo::RouterInfo (): m_Buffer (nullptr)
+	RouterInfo::RouterInfo (): m_Buffer (nullptr), m_LastPickTs(0)
 	{
 		m_Addresses = AddressesPtr(new Addresses ()); // create empty list
 	}
@@ -48,7 +48,7 @@ namespace data
 		m_FamilyID (0), m_IsUpdated (false), m_IsUnreachable (false), m_IsFloodfill (false),
 		m_IsBufferScheduledToDelete (false), m_SupportedTransports (0),
 		m_ReachableTransports (0), m_PublishedTransports (0), m_Caps (0), m_Version (0),
-		m_Congestion (eLowCongestion)
+		m_Congestion (eLowCongestion), m_LastPickTs(0)
 	{
 		m_Addresses = AddressesPtr(new Addresses ()); // create empty list
 		m_Buffer = RouterInfo::NewBuffer (); // always RouterInfo's
@@ -58,7 +58,7 @@ namespace data
 	RouterInfo::RouterInfo (std::shared_ptr<Buffer>&& buf, size_t len):
 		m_FamilyID (0), m_IsUpdated (true), m_IsUnreachable (false), m_IsFloodfill (false),
 		m_IsBufferScheduledToDelete (false), m_SupportedTransports (0), m_ReachableTransports (0), m_PublishedTransports (0),
-		m_Caps (0), m_Version (0), m_Congestion (eLowCongestion)
+		m_Caps (0), m_Version (0), m_Congestion (eLowCongestion), m_LastPickTs(0)
 	{
 		if (len <= MAX_RI_BUFFER_SIZE)
 		{
@@ -1017,6 +1017,77 @@ namespace data
 		return profile;
 	}
 
+	const uint64_t RANDOM_PICK_TIMEOUT_MS = 30000;
+
+	// there's some time between a router being randomly picked in NetDb::GetRandomRouter()
+	// and the same router appearing in Tunnels::GetAddressesInUse()
+	// to avoid double pick, introduce RANDOM_PICK_TIMEOUT_MS
+	bool RouterInfo::RecheckTsAndUpdate (uint64_t currentMillis)
+	{
+		auto lastPickTs = LastPickTs();
+		if (lastPickTs + RANDOM_PICK_TIMEOUT_MS > currentMillis || !UpdateLastPickTs(lastPickTs, currentMillis))
+		{
+			LogPrint(eLogDebug, "(unique_only) Last pick ts check failed ", GetIdentHashBase64().substr(0, 4));
+			return false;
+		}
+
+		return true;
+	}
+
+	std::vector<boost::asio::ip::address> RouterInfo::GetAllHostAddresses () const
+	{
+		std::vector<boost::asio::ip::address> result(static_cast<int>(eNumTransports));
+		auto addresses = GetAddresses().get();
+		if (addresses != nullptr) {
+			for (const auto& address : *addresses)
+				if (address && !address.get()->host.is_unspecified()) result.push_back(address.get()->host);
+		}
+		return result;
+	}
+
+	bool RouterInfo::IsMatch(i2p::util::RoutersInUse inUse) const
+	{
+		if (inUse.IdentHashesBase64.count(GetIdentHashBase64()))
+		{
+			LogPrint(eLogDebug, "(unique_only) Filtered hash ", GetIdentHashBase64().substr(0, 4));
+			return true;
+		}
+		return GetAddress([inUse](const std::shared_ptr<const Address>& address)->bool
+		{
+			auto a = address.get();
+			if (a == nullptr || a->host.is_unspecified())
+			{
+				return false;
+			}
+			if (inUse.Hosts.count(a->host))
+			{
+				LogPrint(eLogDebug, "(unique_only) Filtered address ", a->host.to_string());
+				return true;
+			}
+			return false;
+		}) != nullptr;
+	}
+
+	bool RouterInfo::IsOneOfHosts(std::set<boost::asio::ip::address>* addresses) const
+	{
+		if (addresses == nullptr)
+			return false;
+		return GetAddress([addresses](std::shared_ptr<const Address> address)->bool
+		{
+			auto a = address.get();
+			if (a == nullptr || a->host.is_unspecified())
+			{
+				return false;
+			}
+			if (addresses->count(a->host))
+			{
+				LogPrint(eLogDebug, "Filtered address ", a->host.to_string());
+				return true;
+			}
+			return false;
+		}) != nullptr;
+	}
+
 	void RouterInfo::Encrypt (const uint8_t * data, uint8_t * encrypted) const
 	{
 		auto encryptor = m_RouterIdentity->CreateEncryptor (nullptr);
@@ -1215,7 +1286,7 @@ namespace data
 			{
 				auto addr1 = (*addresses1)[i], addr2 = (*addresses2)[i];
 				if (addr1 && addr2 && !addr1->host.is_unspecified () && !addr2->host.is_unspecified ())
-					return addr1->IsSameSubnet (*addr2); // first adddess with IPs
+					return addr1->IsSameSubnet (*addr2); // first address with IPs
 			}
 		return false;
 	}

--- a/libi2pd/RouterInfo.cpp
+++ b/libi2pd/RouterInfo.cpp
@@ -1024,10 +1024,7 @@ namespace data
 	{
 		auto lastPickTs = LastPickTs();
 		if (lastPickTs + RANDOM_PICK_TIMEOUT_MS > currentMillis || !UpdateLastPickTs(lastPickTs, currentMillis))
-		{
-			LogPrint(eLogDebug, "(unique_only) Last pick ts check failed ", GetIdentHashBase64().substr(0, 4));
 			return false;
-		}
 		return true;
 	}
 
@@ -1044,30 +1041,15 @@ namespace data
 
 	bool RouterInfo::IsMatch(const i2p::util::RoutersInUse& inUse) const
 	{
-		std::string d = "(unique_only) Looking for " + GetIdentHashBase64().substr(0, 4) + " among ";
-		for (auto& i: inUse.IdentHashesBase64)
-		{
-			d += i.substr(0, 4) + " ";
-		}
-		LogPrint(eLogDebug, d);
-
 		if (inUse.IdentHashesBase64.count(GetIdentHashBase64()))
-		{
-			LogPrint(eLogDebug, "(unique_only) Filtered hash ", GetIdentHashBase64().substr(0, 4));
 			return true;
-		}
 		return GetAddress([inUse](const std::shared_ptr<const Address>& address)->bool
 		{
 			auto a = address.get();
 			if (a == nullptr || a->host.is_unspecified())
-			{
 				return false;
-			}
 			if (inUse.Hosts.count(a->host))
-			{
-				LogPrint(eLogDebug, "(unique_only) Filtered address ", a->host.to_string());
 				return true;
-			}
 			return false;
 		}) != nullptr;
 	}
@@ -1080,14 +1062,9 @@ namespace data
 		{
 			auto a = address.get();
 			if (a == nullptr || a->host.is_unspecified())
-			{
 				return false;
-			}
 			if (addresses->count(a->host))
-			{
-				LogPrint(eLogDebug, "Filtered address ", a->host.to_string());
 				return true;
-			}
 			return false;
 		}) != nullptr;
 	}

--- a/libi2pd/RouterInfo.cpp
+++ b/libi2pd/RouterInfo.cpp
@@ -1028,7 +1028,6 @@ namespace data
 			LogPrint(eLogDebug, "(unique_only) Last pick ts check failed ", GetIdentHashBase64().substr(0, 4));
 			return false;
 		}
-
 		return true;
 	}
 
@@ -1043,7 +1042,7 @@ namespace data
 		return result;
 	}
 
-	bool RouterInfo::IsMatch(i2p::util::RoutersInUse inUse) const
+	bool RouterInfo::IsMatch(const i2p::util::RoutersInUse& inUse) const
 	{
 		std::string d = "(unique_only) Looking for " + GetIdentHashBase64().substr(0, 4) + " among ";
 		for (auto& i: inUse.IdentHashesBase64)
@@ -1077,7 +1076,7 @@ namespace data
 	{
 		if (addresses == nullptr)
 			return false;
-		return GetAddress([addresses](std::shared_ptr<const Address> address)->bool
+		return GetAddress([addresses](const std::shared_ptr<const Address>& address)->bool
 		{
 			auto a = address.get();
 			if (a == nullptr || a->host.is_unspecified())

--- a/libi2pd/RouterInfo.cpp
+++ b/libi2pd/RouterInfo.cpp
@@ -1017,8 +1017,6 @@ namespace data
 		return profile;
 	}
 
-	const uint64_t RANDOM_PICK_TIMEOUT_MS = 30000;
-
 	// there's some time between a router being randomly picked in NetDb::GetRandomRouter()
 	// and the same router appearing in Tunnels::GetAddressesInUse()
 	// to avoid double pick, introduce RANDOM_PICK_TIMEOUT_MS
@@ -1047,6 +1045,13 @@ namespace data
 
 	bool RouterInfo::IsMatch(i2p::util::RoutersInUse inUse) const
 	{
+		std::string d = "(unique_only) Looking for " + GetIdentHashBase64().substr(0, 4) + " among ";
+		for (auto& i: inUse.IdentHashesBase64)
+		{
+			d += i.substr(0, 4) + " ";
+		}
+		LogPrint(eLogDebug, d);
+
 		if (inUse.IdentHashesBase64.count(GetIdentHashBase64()))
 		{
 			LogPrint(eLogDebug, "(unique_only) Filtered hash ", GetIdentHashBase64().substr(0, 4));

--- a/libi2pd/RouterInfo.h
+++ b/libi2pd/RouterInfo.h
@@ -320,7 +320,7 @@ namespace data
 			std::shared_ptr<RouterProfile> GetProfile () const;
 			bool RecheckTsAndUpdate(uint64_t currentMillis);
 			std::vector<boost::asio::ip::address> GetAllHostAddresses() const;
-			bool IsMatch(util::RoutersInUse inUse) const;
+			bool IsMatch(const util::RoutersInUse& inUse) const;
 			bool IsOneOfHosts(std::set<boost::asio::ip::address>* addresses) const;
 			void DropProfile () { m_Profile = nullptr; };
 			bool HasProfile () const { return (bool)m_Profile; };

--- a/libi2pd/RouterInfo.h
+++ b/libi2pd/RouterInfo.h
@@ -73,6 +73,7 @@ namespace data
 	const size_t MAX_RI_BUFFER_SIZE = 3072; // if RouterInfo exceeds 3K we consider it as malformed, might extend later
 	const int HIGH_CONGESTION_INTERVAL = 15*60; // in seconds, 15 minutes
 	const int INTRODUCER_UPDATE_INTERVAL = 20*60*1000; // in milliseconds, 20 minutes
+	const uint64_t RANDOM_PICK_TIMEOUT_MS = 60000;
 
 	class RouterInfo: public RoutingDestination
 	{

--- a/libi2pd/RouterInfo.h
+++ b/libi2pd/RouterInfo.h
@@ -337,8 +337,8 @@ namespace data
 
 			bool IsDestination () const { return false; };
 
-		    uint64_t LastPickTs() const { return m_LastPickTs.load(); }
-		    bool UpdateLastPickTs(uint64_t oldTs, uint64_t newTs) { return m_LastPickTs.compare_exchange_strong(oldTs, newTs); }
+			uint64_t LastPickTs() const { return m_LastPickTs.load(); }
+			bool UpdateLastPickTs(uint64_t oldTs, uint64_t newTs) { return m_LastPickTs.compare_exchange_strong(oldTs, newTs); }
 
 		protected:
 
@@ -387,7 +387,7 @@ namespace data
 			int m_Version;
 			Congestion m_Congestion;
 			mutable std::shared_ptr<RouterProfile> m_Profile;
-		    std::atomic<uint64_t> m_LastPickTs; // in milliseconds
+			std::atomic<uint64_t> m_LastPickTs; // in milliseconds
 
 		public:
 

--- a/libi2pd/RouterInfo.h
+++ b/libi2pd/RouterInfo.h
@@ -18,6 +18,7 @@
 #include <array>
 #include <iostream>
 #include <memory>
+#include <set>
 #include <boost/asio.hpp>
 #ifndef __cpp_lib_atomic_shared_ptr
 #include <boost/shared_ptr.hpp>
@@ -25,6 +26,7 @@
 #include "Identity.h"
 #include "Profiling.h"
 #include "Family.h"
+#include "util.h"
 
 namespace i2p
 {
@@ -315,6 +317,10 @@ namespace data
 			static bool SaveToFile (const std::string& fullPath, std::shared_ptr<Buffer> buf);
 
 			std::shared_ptr<RouterProfile> GetProfile () const;
+			bool RecheckTsAndUpdate(uint64_t currentMillis);
+			std::vector<boost::asio::ip::address> GetAllHostAddresses() const;
+			bool IsMatch(util::RoutersInUse inUse) const;
+			bool IsOneOfHosts(std::set<boost::asio::ip::address>* addresses) const;
 			void DropProfile () { m_Profile = nullptr; };
 			bool HasProfile () const { return (bool)m_Profile; };
 
@@ -329,6 +335,9 @@ namespace data
 			void Encrypt (const uint8_t * data, uint8_t * encrypted) const;
 
 			bool IsDestination () const { return false; };
+
+		    uint64_t LastPickTs() const { return m_LastPickTs.load(); }
+		    bool UpdateLastPickTs(uint64_t oldTs, uint64_t newTs) { return m_LastPickTs.compare_exchange_strong(oldTs, newTs); }
 
 		protected:
 
@@ -377,6 +386,7 @@ namespace data
 			int m_Version;
 			Congestion m_Congestion;
 			mutable std::shared_ptr<RouterProfile> m_Profile;
+		    std::atomic<uint64_t> m_LastPickTs; // in milliseconds
 
 		public:
 

--- a/libi2pd/TransitTunnel.cpp
+++ b/libi2pd/TransitTunnel.cpp
@@ -27,7 +27,7 @@ namespace tunnel
 	TransitTunnel::TransitTunnel (uint32_t receiveTunnelID,
 		const i2p::data::IdentHash& nextIdent, uint32_t nextTunnelID,
 		const i2p::crypto::AESKey& layerKey, const i2p::crypto::AESKey& ivKey):
-			TunnelBase (receiveTunnelID, nextTunnelID, nextIdent),
+			TunnelBase (receiveTunnelID, nextTunnelID, nextIdent, nullptr),
 			m_LayerKey (layerKey), m_IVKey (ivKey)
 	{
 	}
@@ -567,7 +567,7 @@ namespace tunnel
 		LogPrint (eLogDebug, "TransitTunnel: VariableTunnelBuild ", num, " records");
 		if (num > i2p::tunnel::MAX_NUM_RECORDS)
 		{
-			LogPrint (eLogError, "TransitTunnle: Too many records in VaribleTunnelBuild message ", num);
+			LogPrint (eLogError, "TransitTunnel: Too many records in VaribleTunnelBuild message ", num);
 			return;
 		}
 		if (len < num*TUNNEL_BUILD_RECORD_SIZE + 1)
@@ -595,7 +595,7 @@ namespace tunnel
 
 	bool TransitTunnels::AddTransitTunnel (std::shared_ptr<TransitTunnel> tunnel)
 	{
-		if (tunnels.AddTunnel (tunnel))
+		if (tunnels.AddTunnel (tunnel, true))
 			m_TransitTunnels.push_back (tunnel);
 		else
 		{

--- a/libi2pd/Transports.cpp
+++ b/libi2pd/Transports.cpp
@@ -1210,43 +1210,27 @@ namespace transport
 		return found ? i2p::data::netdb.FindRouter (ident) : nullptr;
 	}
 
-	const uint64_t RANDOM_PICK_TIMEOUT_MS = 30000;
-
-	std::shared_ptr<RouterInfo> recheck(std::shared_ptr<RouterInfo> candidate, uint64_t currentMillis)
+	std::shared_ptr<RouterInfo> recheck(std::shared_ptr<RouterInfo> candidate, uint64_t currentMillis, util::RoutersInUse& inUse)
 	{
 		if (candidate.get())
-		{
-			if (!candidate->RecheckTsAndUpdate(currentMillis))
-			{
+			if (candidate->IsMatch(inUse) && !candidate->RecheckTsAndUpdate(currentMillis))
 				return {nullptr};
-			}
-		}
 		return candidate;
 	}
 
 	std::shared_ptr<i2p::data::RouterInfo> Transports::GetRandomPeer (bool isHighBandwidth, util::RoutersInUse& inUse) const
 	{
 		LogPrint (eLogInfo, "(unique_only) Transports::GetRandomPeer");
-		/*uint64_t currentMillis = util::GetMillisecondsSinceEpoch ();
+		uint64_t currentMillis = util::GetMillisecondsSinceEpoch ();
 		return recheck(GetRandomPeer (
-			[isHighBandwidth, inUse, currentMillis](std::shared_ptr<const Peer> peer)->bool
-			{
-				// connected, not overloaded and not slow
-				return !peer->router && peer->IsConnected () && peer->isEligible &&
-					peer->sessions.front ()->GetSendQueueSize () <= PEER_ROUTER_INFO_OVERLOAD_QUEUE_SIZE &&
-					!peer->sessions.front ()->IsSlow () && !peer->sessions.front ()->IsBandwidthExceeded (peer->isHighBandwidth) &&
-					(!isHighBandwidth || peer->isHighBandwidth) &&
-				    peer->router->LastPickTs() + RANDOM_PICK_TIMEOUT_MS < currentMillis && peer->router->IsMatch(inUse);
-			}), currentMillis);*/
-		return GetRandomPeer (
-			[isHighBandwidth](std::shared_ptr<const Peer> peer)->bool
+			[isHighBandwidth](const std::shared_ptr<Peer>& peer)->bool
 			{
 				// connected, not overloaded and not slow
 				return !peer->router && peer->IsConnected () && peer->isEligible &&
 					peer->sessions.front ()->GetSendQueueSize () <= PEER_ROUTER_INFO_OVERLOAD_QUEUE_SIZE &&
 					!peer->sessions.front ()->IsSlow () && !peer->sessions.front ()->IsBandwidthExceeded (peer->isHighBandwidth) &&
 					(!isHighBandwidth || peer->isHighBandwidth);
-			});
+			}), currentMillis, inUse);
 	}
 
 	void Transports::RestrictRoutesToFamilies(const std::vector<std::string_view>& families)

--- a/libi2pd/Transports.cpp
+++ b/libi2pd/Transports.cpp
@@ -1117,7 +1117,7 @@ namespace transport
 	}
 
 	template<typename Filter>
-	std::shared_ptr<const i2p::data::RouterInfo> Transports::GetRandomPeer (Filter filter) const
+	std::shared_ptr<i2p::data::RouterInfo> Transports::GetRandomPeer (Filter filter) const
 	{
 		if (m_Peers.empty()) return nullptr;
 		auto ts = i2p::util::GetSecondsSinceEpoch ();
@@ -1210,8 +1210,34 @@ namespace transport
 		return found ? i2p::data::netdb.FindRouter (ident) : nullptr;
 	}
 
-	std::shared_ptr<const i2p::data::RouterInfo> Transports::GetRandomPeer (bool isHighBandwidth) const
+	const uint64_t RANDOM_PICK_TIMEOUT_MS = 30000;
+
+	std::shared_ptr<RouterInfo> recheck(std::shared_ptr<RouterInfo> candidate, uint64_t currentMillis)
 	{
+		if (candidate.get())
+		{
+			if (!candidate->RecheckTsAndUpdate(currentMillis))
+			{
+				return {nullptr};
+			}
+		}
+		return candidate;
+	}
+
+	std::shared_ptr<i2p::data::RouterInfo> Transports::GetRandomPeer (bool isHighBandwidth, util::RoutersInUse& inUse) const
+	{
+		LogPrint (eLogInfo, "(unique_only) Transports::GetRandomPeer");
+		/*uint64_t currentMillis = util::GetMillisecondsSinceEpoch ();
+		return recheck(GetRandomPeer (
+			[isHighBandwidth, inUse, currentMillis](std::shared_ptr<const Peer> peer)->bool
+			{
+				// connected, not overloaded and not slow
+				return !peer->router && peer->IsConnected () && peer->isEligible &&
+					peer->sessions.front ()->GetSendQueueSize () <= PEER_ROUTER_INFO_OVERLOAD_QUEUE_SIZE &&
+					!peer->sessions.front ()->IsSlow () && !peer->sessions.front ()->IsBandwidthExceeded (peer->isHighBandwidth) &&
+					(!isHighBandwidth || peer->isHighBandwidth) &&
+				    peer->router->LastPickTs() + RANDOM_PICK_TIMEOUT_MS < currentMillis && peer->router->IsMatch(inUse);
+			}), currentMillis);*/
 		return GetRandomPeer (
 			[isHighBandwidth](std::shared_ptr<const Peer> peer)->bool
 			{

--- a/libi2pd/Transports.cpp
+++ b/libi2pd/Transports.cpp
@@ -1220,7 +1220,6 @@ namespace transport
 
 	std::shared_ptr<i2p::data::RouterInfo> Transports::GetRandomPeer (bool isHighBandwidth, util::RoutersInUse& inUse) const
 	{
-		LogPrint (eLogInfo, "(unique_only) Transports::GetRandomPeer");
 		uint64_t currentMillis = util::GetMillisecondsSinceEpoch ();
 		return recheck(GetRandomPeer (
 			[isHighBandwidth](const std::shared_ptr<Peer>& peer)->bool

--- a/libi2pd/Transports.cpp
+++ b/libi2pd/Transports.cpp
@@ -1212,7 +1212,7 @@ namespace transport
 
 	std::shared_ptr<RouterInfo> recheck(std::shared_ptr<RouterInfo> candidate, uint64_t currentMillis, util::RoutersInUse& inUse)
 	{
-		if (candidate.get())
+		if (netdb.OnlyUniqueHosts() && candidate.get())
 			if (candidate->IsMatch(inUse) && !candidate->RecheckTsAndUpdate(currentMillis))
 				return {nullptr};
 		return candidate;

--- a/libi2pd/Transports.h
+++ b/libi2pd/Transports.h
@@ -175,7 +175,7 @@ namespace transport
 			uint32_t GetTransitBandwidth15s () const { return m_TransitBandwidth15s; };
 			int GetCongestionLevel (bool longTerm) const;
 			size_t GetNumPeers () const { return m_Peers.size (); };
-			std::shared_ptr<const i2p::data::RouterInfo> GetRandomPeer (bool isHighBandwidth) const;
+			std::shared_ptr<data::RouterInfo> GetRandomPeer(bool isHighBandwidth, util::RoutersInUse& inUse) const;
 
 			/** get a trusted first hop for restricted routes */
 			std::shared_ptr<const i2p::data::RouterInfo> GetRestrictedPeer();
@@ -215,7 +215,7 @@ namespace transport
 			void DetectExternalIP ();
 
 			template<typename Filter>
-				std::shared_ptr<const i2p::data::RouterInfo> GetRandomPeer (Filter filter) const;
+				std::shared_ptr<i2p::data::RouterInfo> GetRandomPeer (Filter filter) const;
 
 		private:
 

--- a/libi2pd/Tunnel.cpp
+++ b/libi2pd/Tunnel.cpp
@@ -29,9 +29,9 @@ namespace i2p
 {
 namespace tunnel
 {
-	Tunnel::Tunnel (std::shared_ptr<TunnelConfig> config):
-		TunnelBase (config->GetTunnelID (), config->GetNextTunnelID (), config->GetNextIdentHash ()),
-		m_Config (config), m_IsShortBuildMessage (false), m_Pool (nullptr),
+	Tunnel::Tunnel (const std::shared_ptr<TunnelConfig>& config):
+		TunnelBase (config->GetTunnelID (), config->GetNextTunnelID (), config->GetNextIdentHash (), config),
+		m_IsShortBuildMessage (false), m_Pool (nullptr),
 		m_State (eTunnelStatePending), m_FarEndTransports (i2p::data::RouterInfo::eAllTransports),
 		m_IsRecreated (false), m_Latency (UNKNOWN_LATENCY)
 	{
@@ -242,22 +242,6 @@ namespace tunnel
 		LogPrint (eLogWarning, "Tunnel: Can't send I2NP messages without delivery instructions");
 	}
 
-	std::vector<std::shared_ptr<const i2p::data::IdentityEx> > Tunnel::GetPeers () const
-	{
-		auto peers = GetInvertedPeers ();
-		std::reverse (peers.begin (), peers.end ());
-		return peers;
-	}
-
-	std::vector<std::shared_ptr<const i2p::data::IdentityEx> > Tunnel::GetInvertedPeers () const
-	{
-		// hops are in inverted order
-		std::vector<std::shared_ptr<const i2p::data::IdentityEx> > ret;
-		for (const auto& it: m_Hops)
-			ret.push_back (it.ident);
-		return ret;
-	}
-
 	void Tunnel::SetState(TunnelState state)
 	{
 		m_State = state;
@@ -463,6 +447,44 @@ namespace tunnel
 		SendTunnelDataMsgs (blocks);
 	}
 
+	bool areInUse(const util::RoutersInUse& inUse, const std::vector<std::shared_ptr<const i2p::data::IdentityEx> >& peers)
+	{
+		for (auto& peer: peers)
+		{
+			if (!peer || !peer.get())
+				continue;
+			if (inUse.IdentHashesBase64.count(peer->GetIdentHash().ToBase64()))
+				return true;
+			auto r = data::netdb.FindRouter(peer->GetIdentHash());
+			if (r && r.get() && r->IsMatch(inUse))
+				return true;
+		}
+		return false;
+	}
+
+	bool TunnelBase::ArePeersAlreadyInUse(const util::RoutersInUse& inUse) const
+	{
+		if (m_Config && m_Config.get() && areInUse(inUse, m_Config->GetPeers()))
+			return true;
+		return areInUse(inUse, GetInvertedPeers());
+	}
+
+	bool Tunnels::AreTunnelPeersAlreadyInUsePending(const std::shared_ptr<TunnelBase>& tun) const
+	{
+		// this is transition none -> pending
+		// forbid to match already pending & already established
+		return tun->ArePeersAlreadyInUse(GetAllRoutersInUse());
+	}
+
+	bool Tunnels::AreTunnelPeersAlreadyInUseEstablished(const std::shared_ptr<TunnelBase>& tun) const
+	{
+		// this is transition pending -> established
+		// forbid to match already established
+		util::RoutersInUse inUse;
+		CollectEstablished(inUse);
+		return tun->ArePeersAlreadyInUse(inUse);
+	}
+
 	Tunnels tunnels;
 
 	Tunnels::Tunnels (): m_IsRunning (false), m_Thread (nullptr), m_MaxNumTransitTunnels (DEFAULT_MAX_NUM_TRANSIT_TUNNELS),
@@ -479,23 +501,26 @@ namespace tunnel
 
 	std::shared_ptr<TunnelBase> Tunnels::GetTunnel (uint32_t tunnelID)
 	{
-		std::lock_guard<std::mutex> l(m_TunnelsMutex);
+		std::lock_guard<std::recursive_mutex> l(m_TunnelsMutex);
 		auto it = m_Tunnels.find(tunnelID);
 		if (it != m_Tunnels.end ())
 			return it->second;
 		return nullptr;
 	}
 
-	bool Tunnels::AddTunnel (std::shared_ptr<TunnelBase> tunnel)
+	bool Tunnels::AddTunnel (std::shared_ptr<TunnelBase> tunnel, bool skipCheck)
 	{
 		if (!tunnel) return false;
-		std::lock_guard<std::mutex> l(m_TunnelsMutex);
+		std::lock_guard<std::recursive_mutex> l(m_TunnelsMutex);
+		// do final recheck for non-unique hosts in newTunnel
+		if (data::netdb.OnlyUniqueHosts() && !skipCheck && AreTunnelPeersAlreadyInUseEstablished(tunnel))
+			return false;
 		return m_Tunnels.emplace (tunnel->GetTunnelID (), tunnel).second;
 	}
 
 	void Tunnels::RemoveTunnel (uint32_t tunnelID)
 	{
-		std::lock_guard<std::mutex> l(m_TunnelsMutex);
+		std::lock_guard<std::recursive_mutex> l(m_TunnelsMutex);
 		m_Tunnels.erase (tunnelID);
 	}
 
@@ -929,7 +954,7 @@ namespace tunnel
 		{
 			// trying to create one more outbound tunnel
 			auto inboundTunnel = GetNextInboundTunnel ();
-			auto inUse = GetRoutersInUse();
+			auto inUse = GetAllRoutersInUse();
 			auto router = i2p::transport::transports.RoutesRestricted() ?
 				i2p::transport::transports.GetRestrictedPeer() :
 				i2p::data::netdb.GetRandomRouter (i2p::context.GetSharedRouterInfo (), false, true, false, inUse); // reachable by us
@@ -997,7 +1022,7 @@ namespace tunnel
 
 		if (m_OutboundTunnels.empty () || m_InboundTunnels.size () < 3)
 		{
-			auto inUse = GetRoutersInUse();
+			auto inUse = GetAllRoutersInUse();
 			// trying to create one more inbound tunnel
 			auto router = i2p::transport::transports.RoutesRestricted() ?
 				i2p::transport::transports.GetRestrictedPeer() :
@@ -1042,7 +1067,15 @@ namespace tunnel
 		newTunnel->SetTunnelPool (pool);
 		uint32_t replyMsgID;
 		RAND_bytes ((uint8_t *)&replyMsgID, 4);
-		AddPendingTunnel (replyMsgID, newTunnel);
+		
+		{
+			// do final recheck for non-unique hosts in newTunnel
+			std::lock_guard<std::recursive_mutex> l(m_TunnelsMutex); // mutex ensures no tunnels will be added during recheck
+			if (data::netdb.OnlyUniqueHosts() && AreTunnelPeersAlreadyInUsePending(newTunnel))
+				return {nullptr};
+			AddPendingTunnel (replyMsgID, newTunnel);
+		}
+
 		newTunnel->Build (replyMsgID, outboundTunnel);
 		return newTunnel;
 	}
@@ -1087,18 +1120,18 @@ namespace tunnel
 
 	void Tunnels::AddInboundTunnel (std::shared_ptr<InboundTunnel> newTunnel)
 	{
-		if (AddTunnel (newTunnel))
+		if (AddTunnel (newTunnel, false))
 		{
 			m_InboundTunnels.push_back (newTunnel);
 			auto pool = newTunnel->GetTunnelPool ();
-			if (!pool)
+			if (!pool && !data::netdb.OnlyUniqueHosts())
 			{
 				// build symmetric outbound tunnel
 				CreateTunnel<OutboundTunnel> (std::make_shared<TunnelConfig>(newTunnel->GetInvertedPeers (),
 						newTunnel->GetNextTunnelID (), newTunnel->GetNextIdentHash (), false), nullptr,
 					GetNextOutboundTunnel ());
 			}
-			else
+			else if (pool)
 			{
 				if (pool->IsActive ())
 					pool->TunnelCreated (newTunnel);
@@ -1117,7 +1150,7 @@ namespace tunnel
 		inboundTunnel->SetTunnelPool (pool);
 		inboundTunnel->SetState (eTunnelStateEstablished);
 		m_InboundTunnels.push_back (inboundTunnel);
-		AddTunnel (inboundTunnel);
+		AddTunnel (inboundTunnel, true);
 		return inboundTunnel;
 	}
 
@@ -1180,30 +1213,41 @@ namespace tunnel
 		}
 	}
 
-	util::RoutersInUse Tunnels::GetRoutersInUse() const
+	util::RoutersInUse Tunnels::GetAllRoutersInUse() const
 	{
 		util::RoutersInUse result;
 		if (!data::netdb.OnlyUniqueHosts())
 			return result;
 
-		std::unique_lock<std::mutex> l(m_TunnelsMutex);
+		std::lock_guard<std::recursive_mutex> l(m_TunnelsMutex);
+		CollectEstablished(result);
+		CollectPending(result);
+
+		return result;
+	}
+
+	void Tunnels::CollectEstablished (util::RoutersInUse& collection) const
+	{
 		for (auto& tun: m_InboundTunnels)
-			tun->CollectRouters(result);
+			tun->CollectRouters(collection);
 		for (auto& tun: m_OutboundTunnels)
-			tun->CollectRouters(result);
+			tun->CollectRouters(collection);
+	}
+
+	void Tunnels::CollectPending (util::RoutersInUse& collection) const
+	{
 		for (auto& pair: m_PendingOutboundTunnels)
 		{
 			auto tun = pair.second.get();
 			if (tun)
-				tun->CollectRouters(result);
+				tun->CollectRouters(collection);
 		}
 		for (auto& pair: m_PendingInboundTunnels)
 		{
 			auto tun = pair.second.get();
 			if (tun)
-				tun->CollectRouters(result);
+				tun->CollectRouters(collection);
 		}
-		return result;
 	}
 }
 }

--- a/libi2pd/Tunnel.cpp
+++ b/libi2pd/Tunnel.cpp
@@ -279,21 +279,32 @@ namespace tunnel
 	void Tunnel::PrintPeers(std::string msg)
 	{
 		std::string d = "Tunnel peers: ";
+		if (m_Config && m_Config.get())
+		{
+			for (auto& peer: m_Config.get()->GetPeers())
+			{
+				d += peer.get()->GetIdentHash().ToBase64().substr(0, 4) + " ";
+			}
+		}
 		for (auto& peer: GetInvertedPeers())
 		{
 			d += peer.get()->GetIdentHash().ToBase64().substr(0, 4) + " ";
 		}
-		LogPrint(eLogDebug, d + " " + msg);
+
+		LogPrint(eLogDebug, msg + " " + d);
 	}
 
-	void Tunnel::CollectRouters(i2p::util::RoutersInUse& collection)
+	void collectRoutersFromPeers(i2p::util::RoutersInUse& collection, std::vector<std::shared_ptr<const i2p::data::IdentityEx> > peers)
 	{
-		for (auto& peer: GetInvertedPeers())
+		for (auto& peer: peers)
 		{
+			if (!peer.get())
+				continue;
+
+			collection.IdentHashesBase64.insert(peer->GetIdentHash().ToBase64());
 			auto r = data::netdb.FindRouter(peer->GetIdentHash()).get();
-			if (r != nullptr)
+			if (r)
 			{
-				collection.IdentHashesBase64.insert(peer->GetIdentHash().ToBase64());
 				for (auto& host: r->GetAllHostAddresses())
 				{
 					if (!host.is_unspecified())
@@ -301,6 +312,13 @@ namespace tunnel
 				}
 			}
 		}
+	}
+
+	void Tunnel::CollectRouters(i2p::util::RoutersInUse& collection)
+	{
+		if (m_Config && m_Config.get())
+			collectRoutersFromPeers(collection, m_Config.get()->GetPeers()); // pending tunnels have m_Config & no m_Hops
+		collectRoutersFromPeers(collection, GetInvertedPeers()); // established tunnels have no m_Config & m_Hops
 	}
 
 	void Tunnel::CollectAddresses(std::set<boost::asio::ip::address>& collection)
@@ -1211,20 +1229,23 @@ namespace tunnel
 		util::RoutersInUse result;
 		for (auto& tun: m_InboundTunnels)
 			tun->CollectRouters(result);
-		for (auto& pair: m_PendingInboundTunnels)
-		{
-			auto tun = pair.second.get();
-			if (tun)
-				tun->CollectRouters(result);
-		}
 		for (auto& tun: m_OutboundTunnels)
 			tun->CollectRouters(result);
+		auto sizeBefore = result.IdentHashesBase64.size();
 		for (auto& pair: m_PendingOutboundTunnels)
 		{
 			auto tun = pair.second.get();
 			if (tun)
 				tun->CollectRouters(result);
 		}
+		for (auto& pair: m_PendingInboundTunnels)
+		{
+			auto tun = pair.second.get();
+			if (tun)
+				tun->CollectRouters(result);
+		}
+		auto sizeAfter = result.IdentHashesBase64.size();
+		LogPrint(eLogDebug, "(unique_only) Hashes in pending tunnels size ", sizeAfter - sizeBefore);
 		std::string d = "(unique_only)  Hosts in use ";
 		for (auto& r: result.Hosts)
 		{

--- a/libi2pd/Tunnel.cpp
+++ b/libi2pd/Tunnel.cpp
@@ -276,24 +276,6 @@ namespace tunnel
 			v((*it).ident);
 	}
 
-	void Tunnel::PrintPeers(std::string msg)
-	{
-		std::string d = "Tunnel peers: ";
-		if (m_Config && m_Config.get())
-		{
-			for (auto& peer: m_Config.get()->GetPeers())
-			{
-				d += peer.get()->GetIdentHash().ToBase64().substr(0, 4) + " ";
-			}
-		}
-		for (auto& peer: GetInvertedPeers())
-		{
-			d += peer.get()->GetIdentHash().ToBase64().substr(0, 4) + " ";
-		}
-
-		LogPrint(eLogDebug, msg + " " + d);
-	}
-
 	void collectRoutersFromPeers(i2p::util::RoutersInUse& collection, std::vector<std::shared_ptr<const i2p::data::IdentityEx> > peers)
 	{
 		for (auto& peer: peers)
@@ -304,13 +286,9 @@ namespace tunnel
 			collection.IdentHashesBase64.insert(peer->GetIdentHash().ToBase64());
 			auto r = data::netdb.FindRouter(peer->GetIdentHash()).get();
 			if (r)
-			{
 				for (auto& host: r->GetAllHostAddresses())
-				{
 					if (!host.is_unspecified())
 						collection.Hosts.insert(host);
-				}
-			}
 		}
 	}
 
@@ -1088,19 +1066,16 @@ namespace tunnel
 
 	void Tunnels::AddPendingTunnel (uint32_t replyMsgID, std::shared_ptr<InboundTunnel> tunnel)
 	{
-		tunnel->PrintPeers("(unique_only) AddPendingTunnel inbound");
 		m_PendingInboundTunnels[replyMsgID] = tunnel;
 	}
 
 	void Tunnels::AddPendingTunnel (uint32_t replyMsgID, std::shared_ptr<OutboundTunnel> tunnel)
 	{
-		tunnel->PrintPeers("(unique_only) AddPendingTunnel outbound");
 		m_PendingOutboundTunnels[replyMsgID] = tunnel;
 	}
 
 	void Tunnels::AddOutboundTunnel (std::shared_ptr<OutboundTunnel> newTunnel)
 	{
-		newTunnel->PrintPeers("(unique_only) AddOutboundTunnel");
 		// we don't need to insert it to m_Tunnels
 		m_OutboundTunnels.push_back (newTunnel);
 		auto pool = newTunnel->GetTunnelPool ();
@@ -1112,14 +1087,12 @@ namespace tunnel
 
 	void Tunnels::AddInboundTunnel (std::shared_ptr<InboundTunnel> newTunnel)
 	{
-		newTunnel->PrintPeers("(unique_only) AddInboundTunnel");
 		if (AddTunnel (newTunnel))
 		{
 			m_InboundTunnels.push_back (newTunnel);
 			auto pool = newTunnel->GetTunnelPool ();
 			if (!pool)
 			{
-				newTunnel->PrintPeers("(unique_only)  Creating symmetric tunnel");
 				// build symmetric outbound tunnel
 				CreateTunnel<OutboundTunnel> (std::make_shared<TunnelConfig>(newTunnel->GetInvertedPeers (),
 						newTunnel->GetNextTunnelID (), newTunnel->GetNextIdentHash (), false), nullptr,
@@ -1218,7 +1191,6 @@ namespace tunnel
 			tun->CollectRouters(result);
 		for (auto& tun: m_OutboundTunnels)
 			tun->CollectRouters(result);
-		auto sizeBefore = result.IdentHashesBase64.size();
 		for (auto& pair: m_PendingOutboundTunnels)
 		{
 			auto tun = pair.second.get();
@@ -1231,49 +1203,6 @@ namespace tunnel
 			if (tun)
 				tun->CollectRouters(result);
 		}
-		auto sizeAfter = result.IdentHashesBase64.size();
-		LogPrint(eLogDebug, "(unique_only) Hashes in pending tunnels size ", sizeAfter - sizeBefore);
-		std::string d = "(unique_only)  Hosts in use ";
-		for (auto& r: result.Hosts)
-		{
-			d += r.to_string() + " ";
-		}
-		LogPrint(eLogDebug, d);
-		std::string d2 = "(unique_only)  Hashes in use ";
-		for (auto& r: result.IdentHashesBase64)
-		{
-			d2 += r.substr(0, 4) + " ";
-		}
-		LogPrint(eLogDebug, d2);
-		return result;
-	}
-
-	std::set<boost::asio::ip::address> Tunnels::GetAddressesInUse() const
-	{
-		std::unique_lock<std::mutex> l(m_TunnelsMutex);
-		std::set<boost::asio::ip::address> result;
-		for (auto& tun: m_InboundTunnels)
-			tun->CollectAddresses(result);
-		for (auto& pair: m_PendingInboundTunnels)
-		{
-			auto tun = pair.second.get();
-			if (tun)
-				tun->CollectAddresses(result);
-		}
-		for (auto& tun: m_OutboundTunnels)
-			tun->CollectAddresses(result);
-		for (auto& pair: m_PendingOutboundTunnels)
-		{
-			auto tun = pair.second.get();
-			if (tun)
-				tun->CollectAddresses(result);
-		}
-		std::string d = "(TunnelPool) Addresses in use ";
-		for (auto& r: result)
-		{
-			d += r.to_string() + " ";
-		}
-		LogPrint(eLogDebug, d);
 		return result;
 	}
 }

--- a/libi2pd/Tunnel.cpp
+++ b/libi2pd/Tunnel.cpp
@@ -314,27 +314,11 @@ namespace tunnel
 		}
 	}
 
-	void Tunnel::CollectRouters(i2p::util::RoutersInUse& collection)
+	void Tunnel::CollectRouters (util::RoutersInUse& collection) const
 	{
 		if (m_Config && m_Config.get())
 			collectRoutersFromPeers(collection, m_Config.get()->GetPeers()); // pending tunnels have m_Config & no m_Hops
 		collectRoutersFromPeers(collection, GetInvertedPeers()); // established tunnels have no m_Config & m_Hops
-	}
-
-	void Tunnel::CollectAddresses(std::set<boost::asio::ip::address>& collection)
-	{
-		for (auto& peer: GetInvertedPeers())
-		{
-			auto r = data::netdb.FindRouter(peer->GetIdentHash()).get();
-			if (r != nullptr)
-			{
-				for (auto& host: r->GetAllHostAddresses())
-				{
-					if (!host.is_unspecified())
-						collection.insert(host);
-				}
-			}
-		}
 	}
 
 	void InboundTunnel::HandleTunnelDataMsg (std::shared_ptr<I2NPMessage>&& msg)
@@ -1225,8 +1209,11 @@ namespace tunnel
 
 	util::RoutersInUse Tunnels::GetRoutersInUse() const
 	{
-		std::unique_lock<std::mutex> l(m_TunnelsMutex);
 		util::RoutersInUse result;
+		if (!data::netdb.OnlyUniqueHosts())
+			return result;
+
+		std::unique_lock<std::mutex> l(m_TunnelsMutex);
 		for (auto& tun: m_InboundTunnels)
 			tun->CollectRouters(result);
 		for (auto& tun: m_OutboundTunnels)

--- a/libi2pd/Tunnel.cpp
+++ b/libi2pd/Tunnel.cpp
@@ -276,6 +276,49 @@ namespace tunnel
 			v((*it).ident);
 	}
 
+	void Tunnel::PrintPeers(std::string msg)
+	{
+		std::string d = "Tunnel peers: ";
+		for (auto& peer: GetInvertedPeers())
+		{
+			d += peer.get()->GetIdentHash().ToBase64().substr(0, 4) + " ";
+		}
+		LogPrint(eLogDebug, d + " " + msg);
+	}
+
+	void Tunnel::CollectRouters(i2p::util::RoutersInUse& collection)
+	{
+		for (auto& peer: GetInvertedPeers())
+		{
+			auto r = data::netdb.FindRouter(peer->GetIdentHash()).get();
+			if (r != nullptr)
+			{
+				collection.IdentHashesBase64.insert(peer->GetIdentHash().ToBase64());
+				for (auto& host: r->GetAllHostAddresses())
+				{
+					if (!host.is_unspecified())
+						collection.Hosts.insert(host);
+				}
+			}
+		}
+	}
+
+	void Tunnel::CollectAddresses(std::set<boost::asio::ip::address>& collection)
+	{
+		for (auto& peer: GetInvertedPeers())
+		{
+			auto r = data::netdb.FindRouter(peer->GetIdentHash()).get();
+			if (r != nullptr)
+			{
+				for (auto& host: r->GetAllHostAddresses())
+				{
+					if (!host.is_unspecified())
+						collection.insert(host);
+				}
+			}
+		}
+	}
+
 	void InboundTunnel::HandleTunnelDataMsg (std::shared_ptr<I2NPMessage>&& msg)
 	{
 		if (!IsEstablished () && GetState () != eTunnelStateExpiring)
@@ -906,9 +949,10 @@ namespace tunnel
 		{
 			// trying to create one more outbound tunnel
 			auto inboundTunnel = GetNextInboundTunnel ();
+			auto inUse = GetRoutersInUse();
 			auto router = i2p::transport::transports.RoutesRestricted() ?
 				i2p::transport::transports.GetRestrictedPeer() :
-				i2p::data::netdb.GetRandomRouter (i2p::context.GetSharedRouterInfo (), false, true, false); // reachable by us
+				i2p::data::netdb.GetRandomRouter (i2p::context.GetSharedRouterInfo (), false, true, false, inUse); // reachable by us
 			if (!inboundTunnel || !router) return;
 			LogPrint (eLogDebug, "Tunnel: Creating one hop outbound tunnel");
 			CreateTunnel<OutboundTunnel> (
@@ -973,11 +1017,12 @@ namespace tunnel
 
 		if (m_OutboundTunnels.empty () || m_InboundTunnels.size () < 3)
 		{
+			auto inUse = GetRoutersInUse();
 			// trying to create one more inbound tunnel
 			auto router = i2p::transport::transports.RoutesRestricted() ?
 				i2p::transport::transports.GetRestrictedPeer() :
 				// should be reachable by us because we send build request directly
-				i2p::data::netdb.GetRandomRouter (i2p::context.GetSharedRouterInfo (), false, true, false);
+				i2p::data::netdb.GetRandomRouter (i2p::context.GetSharedRouterInfo (), false, true, false, inUse);
 			if (!router) {
 				LogPrint (eLogWarning, "Tunnel: Can't find any router, skip creating tunnel");
 				return;
@@ -1041,16 +1086,19 @@ namespace tunnel
 
 	void Tunnels::AddPendingTunnel (uint32_t replyMsgID, std::shared_ptr<InboundTunnel> tunnel)
 	{
+		tunnel->PrintPeers("(unique_only) AddPendingTunnel inbound");
 		m_PendingInboundTunnels[replyMsgID] = tunnel;
 	}
 
 	void Tunnels::AddPendingTunnel (uint32_t replyMsgID, std::shared_ptr<OutboundTunnel> tunnel)
 	{
+		tunnel->PrintPeers("(unique_only) AddPendingTunnel outbound");
 		m_PendingOutboundTunnels[replyMsgID] = tunnel;
 	}
 
 	void Tunnels::AddOutboundTunnel (std::shared_ptr<OutboundTunnel> newTunnel)
 	{
+		newTunnel->PrintPeers("(unique_only) AddOutboundTunnel");
 		// we don't need to insert it to m_Tunnels
 		m_OutboundTunnels.push_back (newTunnel);
 		auto pool = newTunnel->GetTunnelPool ();
@@ -1062,12 +1110,14 @@ namespace tunnel
 
 	void Tunnels::AddInboundTunnel (std::shared_ptr<InboundTunnel> newTunnel)
 	{
+		newTunnel->PrintPeers("(unique_only) AddInboundTunnel");
 		if (AddTunnel (newTunnel))
 		{
 			m_InboundTunnels.push_back (newTunnel);
 			auto pool = newTunnel->GetTunnelPool ();
 			if (!pool)
 			{
+				newTunnel->PrintPeers("(unique_only)  Creating symmetric tunnel");
 				// build symmetric outbound tunnel
 				CreateTunnel<OutboundTunnel> (std::make_shared<TunnelConfig>(newTunnel->GetInvertedPeers (),
 						newTunnel->GetNextTunnelID (), newTunnel->GetNextIdentHash (), false), nullptr,
@@ -1153,6 +1203,70 @@ namespace tunnel
 			LogPrint (eLogDebug, "Tunnel: Max number of transit tunnels set to ", maxNumTransitTunnels);
 			m_MaxNumTransitTunnels = maxNumTransitTunnels;
 		}
+	}
+
+	util::RoutersInUse Tunnels::GetRoutersInUse() const
+	{
+		std::unique_lock<std::mutex> l(m_TunnelsMutex);
+		util::RoutersInUse result;
+		for (auto& tun: m_InboundTunnels)
+			tun->CollectRouters(result);
+		for (auto& pair: m_PendingInboundTunnels)
+		{
+			auto tun = pair.second.get();
+			if (tun)
+				tun->CollectRouters(result);
+		}
+		for (auto& tun: m_OutboundTunnels)
+			tun->CollectRouters(result);
+		for (auto& pair: m_PendingOutboundTunnels)
+		{
+			auto tun = pair.second.get();
+			if (tun)
+				tun->CollectRouters(result);
+		}
+		std::string d = "(unique_only)  Hosts in use ";
+		for (auto& r: result.Hosts)
+		{
+			d += r.to_string() + " ";
+		}
+		LogPrint(eLogDebug, d);
+		std::string d2 = "(unique_only)  Hashes in use ";
+		for (auto& r: result.IdentHashesBase64)
+		{
+			d2 += r.substr(0, 4) + " ";
+		}
+		LogPrint(eLogDebug, d2);
+		return result;
+	}
+
+	std::set<boost::asio::ip::address> Tunnels::GetAddressesInUse() const
+	{
+		std::unique_lock<std::mutex> l(m_TunnelsMutex);
+		std::set<boost::asio::ip::address> result;
+		for (auto& tun: m_InboundTunnels)
+			tun->CollectAddresses(result);
+		for (auto& pair: m_PendingInboundTunnels)
+		{
+			auto tun = pair.second.get();
+			if (tun)
+				tun->CollectAddresses(result);
+		}
+		for (auto& tun: m_OutboundTunnels)
+			tun->CollectAddresses(result);
+		for (auto& pair: m_PendingOutboundTunnels)
+		{
+			auto tun = pair.second.get();
+			if (tun)
+				tun->CollectAddresses(result);
+		}
+		std::string d = "(TunnelPool) Addresses in use ";
+		for (auto& r: result)
+		{
+			d += r.to_string() + " ";
+		}
+		LogPrint(eLogDebug, d);
+		return result;
 	}
 }
 }

--- a/libi2pd/Tunnel.h
+++ b/libi2pd/Tunnel.h
@@ -70,25 +70,18 @@ namespace tunnel
 	class Tunnel: public TunnelBase,
 		 public std::enable_shared_from_this<Tunnel>
 	{
-		struct TunnelHop
-		{
-			std::shared_ptr<const i2p::data::IdentityEx> ident;
-			i2p::crypto::TunnelDecryption decryption;
-		};
 
 		public:
 
 			/** function for visiting a hops stored in a tunnel */
 			typedef std::function<void(std::shared_ptr<const i2p::data::IdentityEx>)> TunnelHopVisitor;
 
-			Tunnel (std::shared_ptr<TunnelConfig> config);
+			Tunnel (const std::shared_ptr<TunnelConfig>& config);
 			~Tunnel ();
 
 			void Build (uint32_t replyMsgID, std::shared_ptr<OutboundTunnel> outboundTunnel = nullptr);
 
 			std::shared_ptr<TunnelConfig> GetTunnelConfig () const { return m_Config; }
-			std::vector<std::shared_ptr<const i2p::data::IdentityEx> > GetPeers () const;
-			std::vector<std::shared_ptr<const i2p::data::IdentityEx> > GetInvertedPeers () const;
 			bool IsShortBuildMessage () const { return m_IsShortBuildMessage; }
 			i2p::data::RouterInfo::CompatibleTransports GetFarEndTransports () const { return m_FarEndTransports; };
 			TunnelState GetState () const { return m_State; };
@@ -125,10 +118,7 @@ namespace tunnel
 
 			void CollectRouters(i2p::util::RoutersInUse& collection) const;
 
-		private:
-
-			std::shared_ptr<TunnelConfig> m_Config;
-			std::vector<TunnelHop> m_Hops;
+	private:
 			bool m_IsShortBuildMessage;
 			std::shared_ptr<TunnelPool> m_Pool; // pool, tunnel belongs to, or null
 			TunnelState m_State;
@@ -222,8 +212,10 @@ namespace tunnel
 	class Tunnels
 	{
 		public:
-
-			Tunnels ();
+		bool AreTunnelPeersAlreadyInUse(const std::shared_ptr<TunnelBase>& tun, bool isEstablished) const;
+		bool AreTunnelPeersAlreadyInUsePending(const std::shared_ptr<TunnelBase>& tun) const;
+		bool AreTunnelPeersAlreadyInUseEstablished(const std::shared_ptr<TunnelBase>& tun) const;
+		Tunnels ();
 			~Tunnels ();
 			void Start ();
 			void Stop ();
@@ -234,7 +226,7 @@ namespace tunnel
 			std::shared_ptr<OutboundTunnel> GetNextOutboundTunnel ();
 			std::shared_ptr<TunnelPool> GetExploratoryPool () const { return m_ExploratoryPool; };
 			std::shared_ptr<TunnelBase> GetTunnel (uint32_t tunnelID);
-			bool AddTunnel (std::shared_ptr<TunnelBase> tunnel);
+			bool AddTunnel (std::shared_ptr<TunnelBase> tunnel, bool skipCheck);
 			void RemoveTunnel (uint32_t tunnelID);
 			int GetTransitTunnelsExpirationTimeout ();
 			void AddOutboundTunnel (std::shared_ptr<OutboundTunnel> newTunnel);
@@ -259,9 +251,11 @@ namespace tunnel
 			int GetCongestionLevel() const { return m_MaxNumTransitTunnels ? CONGESTION_LEVEL_FULL * m_TransitTunnels.GetNumTransitTunnels () / m_MaxNumTransitTunnels : CONGESTION_LEVEL_FULL; }
 			std::mt19937& GetRng () { return m_Rng; }
 
-			util::RoutersInUse GetRoutersInUse() const;
-			
-		private:
+			util::RoutersInUse GetAllRoutersInUse() const;
+		void CollectEstablished(util::RoutersInUse& collection) const;
+		void CollectPending(util::RoutersInUse& collection) const;
+
+	private:
 
 			template<class TTunnel>
 			std::shared_ptr<TTunnel> CreateTunnel (std::shared_ptr<TunnelConfig> config,
@@ -315,7 +309,7 @@ namespace tunnel
 			std::map<uint32_t, std::shared_ptr<OutboundTunnel> > m_PendingOutboundTunnels; // by replyMsgID
 			std::list<std::shared_ptr<InboundTunnel> > m_InboundTunnels;
 			std::list<std::shared_ptr<OutboundTunnel> > m_OutboundTunnels;
-			mutable std::mutex m_TunnelsMutex;
+			mutable std::recursive_mutex m_TunnelsMutex;
 			std::unordered_map<uint32_t, std::shared_ptr<TunnelBase> > m_Tunnels; // tunnelID->tunnel known by this id
 			mutable std::mutex m_PoolsMutex;
 			std::list<std::shared_ptr<TunnelPool>> m_Pools;

--- a/libi2pd/Tunnel.h
+++ b/libi2pd/Tunnel.h
@@ -89,8 +89,6 @@ namespace tunnel
 			std::shared_ptr<TunnelConfig> GetTunnelConfig () const { return m_Config; }
 			std::vector<std::shared_ptr<const i2p::data::IdentityEx> > GetPeers () const;
 			std::vector<std::shared_ptr<const i2p::data::IdentityEx> > GetInvertedPeers () const;
-			void CollectRouters(i2p::util::RoutersInUse& collection);
-		    void CollectAddresses(std::set<boost::asio::ip::address>& collection);
 			bool IsShortBuildMessage () const { return m_IsShortBuildMessage; }
 			i2p::data::RouterInfo::CompatibleTransports GetFarEndTransports () const { return m_FarEndTransports; };
 			TunnelState GetState () const { return m_State; };
@@ -127,6 +125,8 @@ namespace tunnel
 		void PrintPeers(std::string msg);
 
 	private:
+
+			void CollectRouters(i2p::util::RoutersInUse& collection) const;
 
 			std::shared_ptr<TunnelConfig> m_Config;
 			std::vector<TunnelHop> m_Hops;
@@ -255,12 +255,12 @@ namespace tunnel
 			std::shared_ptr<I2NPMessage> NewI2NPTunnelMessage (bool endpoint);
 
 			void SetMaxNumTransitTunnels (uint32_t maxNumTransitTunnels);
-			std::set<boost::asio::ip::address> GetAddressesInUse() const;
-		    util::RoutersInUse GetRoutersInUse() const;
 
 			uint32_t GetMaxNumTransitTunnels () const { return m_MaxNumTransitTunnels; };
 			int GetCongestionLevel() const { return m_MaxNumTransitTunnels ? CONGESTION_LEVEL_FULL * m_TransitTunnels.GetNumTransitTunnels () / m_MaxNumTransitTunnels : CONGESTION_LEVEL_FULL; }
 			std::mt19937& GetRng () { return m_Rng; }
+
+			util::RoutersInUse GetRoutersInUse() const;
 			
 		private:
 

--- a/libi2pd/Tunnel.h
+++ b/libi2pd/Tunnel.h
@@ -89,7 +89,9 @@ namespace tunnel
 			std::shared_ptr<TunnelConfig> GetTunnelConfig () const { return m_Config; }
 			std::vector<std::shared_ptr<const i2p::data::IdentityEx> > GetPeers () const;
 			std::vector<std::shared_ptr<const i2p::data::IdentityEx> > GetInvertedPeers () const;
-			bool IsShortBuildMessage () const { return m_IsShortBuildMessage; };
+			void CollectRouters(i2p::util::RoutersInUse& collection);
+		    void CollectAddresses(std::set<boost::asio::ip::address>& collection);
+			bool IsShortBuildMessage () const { return m_IsShortBuildMessage; }
 			i2p::data::RouterInfo::CompatibleTransports GetFarEndTransports () const { return m_FarEndTransports; };
 			TunnelState GetState () const { return m_State; };
 			void SetState (TunnelState state);
@@ -122,8 +124,9 @@ namespace tunnel
 
 			/** visit all hops we currently store */
 			void VisitTunnelHops(TunnelHopVisitor v);
+		void PrintPeers(std::string msg);
 
-		private:
+	private:
 
 			std::shared_ptr<TunnelConfig> m_Config;
 			std::vector<TunnelHop> m_Hops;
@@ -252,6 +255,9 @@ namespace tunnel
 			std::shared_ptr<I2NPMessage> NewI2NPTunnelMessage (bool endpoint);
 
 			void SetMaxNumTransitTunnels (uint32_t maxNumTransitTunnels);
+			std::set<boost::asio::ip::address> GetAddressesInUse() const;
+		    util::RoutersInUse GetRoutersInUse() const;
+
 			uint32_t GetMaxNumTransitTunnels () const { return m_MaxNumTransitTunnels; };
 			int GetCongestionLevel() const { return m_MaxNumTransitTunnels ? CONGESTION_LEVEL_FULL * m_TransitTunnels.GetNumTransitTunnels () / m_MaxNumTransitTunnels : CONGESTION_LEVEL_FULL; }
 			std::mt19937& GetRng () { return m_Rng; }

--- a/libi2pd/Tunnel.h
+++ b/libi2pd/Tunnel.h
@@ -122,11 +122,10 @@ namespace tunnel
 
 			/** visit all hops we currently store */
 			void VisitTunnelHops(TunnelHopVisitor v);
-		void PrintPeers(std::string msg);
-
-	private:
 
 			void CollectRouters(i2p::util::RoutersInUse& collection) const;
+
+		private:
 
 			std::shared_ptr<TunnelConfig> m_Config;
 			std::vector<TunnelHop> m_Hops;

--- a/libi2pd/TunnelBase.cpp
+++ b/libi2pd/TunnelBase.cpp
@@ -66,6 +66,22 @@ namespace tunnel
 		m_CurrentTransport.reset ();
 		if (m_PendingTransport.valid ())
 			m_PendingTransport = std::future<std::shared_ptr<i2p::transport::TransportSession> >();
-	}	
+	}
+
+	std::vector<std::shared_ptr<const i2p::data::IdentityEx> > TunnelBase::GetPeers () const
+	{
+		auto peers = GetInvertedPeers ();
+		std::reverse (peers.begin (), peers.end ());
+		return peers;
+	}
+
+	std::vector<std::shared_ptr<const i2p::data::IdentityEx> > TunnelBase::GetInvertedPeers () const
+	{
+		// hops are in inverted order
+		std::vector<std::shared_ptr<const i2p::data::IdentityEx> > ret;
+		for (const auto& it: m_Hops)
+			ret.push_back (it.ident);
+		return ret;
+	}
 }
 }

--- a/libi2pd/TunnelBase.h
+++ b/libi2pd/TunnelBase.h
@@ -26,6 +26,7 @@ namespace transport
 	
 namespace tunnel
 {
+	class TunnelConfig;
 	const size_t TUNNEL_DATA_MSG_SIZE = 1028;
 	const size_t TUNNEL_DATA_ENCRYPTED_SIZE = 1008;
 	const size_t TUNNEL_DATA_MAX_PAYLOAD_SIZE = 1003;
@@ -43,15 +44,21 @@ namespace tunnel
 		uint32_t tunnelID;
 		std::shared_ptr<I2NPMessage> data;
 	};
+	struct TunnelHop
+	{
+		std::shared_ptr<const i2p::data::IdentityEx> ident;
+		i2p::crypto::TunnelDecryption decryption;
+	};
 
 	class TunnelBase
 	{
 		public:
 
-			TunnelBase (uint32_t tunnelID, uint32_t nextTunnelID, const i2p::data::IdentHash& nextIdent):
-				m_TunnelID (tunnelID), m_NextTunnelID (nextTunnelID), m_NextIdent (nextIdent),
+			TunnelBase (uint32_t tunnelID, uint32_t nextTunnelID, const i2p::data::IdentHash& nextIdent,
+					const std::shared_ptr<TunnelConfig>& config):
+		        m_Config(config), m_TunnelID (tunnelID), m_NextTunnelID (nextTunnelID), m_NextIdent (nextIdent),
 				m_CreationTime (i2p::util::GetSecondsSinceEpoch ()) {};
-			virtual ~TunnelBase () {};
+			virtual ~TunnelBase () {}
 			virtual void Cleanup () {};
 
 			virtual void HandleTunnelDataMsg (std::shared_ptr<i2p::I2NPMessage>&& tunnelMsg) = 0;
@@ -64,6 +71,14 @@ namespace tunnel
 
 			uint32_t GetCreationTime () const { return m_CreationTime; };
 			void SetCreationTime (uint32_t t) { m_CreationTime = t; };
+
+			virtual std::vector<std::shared_ptr<const i2p::data::IdentityEx> > GetInvertedPeers () const;
+			std::vector<std::shared_ptr<const i2p::data::IdentityEx> > GetPeers () const;
+			virtual bool ArePeersAlreadyInUse(const util::RoutersInUse& inUse) const;
+
+		protected:
+			std::shared_ptr<TunnelConfig> m_Config;
+			std::vector<TunnelHop> m_Hops;
 
 		private:
 

--- a/libi2pd/TunnelPool.cpp
+++ b/libi2pd/TunnelPool.cpp
@@ -319,7 +319,7 @@ namespace tunnel
 			for (const auto& it : m_InboundTunnels)
 				if (it->IsEstablished ()) num++;
 		}
-		/*if (!num && !m_OutboundTunnels.empty () && m_NumOutboundHops > 0 &&
+		if (!data::netdb.OnlyUniqueHosts() && !num && !m_OutboundTunnels.empty () && m_NumOutboundHops > 0 &&
 		    m_NumInboundHops == m_NumOutboundHops)
 		{
 			for (auto it: m_OutboundTunnels)
@@ -329,7 +329,7 @@ namespace tunnel
 				num++;
 				if (num >= m_NumInboundTunnels) break;
 			}
-		}*/
+		}
 		num = m_NumInboundTunnels - num;
 		if (num > 0)
 		{

--- a/libi2pd/TunnelPool.cpp
+++ b/libi2pd/TunnelPool.cpp
@@ -319,7 +319,7 @@ namespace tunnel
 			for (const auto& it : m_InboundTunnels)
 				if (it->IsEstablished ()) num++;
 		}
-		if (!num && !m_OutboundTunnels.empty () && m_NumOutboundHops > 0 &&
+		/*if (!num && !m_OutboundTunnels.empty () && m_NumOutboundHops > 0 &&
 		    m_NumInboundHops == m_NumOutboundHops)
 		{
 			for (auto it: m_OutboundTunnels)
@@ -329,7 +329,7 @@ namespace tunnel
 				num++;
 				if (num >= m_NumInboundTunnels) break;
 			}
-		}
+		}*/
 		num = m_NumInboundTunnels - num;
 		if (num > 0)
 		{

--- a/libi2pd/TunnelPool.cpp
+++ b/libi2pd/TunnelPool.cpp
@@ -573,8 +573,8 @@ namespace tunnel
 		{
 			hop = tryClient ?
 				(m_IsHighBandwidth ?
-				 	i2p::data::netdb.GetHighBandwidthRandomRouter (prevHop, reverse, endpoint, inUse) :
-				 	i2p::data::netdb.GetRandomRouter (prevHop, reverse, endpoint, true, inUse)):
+					i2p::data::netdb.GetHighBandwidthRandomRouter (prevHop, reverse, endpoint, inUse) :
+					i2p::data::netdb.GetRandomRouter (prevHop, reverse, endpoint, true, inUse)):
 				i2p::data::netdb.GetRandomRouter (prevHop, reverse, endpoint, false, inUse);
 			if (hop)
 			{
@@ -589,18 +589,8 @@ namespace tunnel
 		return hop;
 	}
 
-	void printPath(Path & path, std::string msg)
-	{
-		std::string d = msg + " ";
-		for (auto& peer: path.peers)
-			if (peer.get())
-				d += peer.get()->GetIdentHash().ToBase64().substr(0, 4) + " ";
-		LogPrint(eLogDebug, d);
-	}
-
 	bool TunnelPool::StandardSelectPeers(Path & path, int numHops, bool inbound, SelectHopFunc nextHop)
 	{
-		printPath(path, "(unique_only) Path before select ");
 		auto inUse = tunnels.GetRoutersInUse();
 		int start = 0;
 		std::shared_ptr<const i2p::data::RouterInfo> prevHop = i2p::context.GetSharedRouterInfo ();
@@ -628,8 +618,6 @@ namespace tunnel
 			}
 		}
 
-		printPath(path, "(unique_only) Path before select2 ");
-
 		for(int i = start; i < numHops; i++ )
 		{
 			auto hop = nextHop (prevHop, inbound, i == numHops - 1);
@@ -648,7 +636,6 @@ namespace tunnel
 			path.Add (hop);
 		}
 		path.farEndTransports = prevHop->GetCompatibleTransports (inbound); // last hop
-		printPath(path, "(unique_only) Path after select ");
 		return true;
 	}
 

--- a/libi2pd/TunnelPool.cpp
+++ b/libi2pd/TunnelPool.cpp
@@ -566,7 +566,7 @@ namespace tunnel
 	std::shared_ptr<const i2p::data::RouterInfo> TunnelPool::SelectNextHop (std::shared_ptr<const i2p::data::RouterInfo> prevHop,
 		bool reverse, bool endpoint) const
 	{
-		auto inUse = tunnels.GetRoutersInUse();
+		auto inUse = tunnels.GetAllRoutersInUse();
 		bool tryClient = !IsExploratory () && !i2p::context.IsLimitedConnectivity ();
 		std::shared_ptr<const i2p::data::RouterInfo> hop;
 		for (int i = 0; i < TUNNEL_POOL_MAX_HOP_SELECTION_ATTEMPTS; i++)
@@ -591,7 +591,7 @@ namespace tunnel
 
 	bool TunnelPool::StandardSelectPeers(Path & path, int numHops, bool inbound, SelectHopFunc nextHop)
 	{
-		auto inUse = tunnels.GetRoutersInUse();
+		auto inUse = tunnels.GetAllRoutersInUse();
 		int start = 0;
 		std::shared_ptr<const i2p::data::RouterInfo> prevHop = i2p::context.GetSharedRouterInfo ();
 		if(i2p::transport::transports.RoutesRestricted() || !m_TrustedRouters.empty ())
@@ -760,7 +760,7 @@ namespace tunnel
 				config = std::make_shared<TunnelConfig> (path.peers, path.isShort, path.farEndTransports);
 			}
 			auto tunnel = tunnels.CreateInboundTunnel (config, shared_from_this (), outboundTunnel);
-			if (tunnel->IsEstablished ()) // zero hops
+			if (tunnel && tunnel.get() && tunnel->IsEstablished ()) // zero hops
 				TunnelCreated (tunnel);
 		}
 		else
@@ -789,10 +789,13 @@ namespace tunnel
 		if (!m_NumInboundHops || config)
 		{
 			auto newTunnel = tunnels.CreateInboundTunnel (config, shared_from_this(), outboundTunnel);
-			if (newTunnel->IsEstablished ()) // zero hops
-				TunnelCreated (newTunnel);
-			else
-				newTunnel->SetRecreated (true);
+			if (newTunnel && newTunnel.get())
+			{
+				if (newTunnel->IsEstablished ()) // zero hops
+					TunnelCreated (newTunnel);
+				else
+					newTunnel->SetRecreated (true);
+			}
 		}
 	}
 
@@ -827,11 +830,12 @@ namespace tunnel
 			{
 				// TODO: implement it better
 				tunnel = tunnels.CreateOutboundTunnel (config, inboundTunnel->GetTunnelPool ());
-				tunnel->SetTunnelPool (shared_from_this ());
+				if (tunnel && tunnel.get())
+					tunnel->SetTunnelPool (shared_from_this ());
 			}
 			else
 				tunnel = tunnels.CreateOutboundTunnel (config, shared_from_this ());
-			if (tunnel && tunnel->IsEstablished ()) // zero hops
+			if (tunnel && tunnel.get() && tunnel->IsEstablished ()) // zero hops
 				TunnelCreated (tunnel);
 		}
 		else
@@ -862,7 +866,7 @@ namespace tunnel
 			if (!m_NumOutboundHops || config)
 			{
 				auto newTunnel = tunnels.CreateOutboundTunnel (config, shared_from_this ());
-				if (newTunnel->IsEstablished ()) // zero hops
+				if (newTunnel && newTunnel.get() && newTunnel->IsEstablished ()) // zero hops
 					TunnelCreated (newTunnel);
 			}
 		}
@@ -877,7 +881,7 @@ namespace tunnel
 			m_NumOutboundHops > 0 ? std::make_shared<TunnelConfig>(outboundTunnel->GetInvertedPeers (),
 				outboundTunnel->IsShortBuildMessage ()) : nullptr,
 				shared_from_this (), outboundTunnel);
-		if (tunnel->IsEstablished ()) // zero hops
+		if (tunnel && tunnel.get() && tunnel->IsEstablished ()) // zero hops
 			TunnelCreated (tunnel);
 	}
 

--- a/libi2pd/TunnelPool.cpp
+++ b/libi2pd/TunnelPool.cpp
@@ -566,15 +566,16 @@ namespace tunnel
 	std::shared_ptr<const i2p::data::RouterInfo> TunnelPool::SelectNextHop (std::shared_ptr<const i2p::data::RouterInfo> prevHop,
 		bool reverse, bool endpoint) const
 	{
+		auto inUse = tunnels.GetRoutersInUse();
 		bool tryClient = !IsExploratory () && !i2p::context.IsLimitedConnectivity ();
 		std::shared_ptr<const i2p::data::RouterInfo> hop;
 		for (int i = 0; i < TUNNEL_POOL_MAX_HOP_SELECTION_ATTEMPTS; i++)
 		{
 			hop = tryClient ?
 				(m_IsHighBandwidth ?
-				 	i2p::data::netdb.GetHighBandwidthRandomRouter (prevHop, reverse, endpoint) :
-				 	i2p::data::netdb.GetRandomRouter (prevHop, reverse, endpoint, true)):
-				i2p::data::netdb.GetRandomRouter (prevHop, reverse, endpoint, false);
+				 	i2p::data::netdb.GetHighBandwidthRandomRouter (prevHop, reverse, endpoint, inUse) :
+				 	i2p::data::netdb.GetRandomRouter (prevHop, reverse, endpoint, true, inUse)):
+				i2p::data::netdb.GetRandomRouter (prevHop, reverse, endpoint, false, inUse);
 			if (hop)
 			{
 				if (!hop->HasProfile () || !hop->GetProfile ()->IsBad ())
@@ -588,8 +589,19 @@ namespace tunnel
 		return hop;
 	}
 
+	void printPath(Path & path, std::string msg)
+	{
+		std::string d = msg + " ";
+		for (auto& peer: path.peers)
+			if (peer.get())
+				d += peer.get()->GetIdentHash().ToBase64().substr(0, 4) + " ";
+		LogPrint(eLogDebug, d);
+	}
+
 	bool TunnelPool::StandardSelectPeers(Path & path, int numHops, bool inbound, SelectHopFunc nextHop)
 	{
+		printPath(path, "(unique_only) Path before select ");
+		auto inUse = tunnels.GetRoutersInUse();
 		int start = 0;
 		std::shared_ptr<const i2p::data::RouterInfo> prevHop = i2p::context.GetSharedRouterInfo ();
 		if(i2p::transport::transports.RoutesRestricted() || !m_TrustedRouters.empty ())
@@ -606,7 +618,7 @@ namespace tunnel
 			(inbound && (i2p::transport::transports.GetNumPeers () > 25 ||
             (i2p::context.IsLimitedConnectivity () && i2p::transport::transports.GetNumPeers () > 0))))
 		{
-			auto r = i2p::transport::transports.GetRandomPeer (m_IsHighBandwidth && !i2p::context.IsLimitedConnectivity ());
+			auto r = i2p::transport::transports.GetRandomPeer (m_IsHighBandwidth && !i2p::context.IsLimitedConnectivity (), inUse);
 			if (r && r->IsECIES () && (!r->HasProfile () || !r->GetProfile ()->IsBad ()) &&
 				(numHops > 1 || (r->IsV4 () && (!inbound || r->IsPublished (true))))) // first inbound must be published ipv4
 			{
@@ -616,13 +628,15 @@ namespace tunnel
 			}
 		}
 
+		printPath(path, "(unique_only) Path before select2 ");
+
 		for(int i = start; i < numHops; i++ )
 		{
 			auto hop = nextHop (prevHop, inbound, i == numHops - 1);
 			if (!hop && !i) // if no suitable peer found for first hop, try already connected
 			{
 				LogPrint (eLogInfo, "Tunnels: Can't select first hop for a tunnel. Trying already connected");
-				hop = i2p::transport::transports.GetRandomPeer (false);
+				hop = i2p::transport::transports.GetRandomPeer (false, inUse);
 				if (hop && !hop->IsECIES ()) hop = nullptr;
 			}
 			if (!hop)
@@ -634,6 +648,7 @@ namespace tunnel
 			path.Add (hop);
 		}
 		path.farEndTransports = prevHop->GetCompatibleTransports (inbound); // last hop
+		printPath(path, "(unique_only) Path after select ");
 		return true;
 	}
 

--- a/libi2pd/util.h
+++ b/libi2pd/util.h
@@ -19,6 +19,7 @@
 #include <utility>
 #include <charconv>
 #include <boost/asio.hpp>
+#include <set>
 
 #ifdef ANDROID
 #ifndef __clang__
@@ -330,6 +331,13 @@ namespace util
 		bool IsYggdrasilAddress (const boost::asio::ip::address& addr);
 		bool IsPortInReservedRange (const uint16_t port) noexcept;
 	}
+
+	class RoutersInUse
+	{
+	public:
+		std::set<boost::asio::ip::address> Hosts;
+		std::set<std::string> IdentHashesBase64;
+	};
 }
 }
 


### PR DESCRIPTION
To avoid situations like on the screenshots attached, I've introduced a setting to disable building tunnels through routers and host addresses which are currently in use.
The setting doesn't affect transit tunnels.
<img width="791" height="244" alt="1" src="https://github.com/user-attachments/assets/65715b73-bf9b-459e-9921-11a781159c1c" />
<img width="784" height="189" alt="2" src="https://github.com/user-attachments/assets/8cc62da1-50e4-4d6d-8601-af2a97e8ab47" />
