### PR TITLE
Add missing I2PControl RouterInfo metrics

### DIFF
--- a/daemon/I2PControlHandlers.cpp
+++ b/daemon/I2PControlHandlers.cpp
@@ -32,6 +32,8 @@ namespace client
 		m_RouterInfoHandlers["i2p.router.status"]                    = &I2PControlHandlers::StatusHandler;
 		m_RouterInfoHandlers["i2p.router.netdb.knownpeers"]          = &I2PControlHandlers::NetDbKnownPeersHandler;
 		m_RouterInfoHandlers["i2p.router.netdb.activepeers"]         = &I2PControlHandlers::NetDbActivePeersHandler;
+		m_RouterInfoHandlers["i2p.router.netdb.floodfills"]          = &I2PControlHandlers::NetDbFloodfillsHandler;
+		m_RouterInfoHandlers["i2p.router.netdb.leasesets"]           = &I2PControlHandlers::NetDbLeaseSetsHandler;
 		m_RouterInfoHandlers["i2p.router.net.bw.inbound.1s"]         = &I2PControlHandlers::InboundBandwidth1S;
 		m_RouterInfoHandlers["i2p.router.net.bw.inbound.15s"]        = &I2PControlHandlers::InboundBandwidth15S;
 		m_RouterInfoHandlers["i2p.router.net.bw.outbound.1s"]        = &I2PControlHandlers::OutboundBandwidth1S;
@@ -43,9 +45,16 @@ namespace client
 		m_RouterInfoHandlers["i2p.router.net.testing"]               = &I2PControlHandlers::NetTestingHandler;
 		m_RouterInfoHandlers["i2p.router.net.testing.v6"]            = &I2PControlHandlers::NetTestingV6Handler;
 		m_RouterInfoHandlers["i2p.router.net.tunnels.participating"] = &I2PControlHandlers::TunnelsParticipatingHandler;
+		m_RouterInfoHandlers["i2p.router.net.tunnels.inbound"]       = &I2PControlHandlers::TunnelsInboundHandler;
+		m_RouterInfoHandlers["i2p.router.net.tunnels.outbound"]      = &I2PControlHandlers::TunnelsOutboundHandler;
 		m_RouterInfoHandlers["i2p.router.net.tunnels.successrate"]   = &I2PControlHandlers::TunnelsSuccessRateHandler;
+		m_RouterInfoHandlers["i2p.router.net.tunnels.totalsuccessrate"] = &I2PControlHandlers::TunnelsTotalSuccessRateHandler;
+		m_RouterInfoHandlers["i2p.router.net.tunnels.queue"]         = &I2PControlHandlers::TunnelsQueueHandler;
+		m_RouterInfoHandlers["i2p.router.net.tunnels.tbmqueue"]      = &I2PControlHandlers::TunnelsTBMQueueHandler;
 		m_RouterInfoHandlers["i2p.router.net.total.received.bytes"]  = &I2PControlHandlers::NetTotalReceivedBytes;
 		m_RouterInfoHandlers["i2p.router.net.total.sent.bytes"]      = &I2PControlHandlers::NetTotalSentBytes;
+		m_RouterInfoHandlers["i2p.router.net.total.transit.bytes"]   = &I2PControlHandlers::NetTotalTransitBytes;
+		m_RouterInfoHandlers["i2p.router.net.bw.transit.15s"]        = &I2PControlHandlers::TransitBandwidth15S;
 
 		// NetworkSetting
 		m_NetworkSettingHandlers["i2p.router.net.bw.in"]  = &I2PControlHandlers::InboundBandwidthLimit;
@@ -137,6 +146,16 @@ namespace client
 		InsertParam (results, "i2p.router.netdb.activepeers", (int)i2p::transport::transports.GetPeers ().size ());
 	}
 
+	void I2PControlHandlers::NetDbFloodfillsHandler (std::ostringstream& results)
+	{
+		InsertParam (results, "i2p.router.netdb.floodfills", i2p::data::netdb.GetNumFloodfills ());
+	}
+
+	void I2PControlHandlers::NetDbLeaseSetsHandler (std::ostringstream& results)
+	{
+		InsertParam (results, "i2p.router.netdb.leasesets", i2p::data::netdb.GetNumLeaseSets ());
+	}
+
 	void I2PControlHandlers::NetStatusHandler (std::ostringstream& results)
 	{
 		InsertParam (results, "i2p.router.net.status", (int)i2p::context.GetStatus ());
@@ -173,10 +192,40 @@ namespace client
 		InsertParam (results, "i2p.router.net.tunnels.participating", transit);
 	}
 
+	void I2PControlHandlers::TunnelsInboundHandler (std::ostringstream& results)
+	{
+		int inbound = i2p::tunnel::tunnels.CountInboundTunnels ();
+		InsertParam (results, "i2p.router.net.tunnels.inbound", inbound);
+	}
+
+	void I2PControlHandlers::TunnelsOutboundHandler (std::ostringstream& results)
+	{
+		int outbound = i2p::tunnel::tunnels.CountOutboundTunnels ();
+		InsertParam (results, "i2p.router.net.tunnels.outbound", outbound);
+	}
+
 	void I2PControlHandlers::TunnelsSuccessRateHandler (std::ostringstream& results)
 	{
 		int rate = i2p::tunnel::tunnels.GetTunnelCreationSuccessRate ();
 		InsertParam (results, "i2p.router.net.tunnels.successrate", rate);
+	}
+
+	void I2PControlHandlers::TunnelsTotalSuccessRateHandler (std::ostringstream& results)
+	{
+		int rate = i2p::tunnel::tunnels.GetTotalTunnelCreationSuccessRate ();
+		InsertParam (results, "i2p.router.net.tunnels.totalsuccessrate", rate);
+	}
+
+	void I2PControlHandlers::TunnelsQueueHandler (std::ostringstream& results)
+	{
+		int queue = i2p::tunnel::tunnels.GetQueueSize ();
+		InsertParam (results, "i2p.router.net.tunnels.queue", queue);
+	}
+
+	void I2PControlHandlers::TunnelsTBMQueueHandler (std::ostringstream& results)
+	{
+		int queue = i2p::tunnel::tunnels.GetTBMQueueSize ();
+		InsertParam (results, "i2p.router.net.tunnels.tbmqueue", queue);
 	}
 
 	void I2PControlHandlers::InboundBandwidth1S (std::ostringstream& results)
@@ -203,6 +252,12 @@ namespace client
 		InsertParam (results, "i2p.router.net.bw.outbound.15s", bw);
 	}
 
+	void I2PControlHandlers::TransitBandwidth15S (std::ostringstream& results)
+	{
+		double bw = i2p::transport::transports.GetTransitBandwidth15s ();
+		InsertParam (results, "i2p.router.net.bw.transit.15s", bw);
+	}
+
 	void I2PControlHandlers::NetTotalReceivedBytes (std::ostringstream& results)
 	{
 		InsertParam (results, "i2p.router.net.total.received.bytes", (double)i2p::transport::transports.GetTotalReceivedBytes ());
@@ -211,6 +266,11 @@ namespace client
 	void I2PControlHandlers::NetTotalSentBytes (std::ostringstream& results)
 	{
 		InsertParam (results, "i2p.router.net.total.sent.bytes", (double)i2p::transport::transports.GetTotalSentBytes ());
+	}
+
+	void I2PControlHandlers::NetTotalTransitBytes (std::ostringstream& results)
+	{
+		InsertParam (results, "i2p.router.net.total.transit.bytes", (double)i2p::transport::transports.GetTotalTransitTransmittedBytes ());
 	}
 
 // network setting

--- a/daemon/I2PControlHandlers.h
+++ b/daemon/I2PControlHandlers.h
@@ -46,6 +46,8 @@ namespace client
 			void StatusHandler (std::ostringstream& results);
 			void NetDbKnownPeersHandler (std::ostringstream& results);
 			void NetDbActivePeersHandler (std::ostringstream& results);
+			void NetDbFloodfillsHandler (std::ostringstream& results);
+			void NetDbLeaseSetsHandler (std::ostringstream& results);
 			void NetStatusHandler (std::ostringstream& results);
 			void NetStatusV6Handler (std::ostringstream& results);
 			void NetErrorHandler (std::ostringstream& results);
@@ -53,13 +55,20 @@ namespace client
 			void NetTestingHandler (std::ostringstream& results);
 			void NetTestingV6Handler (std::ostringstream& results);
 			void TunnelsParticipatingHandler (std::ostringstream& results);
+			void TunnelsInboundHandler (std::ostringstream& results);
+			void TunnelsOutboundHandler (std::ostringstream& results);
 			void TunnelsSuccessRateHandler (std::ostringstream& results);
+			void TunnelsTotalSuccessRateHandler (std::ostringstream& results);
+			void TunnelsQueueHandler (std::ostringstream& results);
+			void TunnelsTBMQueueHandler (std::ostringstream& results);
 			void InboundBandwidth1S (std::ostringstream& results);
 			void InboundBandwidth15S (std::ostringstream& results);
 			void OutboundBandwidth1S (std::ostringstream& results);
 			void OutboundBandwidth15S (std::ostringstream& results);
+			void TransitBandwidth15S (std::ostringstream& results);
 			void NetTotalReceivedBytes (std::ostringstream& results);
 			void NetTotalSentBytes (std::ostringstream& results);
+			void NetTotalTransitBytes (std::ostringstream& results);
 
 			// NetworkSetting
 			typedef void (I2PControlHandlers::*NetworkSettingRequestHandler)(const std::string& value, std::ostringstream& results);


### PR DESCRIPTION
The I2PControl JSON-RPC interface exposes a subset of router metrics through `RouterInfo`, but several values already available internally are missing from the handler map. This adds 9 new metrics, bringing the API to parity with the webconsole's main status page:

- `i2p.router.netdb.floodfills`
- `i2p.router.netdb.leasesets`
- `i2p.router.net.tunnels.inbound`
- `i2p.router.net.tunnels.outbound`
- `i2p.router.net.tunnels.totalsuccessrate`
- `i2p.router.net.tunnels.queue`
- `i2p.router.net.tunnels.tbmqueue`
- `i2p.router.net.bw.transit.15s`
- `i2p.router.net.total.transit.bytes`

Each metric delegates to an existing public method (`GetNumFloodfills`, `CountInboundTunnels`, `GetTransitBandwidth15s`, etc.) — no new logic was added to the core.

Open to suggestions on the metric names — I tried to follow the existing naming conventions, but happy to adjust if there's a preferred style.
