### PR TITLE
FS.h: add missing header

### DIFF
--- a/libi2pd/FS.h
+++ b/libi2pd/FS.h
@@ -14,6 +14,7 @@
 #include <iostream>
 #include <sstream>
 #include <functional>
+#include <inttypes.h>
 
 #ifndef STD_FILESYSTEM
 #	if (_WIN32 && __GNUG__) // MinGW GCC somehow incorrectly converts paths


### PR DESCRIPTION
Fix for undefined `uint32_t` error.