### PR TITLE
[debian] exclude obsolete dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: i2pd
 Section: net
 Priority: optional
 Maintainer: r4sas <r4sas@i2pmail.org>
-Build-Depends: debhelper (>= 12~), libboost-system-dev (>= 1.46), libboost-date-time-dev (>= 1.46), libboost-filesystem-dev (>= 1.46), libboost-program-options-dev (>= 1.46), libminiupnpc-dev, libssl-dev, zlib1g-dev
+Build-Depends: debhelper (>= 12~), libboost-program-options-dev (>= 1.46), libminiupnpc-dev, libssl-dev, zlib1g-dev
 Standards-Version: 4.3.0
 Homepage: http://i2pd.website/
 Vcs-Git: git://github.com/PurpleI2P/i2pd.git
@@ -11,7 +11,7 @@ Vcs-Browser: https://github.com/PurpleI2P/i2pd
 Package: i2pd
 Architecture: any
 Pre-Depends: ${misc:Pre-Depends}, adduser
-Depends: ${shlibs:Depends}, ${misc:Depends}, lsb-base,
+Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Full-featured C++ implementation of I2P client.
  I2P (Invisible Internet Protocol) is a universal anonymous network layer. All
  communications over I2P are anonymous and end-to-end encrypted, participants


### PR DESCRIPTION
As far as I understand, support for Debian 10 was dropped because of the end of gcc 8 support, unless install gcc 10 in Buster from debian-backports (if possible) 
https://distrowatch.com/table.php?distribution=debian
So some packages are not required.
See also https://github.com/PurpleI2P/i2pd/issues/2262

Not tested on Debian 11.
