### PR TITLE
contrib: add sysusers.d file and update tmpfiles.d config file

### DIFF
--- a/contrib/debian/i2pd.tmpfile
+++ b/contrib/debian/i2pd.tmpfile
@@ -1,2 +1,0 @@
-d /run/i2pd 0755 i2pd i2pd - -
-d /var/log/i2pd 0755 i2pd i2pd - -

--- a/contrib/i2pd.sysusers
+++ b/contrib/i2pd.sysusers
@@ -1,0 +1,1 @@
+u! i2pd - - /var/lib/i2pd

--- a/contrib/i2pd.tmpfiles
+++ b/contrib/i2pd.tmpfiles
@@ -1,0 +1,4 @@
+d /run/i2pd 0755 i2pd i2pd - -
+d /var/log/i2pd 0755 i2pd i2pd - -
+d /var/lib/i2pd 0750 i2pd i2pd
+f /var/log/i2pd/i2pd.log 0640 i2pd adm


### PR DESCRIPTION
sysusers.d/tmpfiles.d config files allow a package to use declarative configuration instead of manually written maintainer scripts.
This also allows image-based systems to be created with /usr/ only, and also allows for factory resetting a system and recreating /etc/ on boot.

https://www.freedesktop.org/software/systemd/man/latest/sysusers.d.html
https://www.freedesktop.org/software/systemd/man/latest/tmpfiles.d.html

They are not specific to debian, so move them to the contrib/ directory.
Also rename to the canonical form, which is tmpfiles (plural).