### PR TITLE
added log file size limit option

### DIFF
--- a/contrib/i2pd.conf
+++ b/contrib/i2pd.conf
@@ -263,6 +263,10 @@ verify = true
 # openfiles = 0
 ## Maximum size of corefile in Kb (0 - use system limit)
 # coresize = 0
+## Maximum log file size before it gets truncated and started anew.
+## Accepts plain bytes or values with K/M/G suffix, e.g. 15M, 5G.
+## 0 means no limit (default: 0).
+# logfilesize = 0
 
 [trust]
 ## Enable explicit trust options. (default: false)

--- a/daemon/Daemon.cpp
+++ b/daemon/Daemon.cpp
@@ -9,6 +9,8 @@
 #include <thread>
 #include <memory>
 #include <regex>
+#include <cctype>
+#include <cstdint>
 
 #include "Daemon.h"
 
@@ -54,6 +56,39 @@ namespace util
 	Daemon_Singleton::Daemon_Singleton() : isDaemon(false), running(true), d(*new Daemon_Singleton_Private()) {}
 	Daemon_Singleton::~Daemon_Singleton() {
 		delete &d;
+	}
+
+	/**
+	 * Parse a size value with an optional K/M/G/T suffix (case-insensitive,
+	 * trailing 'B' permitted, e.g. "5G", "15mb", "1024"). Returns 0 on
+	 * empty/invalid input or when the parsed value is 0.
+	 */
+	static size_t ParseSizeWithSuffix (const std::string& s)
+	{
+		if (s.empty ()) return 0;
+		size_t i = 0;
+		while (i < s.size () && std::isspace ((unsigned char)s[i])) i++;
+		size_t start = i;
+		while (i < s.size () && std::isdigit ((unsigned char)s[i])) i++;
+		if (i == start) return 0;
+		uint64_t value = 0;
+		try { value = std::stoull (s.substr (start, i - start)); }
+		catch (...) { return 0; }
+		while (i < s.size () && std::isspace ((unsigned char)s[i])) i++;
+		uint64_t mult = 1;
+		if (i < s.size ())
+		{
+			char c = std::tolower ((unsigned char)s[i]);
+			switch (c)
+			{
+				case 'k': mult = 1024ULL; break;
+				case 'm': mult = 1024ULL * 1024; break;
+				case 'g': mult = 1024ULL * 1024 * 1024; break;
+				case 't': mult = 1024ULL * 1024 * 1024 * 1024; break;
+				default: return 0; // unknown suffix
+			}
+		}
+		return (size_t)(value * mult);
 	}
 
 	bool Daemon_Singleton::IsService () const
@@ -135,6 +170,11 @@ namespace util
 			if (logfile == "")
 				logfile = i2p::fs::DataDirPath("i2pd.log");
 			LogPrint(eLogInfo, "Log: Sending messages to ", logfile);
+			std::string logfilesize; i2p::config::GetOption("limits.logfilesize", logfilesize);
+			size_t limit = ParseSizeWithSuffix (logfilesize);
+			if (limit > 0)
+				LogPrint(eLogInfo, "Log: Logfile size limit set to ", limit, " bytes");
+			i2p::log::Logger().SetLogFileSizeLimit (limit);
 			i2p::log::Logger().SendTo (logfile);
 #ifndef _WIN32
 		} else if (logs == "syslog") {

--- a/libi2pd/Config.cpp
+++ b/libi2pd/Config.cpp
@@ -94,6 +94,7 @@ namespace config {
 			("limits.openfiles", value<uint16_t>()->default_value(0),         "Maximum number of open files (0 - use system default)")
 #endif
 			("limits.transittunnels", value<uint32_t>()->default_value(25000), "Maximum active transit tunnels (default:25000)")
+			("limits.logfilesize", value<std::string>()->default_value("0"),  "Maximum log file size before truncation. Accepts plain bytes or values with K/M/G suffix (e.g. 15M, 5G). 0 disables (default: 0)")
 			("limits.zombies", value<double>()->default_value(0),             "Minimum percentage of successfully created tunnels under which tunnel cleanup is paused (default [%]: 0.00)")
 			("limits.ntcpsoft", value<uint16_t>()->default_value(0),          "Ignored")
 			("limits.ntcphard", value<uint16_t>()->default_value(0),          "Ignored")

--- a/libi2pd/Log.cpp
+++ b/libi2pd/Log.cpp
@@ -71,8 +71,17 @@ namespace log {
 	Log::Log():
 	m_Destination(eLogStdout), m_MinLevel(eLogInfo),
 	m_LogStream (nullptr), m_Logfile(""), m_HasColors(true), m_TimeFormat("%H:%M:%S"),
-	m_IsRunning (false), m_Thread (nullptr)
+	m_IsRunning (false), m_Thread (nullptr), m_LogFileSizeLimit (0), m_LogFileBytes (0)
 	{
+	}
+
+	/** @brief Returns the current size of @a path on disk, or 0 if it can't be read. */
+	static size_t GetFileSizeOnDisk (const std::string& path)
+	{
+		std::ifstream f (path, std::ios::binary | std::ios::ate);
+		if (!f.is_open ()) return 0;
+		std::streamoff sz = f.tellg ();
+		return sz > 0 ? (size_t)sz : 0;
 	}
 
 	Log::~Log ()
@@ -175,10 +184,19 @@ namespace log {
 			case eLogFile:
 			case eLogStream:
 				if (m_LogStream)
+				{
 					*m_LogStream << TimeAsString(msg->timestamp)
 						<< "@" << short_tid
 						<< "/" << g_LogLevelStr[msg->level]
 						<< " - " << msg->text << std::endl;
+					if (m_Destination == eLogFile && m_LogFileSizeLimit > 0)
+					{
+						// Approximate written bytes: timestamp(8) + "@" + 3 + "/" + level(8) + " - " + msg + "\n"
+						m_LogFileBytes += msg->text.size () + 24;
+						if (m_LogFileBytes >= m_LogFileSizeLimit)
+							Rotate ();
+					}
+				}
 				break;
 			case eLogStdout:
 			default:
@@ -222,6 +240,7 @@ namespace log {
 			m_Logfile = path;
 			m_Destination = eLogFile;
 			m_LogStream = os;
+			m_LogFileBytes = GetFileSizeOnDisk (path);
 			return;
 		}
 		LogPrint(eLogCritical, "Log: Can't open file ", path);
@@ -246,6 +265,22 @@ namespace log {
 	void Log::Reopen() {
 		if (m_Destination == eLogFile)
 			SendTo(m_Logfile);
+	}
+
+	void Log::Rotate() {
+		if (m_Destination != eLogFile || m_Logfile.empty ()) return;
+		m_LogStream = nullptr; // close previous
+		auto flags = std::ofstream::out | std::ofstream::trunc;
+		auto os = std::make_shared<std::ofstream> (m_Logfile, flags);
+		if (os->is_open ())
+		{
+			m_HasColors = false;
+			m_LogStream = os;
+			m_LogFileBytes = 0;
+			return;
+		}
+		// fall back to plain reopen if truncation failed for any reason
+		SendTo (m_Logfile);
 	}
 
 	Log & Logger() {

--- a/libi2pd/Log.h
+++ b/libi2pd/Log.h
@@ -64,6 +64,8 @@ namespace log {
 			std::string m_TimeFormat;
 			volatile bool m_IsRunning;
 			std::thread * m_Thread;
+			size_t m_LogFileSizeLimit;
+			size_t m_LogFileBytes;
 
 		private:
 
@@ -73,6 +75,9 @@ namespace log {
 
 			void Run ();
 			void Process (std::shared_ptr<LogMsg> msg);
+
+			/** @brief Truncate logfile and reopen it from scratch */
+			void Rotate ();
 
 			/**
 			 * @brief Makes formatted string from unix timestamp
@@ -116,6 +121,14 @@ namespace log {
 			 * @param format String with timestamp format
 			 */
 			void SetTimeFormat (std::string format) { m_TimeFormat = format; };
+
+			/**
+			 * @brief Sets maximum logfile size in bytes
+			 * @param limit Maximum logfile size in bytes (0 - no limit).
+			 *              When the file exceeds this size it is truncated
+			 *              and a new one is started in its place.
+			 */
+			void SetLogFileSizeLimit (size_t limit) { m_LogFileSizeLimit = limit; };
 
 	#ifndef _WIN32
 			/**


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                              
  Adds a new `limits.logfilesize` option that automatically truncates the log                                                                                                                                                                                 
  file once it grows beyond the configured size and starts a fresh one in
  its place. Default is `0` (no limit), preserving the previous behavior.                                                                                                                                                                                     
                                                                                                                                                                                                                                                              
  Motivated by an IRC report of `/var/log/i2pd` accumulating ~30 GB over half                                                                                                                                                                                 
  a month of uptime. `kill -USR1` works for manual rotation but is easy to                                                                                                                                                                                    
  forget; this gives users a simple safety net via configuration.                                                                                                                                                                                             
                                                                                                                                                                                                                                                              
  ## Configuration                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                              
  New option in the `[limits]` section:                                                                                                                                                                                                                       
   
  [limits]                                                                                                                                                                                                                                                    
  logfilesize = 100M
     
  Supported values:
                                                                                                                                                                                                                                                              
  | Value         | Meaning                          |
  |---------------|----------------------------------|                                                                                                                                                                                                        
  | `0`           | no limit (default)               |
  | `<number>`    | size in bytes (e.g. `1048576`)   |                                                                                                                                                                                                        
  | `<number>K`   | kibibytes, e.g. `512K` / `512KB` |
  | `<number>M`   | mebibytes, e.g. `100M` / `100MB` |                                                                                                                                                                                                        
  | `<number>G`   | gibibytes, e.g. `2G` / `2GB`     |                                                                                                                                                                                                        
                                                                                                                                                                                                                                                              
  Suffixes are case-insensitive. Invalid input falls back to `0`.                                                                                                                                                                                             
                                                                                                                                                                                                                                                              
  ## Implementation notes                                                                                                                                                                                                                                     
   
  - Tracked via an internal byte counter in `i2p::log::Log`, initialized                                                                                                                                                                                      
    from the existing on-disk file size on open, so an already-oversized
    log gets rotated on the first message after startup.                                                                                                                                                                                                      
  - On limit hit, the file is reopened with `std::ofstream::trunc` — same                                                                                                                                                                                     
    inode, same permissions/ownership, no renaming or unlink. Tools that                                                                                                                                                                                      
    watch the file (`tail -f`, log shippers) keep working across rotations.                                                                                                                                                                                   
  - Suffix parsing lives in `Daemon.cpp` (`ParseSizeWithSuffix`).                                                                                                                                                                                             
  - Only affects `log = file`. `stdout` and `syslog` destinations are                                                                                                                                                                                         
    untouched.                                                                                                                                                                                                                                                
  - `kill -USR1` reopen path is unchanged.                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                              
  ## Test plan    
                                                                                                                                                                                                                                                              
  - [x] `logfilesize = 0` — file grows without bound (legacy behavior)                                                                                                                                                                                        
  - [x] `logfilesize = 4K` with `loglevel = debug` — file repeatedly
        truncates near the limit                                                                                                                                                                                                                              
  - [x] Pre-existing oversized file rotates on first new message after start