### PR TITLE
Fix libi2pd underlinking exposed by "-Wl,--as-needed" and strict linkers

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -356,6 +356,8 @@ message(STATUS "  THREADSANITIZER  : ${WITH_THREADSANITIZER}")
 message(STATUS "  UNDEFSANITIZER   : ${WITH_UNDEFSANITIZER}")
 message(STATUS "---------------------------------------")
 
+target_link_libraries(libi2pd PUBLIC ZLIB::ZLIB OpenSSL::SSL OpenSSL::Crypto ${Boost_LIBRARIES} Threads::Threads)
+
 if(WITH_BINARY)
   if(WIN32)
     add_executable("${PROJECT_NAME}" WIN32 ${DAEMON_SRC} ${WIN32_RC})


### PR DESCRIPTION
This PR fixes a runtime crash on Linux caused by underlinking the core shared library.

Currently, libi2pd requires crc32 from zlib (along with OpenSSL and Boost) but isn't explicitly linked to them in CMakeLists.txt. It only survives at runtime because more lenient linking setups (like the default bfd used here) leave the main executable's unused dependencies globally visible for the shared library to piggyback on.

If a user builds i2pd in an environment that enforces -Wl,--as-needed (which is standard on distributions like Gentoo) combined with a strict linker like mold, the linker correctly identifies that the main executable doesn't use zlib directly and strips it. This removes the accidental fallback, causing a fatal `undefined symbol: crc32` crash the moment the daemon executes.

Explicitly linking the required external dependencies directly to libi2pd resolves this permanently without affecting libi2pdclient or libi2pdlang.