### PR TITLE
Prevent buffer overflow on large I2PControl requests

### DIFF
--- a/daemon/I2PControl.cpp
+++ b/daemon/I2PControl.cpp
@@ -257,10 +257,13 @@ namespace client
 						return; // TODO:
 					}
 					std::streamoff rem = contentLength + ss.tellg () - bytes_transferred; // more bytes to read
-					if (rem > 0)
+					while (rem > 0) // read in chunks to prevent buffer overflow
 					{
-						bytes_transferred = boost::asio::read (*socket, boost::asio::buffer (buf->data (), rem));
+						size_t toRead = std::min ((size_t)rem, buf->size ()); // don't exceed buffer size
+						bytes_transferred = boost::asio::read (*socket, boost::asio::buffer (buf->data (), toRead));
+						if (bytes_transferred == 0) break;
 						ss.write (buf->data (), bytes_transferred);
+						rem -= bytes_transferred;
 					}
 				}
 				std::ostringstream response;


### PR DESCRIPTION
When an I2PControl JSON-RPC request body is larger than the internal 1024-byte buffer, `boost::asio::buffer(buf->data(), rem)` is called with `rem` exceeding the buffer size. This creates a buffer view past the array bounds, causing heap corruption and a crash (SIGABRT). I found this while experimenting with additional API parameters not currently exposed by the app — current real-world usage doesn't produce requests large enough to trigger it, but any sufficiently large request body will.

The fix changes the single read into a loop that reads in chunks of at most `buf->size()`.

### Reproduction

Start i2pd with I2PControl enabled, authenticate, then send a large payload (~3000+ bytes):

```bash
# authenticate
TOKEN=$(curl -k -s https://127.0.0.1:7650/jsonrpc \
  -d '{"id":1,"method":"Authenticate","jsonrpc":"2.0","params":{"API":1,"Password":"itoopie"}}' \
  | grep -o '"Token":"[^"]*"' | cut -d'"' -f4)

# send large payload — crashes i2pd before fix
PADDING=$(printf 'X%.0s' $(seq 1 3000))
curl -k -s https://127.0.0.1:7650/jsonrpc \
  -d "{\"id\":1,\"jsonrpc\":\"2.0\",\"method\":\"RouterInfo\",\"params\":{\"Token\":\"$TOKEN\",\"padding\":\"$PADDING\"}}"
```
