### PR TITLE
Case insensitive http headers

### DIFF
--- a/libi2pd/HTTP.cpp
+++ b/libi2pd/HTTP.cpp
@@ -372,7 +372,7 @@ namespace http
 	void HTTPReq::UpdateHeader (const std::string& name, const std::string& value)
 	{
 		for (auto& it : headers)
-			if (it.first == name)
+			if (boost::iequals(it.first, name))
 			{
 				it.second = value;
 				break;
@@ -383,7 +383,7 @@ namespace http
 	{
 		for (auto it = headers.begin (); it != headers.end ();)
 		{
-			if (!it->first.compare(0, name.length (), name) && it->first != exempt)
+			if (boost::istarts_with(it->first, name) && !boost::iequals(it->first, exempt))
 				it = headers.erase (it);
 			else
 				it++;
@@ -393,7 +393,7 @@ namespace http
 	std::string HTTPReq::GetHeader (std::string_view name) const
 	{
 		for (auto& it : headers)
-			if (it.first == name)
+			if (boost::iequals(it.first, name))
 				return it.second;
 		return "";
 	}
@@ -402,7 +402,7 @@ namespace http
 	{
 		size_t num = 0;
 		for (auto& it : headers)
-			if (it.first == name) num++;
+			if (boost::iequals(it.first, name)) num++;
 		return num;
 	}
 

--- a/libi2pd/HTTP.h
+++ b/libi2pd/HTTP.h
@@ -16,6 +16,7 @@
 #include <string>
 #include <string_view>
 #include <vector>
+#include <boost/algorithm/string/predicate.hpp>
 
 namespace i2p
 {
@@ -23,6 +24,17 @@ namespace http
 {
 	constexpr std::string_view CRLF = "\r\n";         /**< HTTP line terminator */
 	constexpr std::string_view HTTP_EOH = "\r\n\r\n"; /**< HTTP end-of-headers mark */
+
+	// case-insensitive comparator for HTTP header names (RFC 7230)
+	struct CaseInsensitiveLess
+	{
+		using is_transparent = void;
+
+		bool operator() (std::string_view a, std::string_view b) const
+		{
+			return boost::ilexicographical_compare(a, b);
+		}
+	};
 
 	struct URL
 	{
@@ -66,7 +78,7 @@ namespace http
 
 	struct HTTPMsg
 	{
-		std::map<std::string, std::string> headers;
+		std::map<std::string, std::string, CaseInsensitiveLess> headers;
 
 		void add_header(const char *name, const std::string & value, bool replace = false);
 		void add_header(const char *name, const char *value, bool replace = false);

--- a/tests/test-http-req.cpp
+++ b/tests/test-http-req.cpp
@@ -83,6 +83,59 @@ int main() {
   assert(req->GetHeader("Accept-Encoding") == "");
   delete req;
 
+  /* test: case-insensitive header matching (RFC 7230) */
+  buf =
+    "GET / HTTP/1.1\r\n"
+    "HOST: example.i2p\r\n"
+    "content-type: text/html\r\n"
+    "Content-Length: 100\r\n"
+    "X-Custom-Header: value\r\n"
+    "\r\n";
+  len = strlen(buf);
+  req = new HTTPReq;
+  assert((ret = req->parse(buf, len)) == len);
+  /* GetHeader should be case-insensitive */
+  assert(req->GetHeader("Host") == "example.i2p");
+  assert(req->GetHeader("host") == "example.i2p");
+  assert(req->GetHeader("HOST") == "example.i2p");
+  assert(req->GetHeader("Content-Type") == "text/html");
+  assert(req->GetHeader("content-type") == "text/html");
+  assert(req->GetHeader("CONTENT-TYPE") == "text/html");
+  assert(req->GetHeader("Content-Length") == "100");
+  assert(req->GetHeader("content-length") == "100");
+  assert(req->GetHeader("x-custom-header") == "value");
+  assert(req->GetHeader("X-CUSTOM-HEADER") == "value");
+  /* GetNumHeaders should be case-insensitive */
+  assert(req->GetNumHeaders("Host") == 1);
+  assert(req->GetNumHeaders("host") == 1);
+  assert(req->GetNumHeaders("HOST") == 1);
+  assert(req->GetNumHeaders("content-type") == 1);
+  delete req;
+
+  /* test: UpdateHeader case-insensitivity */
+  req = new HTTPReq;
+  req->AddHeader("Content-Type", "text/plain");
+  assert(req->GetHeader("Content-Type") == "text/plain");
+  req->UpdateHeader("content-type", "application/json");
+  assert(req->GetHeader("Content-Type") == "application/json");
+  assert(req->GetHeader("CONTENT-TYPE") == "application/json");
+  req->UpdateHeader("CONTENT-TYPE", "text/html");
+  assert(req->GetHeader("content-type") == "text/html");
+  delete req;
+
+  /* test: RemoveHeader case-insensitivity */
+  req = new HTTPReq;
+  req->AddHeader("X-Forwarded-For", "1.2.3.4");
+  req->AddHeader("X-Forwarded-Host", "proxy.i2p");
+  req->AddHeader("Accept", "*/*");
+  assert(req->GetNumHeaders() == 3);
+  /* remove headers starting with "x-forwarded" (case-insensitive), exempt "X-Forwarded-Host" */
+  req->RemoveHeader("X-Forwarded", "x-forwarded-host");
+  assert(req->GetNumHeaders() == 2);
+  assert(req->GetHeader("X-Forwarded-Host") == "proxy.i2p");
+  assert(req->GetHeader("X-Forwarded-For") == "");
+  delete req;
+
   return 0;
 }
 

--- a/tests/test-http-res.cpp
+++ b/tests/test-http-res.cpp
@@ -44,6 +44,74 @@ int main() {
   res->add_header("Content-Length", "0");
   assert(res->to_string() == buf);
 
+  /* test: case-insensitive header parsing (RFC 7230) */
+  buf =
+    "HTTP/1.1 200 OK\r\n"
+    "content-type: text/html\r\n"
+    "CONTENT-LENGTH: 42\r\n"
+    "transfer-encoding: chunked\r\n"
+    "content-encoding: gzip\r\n"
+    "\r\n";
+  len = strlen(buf);
+  res = new HTTPRes;
+  assert((ret = res->parse(buf, len)) == len);
+  assert(res->code == 200);
+  /* content_length() should work with any case */
+  assert(res->content_length() == 42);
+  /* is_chunked() should work with any case */
+  assert(res->is_chunked() == true);
+  /* is_gzipped() should work with any case */
+  assert(res->is_gzipped() == true);
+  delete res;
+
+  /* test: add_header case-insensitivity (no duplicates) */
+  res = new HTTPRes;
+  res->add_header("Content-Type", "text/plain");
+  res->add_header("content-type", "text/html"); /* should not add duplicate */
+  assert(res->headers.size() == 1);
+  res->add_header("content-type", "application/json", true); /* replace=true */
+  assert(res->headers.size() == 1);
+  delete res;
+
+  /* test: del_header case-insensitivity */
+  res = new HTTPRes;
+  res->add_header("X-Custom-Header", "value");
+  assert(res->headers.size() == 1);
+  res->del_header("x-custom-header");
+  assert(res->headers.size() == 0);
+  delete res;
+
+  /* test: to_string() doesn't add duplicate Date/Content-Length with different case */
+  res = new HTTPRes;
+  res->version = "HTTP/1.1";
+  res->code = 200;
+  res->status = "OK";
+  res->add_header("date", "Thu, 01 Jan 1970 00:00:00 GMT");
+  res->add_header("content-length", "0");
+  res->body = "";
+  std::string response = res->to_string();
+  /* should not have duplicate headers */
+  size_t date_count = 0, pos = 0;
+  while ((pos = response.find("ate:", pos)) != std::string::npos) {
+    date_count++;
+    pos++;
+  }
+  assert(date_count == 1); /* only one Date header */
+  delete res;
+
+  /* test: get_header case-insensitivity (used by Reseed for Location redirect) */
+  buf =
+    "HTTP/1.1 302 Found\r\n"
+    "location: https://example.com/new\r\n"
+    "\r\n";
+  len = strlen(buf);
+  res = new HTTPRes;
+  assert((ret = res->parse(buf, len)) == len);
+  assert(res->get_header("Location") == "https://example.com/new");
+  assert(res->get_header("location") == "https://example.com/new");
+  assert(res->get_header("LOCATION") == "https://example.com/new");
+  delete res;
+
   return 0;
 }
 


### PR DESCRIPTION
HTTP header names are case-insensitive, but i2pd's HTTP library compares them case-sensitively. This means a client sending `host:` instead of `Host:` gets a 403 from the web console, the HTTP proxy can't find the destination host, and response headers like `content-length` or `transfer-encoding` go unrecognized. A similar fix was already applied to I2PControl's HTTP parser (#2268); this extends case-insensitive matching to the shared HTTP library.

The fix: `HTTPMsg` gets a case-insensitive comparator on its `std::map` so all lookups work automatically. `HTTPReq` keeps its `std::list` and just swaps `==` for `boost::iequals` in the lookup methods. No containers, signatures, or behavior changed.
