### PR TITLE
use C++17, add Boost Atomic

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -286,7 +286,7 @@ else()
   endif()
 endif()
 
-find_package(Boost REQUIRED COMPONENTS filesystem program_options)
+find_package(Boost REQUIRED COMPONENTS filesystem program_options atomic)
 if(NOT DEFINED Boost_FOUND)
   message(SEND_ERROR "Boost is not found, or your boost version was below 1.46. Please download Boost!")
 endif()

--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -9,6 +9,12 @@ endif()
 # for debugging
 #set(CMAKE_VERBOSE_MAKEFILE on)
 
+# fix: error C2039: 'string_view': is not a member of 'std'
+# MSVC defaults to C++14
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 # paths
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules")
 set(CMAKE_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/..")


### PR DESCRIPTION
fix build on windows

i2pd 2.60.0: build error: `error C2039: 'string_view': is not a member of 'std'`
[i2pd.2.60.0.windows.cpp14.build.error.txt.gz](https://github.com/user-attachments/files/28088946/i2pd.2.60.0.windows.cpp14.build.error.txt.gz)

```
2026-05-20T22:13:44.1011650Z (%BUILD_PREFIX%) %SRC_DIR%\build>cmake --build . --config Release 
2026-05-20T22:13:44.2048368Z MSBuild version 17.14.40+3e7442088 for .NET Framework
2026-05-20T22:13:44.2331413Z 
2026-05-20T22:13:44.5402165Z   1>Checking Build System
2026-05-20T22:13:44.7141691Z   Building Custom Rule D:/bld/i2pd_1779315167388/work/build/CMakeLists.txt
2026-05-20T22:13:44.8672139Z   Base.cpp
2026-05-20T22:13:45.5394221Z C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\string_view(12): warning STL4038: Th
e contents of <string_view> are available only with C++17 or later. [%SRC_DIR%\build\libi2pd.vcxproj]
2026-05-20T22:13:45.5738312Z   Blinding.cpp
2026-05-20T22:13:45.5791982Z %SRC_DIR%\libi2pd\Base.h(22,34): error C2039: 'string_view': is not a member of 'std' [%SRC_DIR%\build\libi2pd.vcxproj]
```

with 3e2e402: link error `LINK : fatal error LNK1104: cannot open file 'boost_atomic.lib'`
[i2pd.2.60.0-3e2e402.windows.cpp14.build.error.fixed.now.link.error.txt.gz](https://github.com/user-attachments/files/28088954/i2pd.2.60.0-3e2e402.windows.cpp14.build.error.fixed.now.link.error.txt.gz)

```
2026-05-20T22:46:11.8594773Z (%BUILD_PREFIX%) %SRC_DIR%\build>cmake --build . --config Release 
2026-05-20T22:46:11.9668177Z MSBuild version 17.14.40+3e7442088 for .NET Framework
2026-05-20T22:46:11.9960987Z 
2026-05-20T22:46:12.2910622Z   1>Checking Build System
2026-05-20T22:46:12.4675347Z   Building Custom Rule D:/bld/i2pd_1779317111489/work/build/CMakeLists.txt
2026-05-20T22:46:12.6212958Z   Base.cpp
2026-05-20T22:46:13.5647011Z   Blinding.cpp
2026-05-20T22:46:16.7387909Z   Config.cpp
...
2026-05-20T22:53:11.2585005Z   Win32App.cpp
2026-05-20T22:53:16.2443044Z   Win32Service.cpp
2026-05-20T22:53:17.0498037Z   Win32NetState.cpp
2026-05-20T22:53:20.3170103Z   Generating Code...
2026-05-20T22:53:43.9864561Z LINK : fatal error LNK1104: cannot open file 'boost_atomic.lib' [%SRC_DIR%\build\i2pd.vcxproj]

```

with 270e5d8: build success
[i2pd.2.60.0-270e5d8.windows.build.success.txt.gz](https://github.com/user-attachments/files/28088975/i2pd.2.60.0-270e5d8.windows.build.success.txt.gz)

```
2026-05-20T23:39:51.3809609Z   Win32App.cpp
2026-05-20T23:39:56.4615427Z   Win32Service.cpp
2026-05-20T23:39:57.3141476Z   Win32NetState.cpp
2026-05-20T23:40:00.5927793Z   Generating Code...
2026-05-20T23:40:24.7480729Z   i2pd.vcxproj -> %SRC_DIR%\build\Release\i2pd.exe
2026-05-20T23:40:24.8042163Z   Building Custom Rule D:/bld/i2pd_1779319900350/work/build/CMakeLists.txt
2026-05-20T23:40:24.8971248Z 
2026-05-20T23:40:24.8975271Z (%BUILD_PREFIX%) %SRC_DIR%\build>cmake --install . --config Release 
2026-05-20T23:40:24.9314574Z -- Installing: D:/bld/i2pd_1779319900350/_h_env/lib/libi2pd.lib
2026-05-20T23:40:25.0416328Z -- Installing: D:/bld/i2pd_1779319900350/_h_env/lib/libi2pdclient.lib
2026-05-20T23:40:25.1238044Z -- Installing: D:/bld/i2pd_1779319900350/_h_env/lib/libi2pdlang.lib
2026-05-20T23:40:25.1489450Z -- Installing: D:/bld/i2pd_1779319900350/_h_env/bin/i2pd.exe
2026-05-20T23:40:25.1602604Z 
2026-05-20T23:40:25.1606799Z (%BUILD_PREFIX%) %SRC_DIR%\build>cd .. 
```


via

- https://github.com/conda-forge/staged-recipes/pull/33405
