### PR TITLE
Don't preserve session lifetime in handlers

### DIFF
--- a/libi2pd/Transports.cpp
+++ b/libi2pd/Transports.cpp
@@ -896,10 +896,12 @@ namespace transport
 		m_X25519KeysPairSupplier.Return (pair);
 	}
 
-	void Transports::PeerConnected (std::shared_ptr<TransportSession> session)
+	void Transports::PeerConnected (std::weak_ptr<TransportSession> session)
 	{
-		boost::asio::post (*m_Service, [session, this]()
+		boost::asio::post (*m_Service, [weakSession = std::move(session), this]()
 		{
+			auto session = weakSession.lock();
+			if (!session) return;
 			auto remoteIdentity = session->GetRemoteIdentity ();
 			if (!remoteIdentity) return;
 			auto ident = remoteIdentity->GetIdentHash ();
@@ -973,10 +975,12 @@ namespace transport
 		});
 	}
 
-	void Transports::PeerDisconnected (std::shared_ptr<TransportSession> session)
+	void Transports::PeerDisconnected (std::weak_ptr<TransportSession> session)
 	{
-		boost::asio::post (*m_Service, [session, this]()
+		boost::asio::post (*m_Service, [weakSession = std::move(session), this]()
 		{
+			auto session = weakSession.lock();
+			if (!session) return;
 			auto remoteIdentity = session->GetRemoteIdentity ();
 			if (!remoteIdentity) return;
 			auto ident = remoteIdentity->GetIdentHash ();

--- a/libi2pd/Transports.h
+++ b/libi2pd/Transports.h
@@ -156,8 +156,8 @@ namespace transport
 			std::future<std::shared_ptr<TransportSession> > SendMessage (const i2p::data::IdentHash& ident, std::shared_ptr<i2p::I2NPMessage> msg);
 			std::future<std::shared_ptr<TransportSession> > SendMessages (const i2p::data::IdentHash& ident, std::list<std::shared_ptr<i2p::I2NPMessage> >&& msgs);
 
-			void PeerConnected (std::shared_ptr<TransportSession> session);
-			void PeerDisconnected (std::shared_ptr<TransportSession> session);
+			void PeerConnected (std::weak_ptr<TransportSession> session);
+			void PeerDisconnected (std::weak_ptr<TransportSession> session);
 			bool IsConnected (const i2p::data::IdentHash& ident) const;
 			void UpdatePeerParams (std::shared_ptr<const i2p::data::RouterInfo> r);
 


### PR DESCRIPTION
This is an issue because i2pd does not wait for all handlers queued for execution inside io_context to execute before it's destroyed. Because these handlers preserve lifetime of IO objects via a shared pointer we get into a situation where destroying io_context will invoke destructors on those IO objects which in turn will attempt to access io_context and the app will crash.

More info here https://github.com/PurpleI2P/i2pd/issues/2354