### PR TITLE
LibreSSL ML-KEM compatibility fixes and OpenBSD hardening cleanup

### DIFF
--- a/daemon/Daemon.cpp
+++ b/daemon/Daemon.cpp
@@ -9,6 +9,10 @@
 #include <thread>
 #include <memory>
 #include <regex>
+#include <array>
+#include <utility>
+#include <fstream>
+#include <sstream>
 
 #ifdef __OpenBSD__
 #	include<unistd.h>
@@ -38,6 +42,12 @@
 #include "UPnP.h"
 #include "Timestamp.h"
 #include "I18N.h"
+
+#ifdef __OpenBSD__
+#include <unistd.h>
+#include <errno.h>
+#include <cstring>
+#endif
 
 namespace i2p
 {
@@ -106,84 +116,6 @@ namespace util
 
 		i2p::config::ParseConfig(config);
 		i2p::config::Finalize();
-
-#ifdef __OpenBSD__
-		auto init_pledge = []() {
-			std::string pledge_file; i2p::config::GetOption("openbsd.pledge_file", pledge_file);
-			if (pledge_file == "")
-			{
-				LogPrint(eLogDebug, "Use default pledge values");
-				// TODO: remove that not need
-				pledge("stdio rpath wpath cpath inet dns unix recvfd sendfd proc error mcast chown flock",nullptr);
-			} else {
-				std::ifstream f(pledge_file);
-				if(!f) {
-					std::cerr << "Can't open pledge file " << pledge_file<<std::endl;
-					exit(1);
-				}
-				std::string line;
-				std::vector<std::string> rules;
-				while(std::getline(f, line)){
-					rules.push_back(line);
-				}
-				if(f.bad()) {
-					std::cerr << "IO error with pledge file" << std::endl;
-				}
-				std::ostringstream out;
-				for(auto r : rules)
-					out << r << " ";
-				pledge(out.str().c_str(), nullptr);
-			}		
-
-
-		};
-		auto init_unevil = []() {
-			unveil("/usr/lib", "r");
-			unveil("/usr/local/lib", "r"); 
-			unveil("/usr/libexec/ld.so", "r"); 
-			unveil("/dev/urandom", "r");
-			unveil("/tmp", "rw");
-			unveil("/etc/i2pd", "r"); // ваще не нужно вроде на весь прям каталог
-			
-			#define UNVEIL_DIR(dir) unveil(dir.c_str(), "rwc")
-			
-			std::string unevil_file; i2p::config::GetOption("openbsd.unevil_file",unevil_file);
-			UNVEIL_DIR(unevil_file);
-			std::string tunnelsdir, certsdir, logfile, datadir, reseed_file, openbsd_pledge_file;
-			i2p::config::GetOption("tunnelsdir", tunnelsdir);
-			UNVEIL_DIR(tunnelsdir);
-			i2p::config::GetOption("certsdir", certsdir);
-			UNVEIL_DIR(certsdir);
-			i2p::config::GetOption("datadir", datadir);
-			UNVEIL_DIR(datadir);
-			i2p::config::GetOption("reseed.file", reseed_file);
-			unveil(reseed_file.c_str(), "r");
-			i2p::config::GetOption("openbsd.pledge_file", openbsd_pledge_file);
-			unveil(openbsd_pledge_file.c_str(), "r");
-			std::string tunconf ;i2p::config::GetOption("tunconf", tunconf); unveil(tunconf.c_str(), "r");
-			std::string conf ;i2p::config::GetOption("tunconf", conf); unveil(conf.c_str(), "r");
-			std::string pidfile ;i2p::config::GetOption("pidfile", pidfile); unveil(pidfile.c_str(), "rwc");
-			i2p::config::GetOption("logfile", logfile); unveil(logfile.c_str(), "rwc");
-			if(unevil_file != "")
-			{
-				std::ifstream f(unevil_file);
-				if (!f) {
-					std::cerr << "Can't open unevil file" << std::endl;
-					exit(1);
-				}
-				std::string line;
-				while(std::getline(f, line)){
-						UNVEIL_DIR(line);
-				}
-			}
-			#undef UNVEIL_DIR
-			unveil(NULL, NULL); 
-		};
-		bool openbsd_unevil_enabled; i2p::config::GetOption("openbsd.unevil_enabled", openbsd_unevil_enabled);
-		bool openbsd_pledge_enabled; i2p::config::GetOption("openbsd.pledge_enabled", openbsd_pledge_enabled);
-		if(openbsd_unevil_enabled) init_unevil();
-		if(openbsd_pledge_enabled) init_pledge();
-#endif
 
 		i2p::config::GetOption("daemon", isDaemon);
 
@@ -394,6 +326,98 @@ namespace util
 
 		std::string httpLang; i2p::config::GetOption("http.lang", httpLang);
 		i2p::i18n::SetLanguage(httpLang);
+
+#ifdef __OpenBSD__
+		auto unveilPath = [] (const std::string& path, const char * mask)
+		{
+			if (!path.empty ())
+			{
+				if (unveil (path.c_str (), mask) == -1)
+					LogPrint (eLogError, "Daemon: unveil failed for ", path, ": ", std::strerror (errno));
+			}
+		};
+
+		std::string tunconf; i2p::config::GetOption ("tunconf", tunconf);
+		if (tunconf.empty ()) tunconf = i2p::fs::DataDirPath ("tunnels.conf");
+		std::string tunnelsdir; i2p::config::GetOption ("tunnelsdir", tunnelsdir);
+		if (tunnelsdir.empty ()) tunnelsdir = i2p::fs::DataDirPath ("tunnels.d");
+		std::string pidfile; i2p::config::GetOption ("pidfile", pidfile);
+		if (pidfile.empty ()) pidfile = i2p::fs::DataDirPath ("i2pd.pid");
+		std::string reseedFile; i2p::config::GetOption ("reseed.file", reseedFile);
+		std::string reseedZipFile; i2p::config::GetOption ("reseed.zipfile", reseedZipFile);
+		std::string openbsdUnveilFile, openbsdUnevilFile, openbsdPledgeFile;
+		bool openbsdUnveilEnabled = true, openbsdPledgeEnabled = true;
+		i2p::config::GetOption ("openbsd.unveil_file", openbsdUnveilFile);
+		i2p::config::GetOption ("openbsd.unevil_file", openbsdUnevilFile); // backward-compatible typo
+		i2p::config::GetOption ("openbsd.unveil_enabled", openbsdUnveilEnabled);
+		i2p::config::GetOption ("openbsd.unevil_enabled", openbsdUnveilEnabled); // backward-compatible typo
+		i2p::config::GetOption ("openbsd.pledge_file", openbsdPledgeFile);
+		i2p::config::GetOption ("openbsd.pledge_enabled", openbsdPledgeEnabled);
+		if (openbsdUnveilFile.empty ()) openbsdUnveilFile = openbsdUnevilFile;
+
+		// local reseed file only; URLs are network inputs and don't need unveil
+		if (reseedFile.rfind ("https://", 0) == 0) reseedFile.clear ();
+
+		// limit filesystem access to runtime paths determined from effective config/defaults
+		const std::array<std::pair<std::string, const char *>, 9> unveilRules =
+		{{
+			{config, "r"},
+			{datadir, "rwc"},
+			{certsdir, "r"},
+			{tunconf, "r"},
+			{tunnelsdir, "r"},
+			{pidfile, "rwc"},
+			{logfile, "rwc"},
+			{reseedFile, "r"},
+			{reseedZipFile, "r"}
+		}};
+		if (openbsdUnveilEnabled)
+		{
+			for (const auto& rule: unveilRules)
+				unveilPath (rule.first, rule.second);
+			if (!openbsdUnveilFile.empty ())
+			{
+				std::ifstream extraRules (openbsdUnveilFile);
+				if (!extraRules)
+					LogPrint (eLogError, "Daemon: can't open OpenBSD unveil file ", openbsdUnveilFile);
+				else
+				{
+					std::string line;
+					while (std::getline (extraRules, line))
+						unveilPath (line, "rwc");
+				}
+			}
+
+			if (unveil (nullptr, nullptr) == -1)
+			{
+				LogPrint (eLogError, "Daemon: unveil lock failed: ", std::strerror (errno));
+				return false;
+			}
+		}
+		std::string pledgePromises = "stdio inet dns flock rpath wpath cpath";
+		if (openbsdPledgeEnabled && !openbsdPledgeFile.empty ())
+		{
+			std::ifstream promisesFile (openbsdPledgeFile);
+			if (!promisesFile)
+				LogPrint (eLogError, "Daemon: can't open OpenBSD pledge file ", openbsdPledgeFile);
+			else
+			{
+				std::ostringstream out;
+				std::string line;
+				while (std::getline (promisesFile, line))
+				{
+					if (!line.empty ()) out << line << ' ';
+				}
+				auto customPromises = out.str ();
+				if (!customPromises.empty ()) pledgePromises = customPromises;
+			}
+		}
+		if (openbsdPledgeEnabled && pledge (pledgePromises.c_str (), nullptr) == -1)
+		{
+			LogPrint (eLogError, "Daemon: pledge failed: ", std::strerror (errno));
+			return false;
+		}
+#endif
 
 		return true;
 	}

--- a/libi2pd/Config.cpp
+++ b/libi2pd/Config.cpp
@@ -136,7 +136,7 @@ namespace config {
 			("httpproxy.addresshelper", value<bool>()->default_value(true),           "Enable or disable addresshelper")
 			("httpproxy.senduseragent", value<bool>()->default_value(false),          "Pass through user's User-Agent if enabled. Disabled by default")
 			("httpproxy.i2cp.leaseSetType", value<std::string>()->default_value("3"), "Local destination's LeaseSet type")
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 			("httpproxy.i2cp.leaseSetEncType", value<std::string>()->default_value("6,4,0"), "Local destination's LeaseSet encryption type")
 #else
 			("httpproxy.i2cp.leaseSetEncType", value<std::string>()->default_value("4,0"), "Local destination's LeaseSet encryption type")
@@ -170,7 +170,7 @@ namespace config {
 			("socksproxy.outproxy", value<std::string>()->default_value("127.0.0.1"),  "Upstream outproxy address for SOCKS Proxy")
 			("socksproxy.outproxyport", value<uint16_t>()->default_value(9050),        "Upstream outproxy port for SOCKS Proxy")
 			("socksproxy.i2cp.leaseSetType", value<std::string>()->default_value("3"), "Local destination's LeaseSet type")
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 			("socksproxy.i2cp.leaseSetEncType", value<std::string>()->default_value("6,4,0"), "Local destination's LeaseSet encryption type")
 #else
 			("socksproxy.i2cp.leaseSetEncType", value<std::string>()->default_value("4,0"), "Local destination's LeaseSet encryption type")
@@ -191,7 +191,7 @@ namespace config {
 			("shareddest.inbound.quantity", value<std::string>()->default_value("3"),  "Shared local destination inbound tunnels quantity")
 			("shareddest.outbound.quantity", value<std::string>()->default_value("3"), "Shared local destination outbound tunnels quantity")
 			("shareddest.i2cp.leaseSetType", value<std::string>()->default_value("3"), "Shared local destination's LeaseSet type")
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 			("shareddest.i2cp.leaseSetEncType", value<std::string>()->default_value("6,4,0"), "Shared local destination's LeaseSet encryption type")
 #else
 			("shareddest.i2cp.leaseSetEncType", value<std::string>()->default_value("4,0"), "Shared local destination's LeaseSet encryption type")
@@ -331,7 +331,7 @@ namespace config {
 			("ntcp2.port", value<uint16_t>()->default_value(0),            "Port to listen for incoming NTCP2 connections (default: auto)")
 			("ntcp2.addressv6", value<std::string>()->default_value("::"), "Address to publish NTCP2 with")
 			("ntcp2.proxy", value<std::string>()->default_value(""),       "Proxy URL for NTCP2 transport")
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 			("ntcp2.version", value<int>()->default_value(4),              "Protocol version. 2 - standard, 3,4,5 - post quantum (default: 4)")
 #else
 			("ntcp2.version", value<int>()->default_value(2),              "Protocol version. 2 - standard, 3,4,5 - post quantum (default: 2)")

--- a/libi2pd/Config.cpp
+++ b/libi2pd/Config.cpp
@@ -394,10 +394,13 @@ namespace config {
 #ifdef __OpenBSD__
 		options_description openbsd_specific("OpenBSD specific options");
 		openbsd_specific.add_options()
-			("openbsd.pledge_file", value<std::string>()->default_value(""), "OpenbSD file with pledge rules")
-			("openbsd.unevil_file", value<std::string>()->default_value(""), "OpenBSD file with unevil rules")
-			("openbsd.unevil_enabled", value<bool>()->default_value(true),     "use unevil rues")
-			("openbsd.pledge_enabled", value<bool>()->default_value(true),     "use pledge rules")
+			("openbsd.pledge_file", value<std::string>()->default_value(""), "OpenBSD file with custom pledge promises")
+			("openbsd.unveil_file", value<std::string>()->default_value(""),  "OpenBSD file with extra unveil paths")
+			("openbsd.unveil_enabled", value<bool>()->default_value(true),   "Enable unveil hardening (default: enabled)")
+			("openbsd.pledge_enabled", value<bool>()->default_value(true),   "Enable pledge hardening (default: enabled)")
+			// deprecated misspelled options kept for backward compatibility
+			("openbsd.unevil_file", value<std::string>()->default_value(""), "Deprecated alias for openbsd.unveil_file")
+			("openbsd.unevil_enabled", value<bool>()->default_value(true),   "Deprecated alias for openbsd.unveil_enabled")
 			;
 #endif
 

--- a/libi2pd/Crypto.h
+++ b/libi2pd/Crypto.h
@@ -31,8 +31,16 @@
 #if (!defined(LIBRESSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER != 0x030000000)) // 3.0.0, regression in SipHash, not implemented in LibreSSL
 #	define OPENSSL_SIPHASH 1
 #endif
-#if (OPENSSL_VERSION_NUMBER >= 0x030500000) || ( (defined(LIBRESSL_VERSION_NUMBER) && (LIBRESSL_VERSION_NUMBER >= 0x4030000fL)) )  // 3.5.0 openssl, 4.3.0 libressl
+#if !defined(LIBRESSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER >= 0x030500000) // 3.5.0
 #	define OPENSSL_PQ 1
+#endif
+
+#if defined(OPENSSL_PQ) || defined(USE_LIBOQS_MLDSA)
+#	define OPENSSL_MLDSA 1
+#endif
+
+#if defined(OPENSSL_PQ) || (defined(LIBRESSL_VERSION_NUMBER) && (LIBRESSL_VERSION_NUMBER >= 0x4030000fL))
+#	define OPENSSL_MLKEM 1
 #endif
 
 namespace i2p

--- a/libi2pd/Destination.cpp
+++ b/libi2pd/Destination.cpp
@@ -999,7 +999,7 @@ namespace client
 					try
 					{
 						i2p::data::CryptoKeyType cryptoType = std::stoi(it1);
-#if !OPENSSL_PQ
+#if !OPENSSL_MLKEM
 						if (cryptoType <= i2p::data::CRYPTO_KEY_TYPE_ECIES_X25519_AEAD) // skip PQ keys if not supported
 #endif
 						{
@@ -1020,11 +1020,11 @@ namespace client
 		if (encryptionKeyTypes.empty ())
 		{
 			encryptionKeyTypes.insert ( { GetIdentity ()->GetCryptoKeyType (),
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 				i2p::data::CRYPTO_KEY_TYPE_ECIES_MLKEM768_X25519_AEAD,
 #endif
 				i2p::data::CRYPTO_KEY_TYPE_ECIES_X25519_AEAD });
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 			m_PreferredCryptoType = i2p::data::CRYPTO_KEY_TYPE_ECIES_MLKEM768_X25519_AEAD;
 #else
 			m_PreferredCryptoType = i2p::data::CRYPTO_KEY_TYPE_ECIES_X25519_AEAD;

--- a/libi2pd/ECIESX25519AEADRatchetSession.cpp
+++ b/libi2pd/ECIESX25519AEADRatchetSession.cpp
@@ -265,7 +265,7 @@ namespace garlic
 	void ECIESX25519AEADRatchetSession::CleanupReceiveNSRKeys ()
 	{
 		m_EphemeralKeys = nullptr;
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 		m_PQKeys = nullptr;
 #endif
 	}
@@ -286,7 +286,7 @@ namespace garlic
 		uint8_t sharedSecret[32];
 		bool decrypted = false;
 		auto cryptoType = GetOwner ()->GetRatchetsHighestCryptoType ();
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 		if (cryptoType > i2p::data::CRYPTO_KEY_TYPE_ECIES_X25519_AEAD) // we support post quantum
 		{
 			i2p::crypto::InitNoiseIKStateMLKEM (GetNoiseState (), cryptoType, GetOwner ()->GetEncryptionPublicKey (cryptoType)); // bpk
@@ -564,7 +564,7 @@ namespace garlic
 		offset += 32;
 
 		// KDF1
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 		if (m_RemoteStaticKeyType >= i2p::data::CRYPTO_KEY_TYPE_ECIES_MLKEM512_X25519_AEAD)
 		{
 			i2p::crypto::InitNoiseIKStateMLKEM (GetNoiseState (), m_RemoteStaticKeyType, m_RemoteStaticKey); // bpk
@@ -582,7 +582,7 @@ namespace garlic
 			return false;
 		}
 		MixKey (sharedSecret);
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 		if (m_RemoteStaticKeyType >= i2p::data::CRYPTO_KEY_TYPE_ECIES_MLKEM512_X25519_AEAD)
 		{
 			auto keyLen = i2p::crypto::GetMLKEMPublicKeyLen (m_RemoteStaticKeyType);
@@ -671,7 +671,7 @@ namespace garlic
 			return false;
 		}
 		MixKey (sharedSecret);
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 		if (m_PQKeys)
 		{
 			m_NSRCK = std::make_unique<std::array<uint8_t, 64> >();
@@ -742,7 +742,7 @@ namespace garlic
 		MixHash (m_EphemeralKeys->GetPublicKey (), 32); // h = SHA256(h || bepk)
 		m_N = 0;
 		size_t offset = 40;
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 		if (m_PQKeys)
 		{
 			if (m_NSRCK)
@@ -809,7 +809,7 @@ namespace garlic
 			return false;
 		}
 		MixKey (sharedSecret);
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 		if (m_RemoteStaticKeyType >= i2p::data::CRYPTO_KEY_TYPE_ECIES_MLKEM512_X25519_AEAD)
 		{
 			// decrypt kem_ciphertext section
@@ -976,7 +976,7 @@ namespace garlic
 				m_State = eSessionStateEstablished;
 				m_NSRSendTagset = nullptr;
 				m_EphemeralKeys = nullptr;
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 				m_PQKeys = nullptr;
 				m_NSRCK = nullptr;
 #endif
@@ -1059,7 +1059,7 @@ namespace garlic
 
 	std::shared_ptr<I2NPMessage> ECIESX25519AEADRatchetSession::WrapPayload (const uint8_t * payload, size_t len)
 	{
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 		auto m = NewI2NPMessage (len + (m_State == eSessionStateEstablished ? 28 :
 			i2p::crypto::GetMLKEMPublicKeyLen (m_RemoteStaticKeyType) + 116));
 #else
@@ -1079,7 +1079,7 @@ namespace garlic
 				if (!NewOutgoingSessionMessage (payload, len, buf, m->maxLen))
 					return nullptr;
 				len += 96;
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 				if (m_RemoteStaticKeyType >= i2p::data::CRYPTO_KEY_TYPE_ECIES_MLKEM512_X25519_AEAD)
 					len += i2p::crypto::GetMLKEMPublicKeyLen (m_RemoteStaticKeyType) + 16;
 #endif
@@ -1088,7 +1088,7 @@ namespace garlic
 				if (!NewSessionReplyMessage (payload, len, buf, m->maxLen))
 					return nullptr;
 				len += 72;
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 				if (m_RemoteStaticKeyType >= i2p::data::CRYPTO_KEY_TYPE_ECIES_MLKEM512_X25519_AEAD)
 					len += i2p::crypto::GetMLKEMCipherTextLen (m_RemoteStaticKeyType) + 16;
 #endif
@@ -1097,7 +1097,7 @@ namespace garlic
 				if (!NextNewSessionReplyMessage (payload, len, buf, m->maxLen))
 					return nullptr;
 				len += 72;
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 				if (m_RemoteStaticKeyType >= i2p::data::CRYPTO_KEY_TYPE_ECIES_MLKEM512_X25519_AEAD)
 					len += i2p::crypto::GetMLKEMCipherTextLen (m_RemoteStaticKeyType) + 16;
 #endif

--- a/libi2pd/ECIESX25519AEADRatchetSession.h
+++ b/libi2pd/ECIESX25519AEADRatchetSession.h
@@ -237,7 +237,7 @@ namespace garlic
 			uint8_t m_Aepk[32]; // Alice's ephemeral keys, for incoming only
 			uint8_t m_NSREncodedKey[32], m_NSRH[32], m_NSRKey[32]; // new session reply, for incoming only
 			std::shared_ptr<i2p::crypto::X25519Keys> m_EphemeralKeys;
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 			std::unique_ptr<i2p::crypto::MLKEMKeys> m_PQKeys;
 			std::unique_ptr<std::array<uint8_t, 64> > m_NSRCK; // before cipher text encryptio
 #endif
@@ -285,4 +285,3 @@ namespace garlic
 }
 
 #endif
-

--- a/libi2pd/Identity.cpp
+++ b/libi2pd/Identity.cpp
@@ -432,7 +432,7 @@ namespace data
 				auto keyLen = verifier->GetPublicKeyLen ();
 				if (keyLen <= 128)
 					verifier->SetPublicKey (m_StandardIdentity.signingKey + 128 - keyLen);
-#if OPENSSL_PQ
+#if OPENSSL_MLDSA
 				else if (keyLen > 384)
 				{
 					// for post-quantum

--- a/libi2pd/LeaseSet.cpp
+++ b/libi2pd/LeaseSet.cpp
@@ -422,7 +422,7 @@ namespace data
 			if (IsStoreLeases () && !preferredKeyFound) // create encryptor with leases only
 			{
 				// we pick max key type if preferred not found
-#if !OPENSSL_PQ
+#if !OPENSSL_MLKEM
 				if (keyType <= i2p::data::CRYPTO_KEY_TYPE_ECIES_X25519_AEAD) // skip PQ keys if not supported
 #endif
 				{

--- a/libi2pd/NTCP2.cpp
+++ b/libi2pd/NTCP2.cpp
@@ -13,6 +13,9 @@
 #include <stdlib.h>
 #include <vector>
 #include <chrono>
+#include <algorithm>
+#include <sstream>
+#include <iomanip>
 #include "Log.h"
 #include "I2PEndian.h"
 #include "Crypto.h"
@@ -33,6 +36,23 @@ namespace i2p
 {
 namespace transport
 {
+	namespace
+	{
+		std::string HexSnippet (const uint8_t * data, size_t len, size_t maxLen = 24)
+		{
+			std::ostringstream s;
+			s << std::hex << std::setfill ('0');
+			auto n = std::min (len, maxLen);
+			for (size_t i = 0; i < n; i++)
+			{
+				if (i) s << ' ';
+				s << std::setw (2) << (int)data[i];
+			}
+			if (len > n) s << " ...";
+			return s.str ();
+		}
+	}
+
 	NTCP2Establisher::NTCP2Establisher ():
 		m_SessionConfirmedBuffer (nullptr), m_BufferLen (0), m_IsLongPadding (false)
 	{
@@ -146,6 +166,7 @@ namespace transport
 	bool NTCP2Establisher::CreateSessionRequestMessage (std::mt19937& rng)
 	{
 		size_t offset  = 0;
+		size_t pqKeyLen = 0;
 		// encrypt X
 		i2p::crypto::CBCEncryption encryption;
 		encryption.SetKey (m_RemoteIdentHash);
@@ -177,8 +198,9 @@ namespace transport
         {
             // ML-KEM frame
             auto keyLen = i2p::crypto::GetMLKEMPublicKeyLen (m_CryptoType);
-			std::vector<uint8_t> encapsKey(keyLen);
-			m_PQKeys->GetPublicKey (encapsKey.data ());
+            pqKeyLen = keyLen;
+            std::vector<uint8_t> encapsKey(keyLen);
+            m_PQKeys->GetPublicKey (encapsKey.data ());
 			// encrypt encapsKey
 			if (!Encrypt (encapsKey.data (), m_Buffer + offset, keyLen))
 			{
@@ -225,6 +247,9 @@ namespace transport
             MixHash (m_Buffer + offset, paddingLength);
 		}
 		m_BufferLen = offset + paddingLength;
+		LogPrint (eLogDebug, "NTCP2: SessionRequest built crypto=", (int)m_CryptoType,
+			" pq=", m_PQKeys ? 1 : 0, " pqKeyLen=", pqKeyLen, " totalLen=", m_BufferLen,
+			" head=", HexSnippet (m_Buffer, m_BufferLen));
 		// create m3p2 payload (RouterInfo block) for SessionConfirmed
 		m_SessionConfirmedBuffer = new uint8_t[m3p2Len + 48]; // m3p1 is 48 bytes
 		uint8_t * m3p2 = m_SessionConfirmedBuffer + 48;
@@ -422,6 +447,9 @@ namespace transport
 			LogPrint (eLogWarning, "NTCP2: SessionRequest AEAD verification failed ");
 			return false;
 		}
+		LogPrint (eLogDebug, "NTCP2: SessionRequest parsed crypto=", (int)m_CryptoType,
+			" pq=", pq ? 1 : 0, " padLen=", paddingLen, " m3p2Len=", m3p2Len, " totalLen=", m_BufferLen,
+			" head=", HexSnippet (m_Buffer, m_BufferLen));
 		return true;
 	}
 

--- a/libi2pd/NTCP2.cpp
+++ b/libi2pd/NTCP2.cpp
@@ -46,7 +46,7 @@ namespace transport
 
 	void NTCP2Establisher::SetVersion (int version)
 	{
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
         switch (version)
         {
             case 3:
@@ -69,7 +69,7 @@ namespace transport
 
 	bool NTCP2Establisher::KeyDerivationFunction1 (const uint8_t * pub, i2p::crypto::X25519Keys& priv, const uint8_t * rs, const uint8_t * epub)
 	{
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
         if (m_CryptoType == i2p::data::CRYPTO_KEY_TYPE_ECIES_X25519_AEAD)
             i2p::crypto::InitNoiseXKState (*this, rs);
         else
@@ -149,7 +149,7 @@ namespace transport
 		// encrypt X
 		i2p::crypto::CBCEncryption encryption;
 		encryption.SetKey (m_RemoteIdentHash);
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
         if (m_CryptoType > i2p::data::CRYPTO_KEY_TYPE_ECIES_X25519_AEAD)
         {
             uint8_t pub[32];
@@ -172,7 +172,7 @@ namespace transport
 		size_t maxPaddingLength = m_IsLongPadding ? NTCP2_SESSION_HANDSHAKE_LONG_MAX_SIZE : NTCP2_SESSION_HANDSHAKE_MAX_SIZE;
 		maxPaddingLength -= 64;
 		size_t maxMsgSize = m_MaxMsgSize;
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
         if (m_PQKeys)
         {
             // ML-KEM frame
@@ -249,7 +249,7 @@ namespace transport
 		size_t maxPaddingLength = m_IsLongPadding ? NTCP2_SESSION_HANDSHAKE_LONG_MAX_SIZE : NTCP2_SESSION_HANDSHAKE_MAX_SIZE;
 		maxPaddingLength -= 64;
 		size_t maxMsgSize = m_MaxMsgSize;
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
         if (m_PQKeys)
         {
             size_t cipherTextLen = i2p::crypto::GetMLKEMCipherTextLen (m_CryptoType);
@@ -339,7 +339,7 @@ namespace transport
             memcpy (m_IV, m_Buffer + 16, 16); // save last block as IV for SessionCreated
             if (x[31] & 0x80)
             {
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
                 if (m_CryptoType > i2p::data::CRYPTO_KEY_TYPE_ECIES_X25519_AEAD)
                 {
                     pq = true;
@@ -362,7 +362,7 @@ namespace transport
             }
 		}
 		offset += 32;
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
         if (pq) return true; // we need to read extra ML-KEM block first
         if (m_CryptoType > i2p::data::CRYPTO_KEY_TYPE_ECIES_X25519_AEAD)
         {
@@ -439,7 +439,7 @@ namespace transport
 			LogPrint (eLogWarning, "NTCP2: SessionCreated KDF failed");
 			return false;
 		}
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
         if (m_CryptoType > i2p::data::CRYPTO_KEY_TYPE_ECIES_X25519_AEAD && m_PQKeys)
 		{
 			// decrypt kem_ciphertext  frame
@@ -541,9 +541,11 @@ namespace transport
 				memcpy (m_Establisher->m_RemoteStaticKey, addr->s, 32);
 				memcpy (m_Establisher->m_IV, addr->i, 16);
 				m_RemoteEndpoint = boost::asio::ip::tcp::endpoint (addr->host, addr->port);
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
                 if (m_Server.GetVersion () > 2) // we support post quantum in config
                     m_Establisher->SetVersion (addr->v);
+				LogPrint (eLogDebug, "NTCP2: PQ selection server=", m_Server.GetVersion (),
+					" remote=", (int)addr->v, " crypto=", (int)m_Establisher->m_CryptoType);
 #endif
 				if (addr->v > 2 && in_RemoteRouter->GetVersion () >= MAKE_VERSION_NUMBER(0, 9, 69)) // 0.9.69
 					m_Establisher->m_IsLongPadding = true;
@@ -697,7 +699,7 @@ namespace transport
 		{
 			// we receive first 64 bytes (32 Y, and 32 ChaCha/Poly frame) first and ML-KEM frame if post quantum
 			size_t len = 64;
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 			if (m_Establisher->m_CryptoType > i2p::data::CRYPTO_KEY_TYPE_ECIES_X25519_AEAD)
                 len += i2p::crypto::GetMLKEMCipherTextLen (m_Establisher->m_CryptoType) + 16;
 #endif
@@ -737,7 +739,7 @@ namespace transport
 				SendSessionCreated ();
 				boost::asio::post (m_Server.GetService (), std::bind (&NTCP2Session::Terminate, shared_from_this ()));
 			}
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 			else if (pq)
 			{
                 auto keyLen = i2p::crypto::GetMLKEMPublicKeyLen (m_Establisher->m_CryptoType);
@@ -784,7 +786,7 @@ namespace transport
 		}
 	}
 
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
     void NTCP2Session::HandleSessionRequestMLKEMReceived (const boost::system::error_code& ecode, std::size_t bytes_transferred)
     {
         if (ecode)
@@ -843,7 +845,7 @@ namespace transport
 		{
 			if (paddingLen > 0)
 			{
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 				if (paddingLen <= m_Establisher->m_MaxMsgSize - 80)
 #else
 				if (paddingLen <= m_Establisher->m_MaxMsgSize - 64)
@@ -1150,6 +1152,7 @@ namespace transport
 	{
 		if (m_Establisher->m_CryptoType > i2p::data::CRYPTO_KEY_TYPE_ECIES_X25519_AEAD && !(m_Server.GetRng ()() & 0x03))
 			m_Establisher->SetVersion (2); // switch to non-PQ  with a probability of one in four
+		LogPrint (eLogDebug, "NTCP2: Login crypto type ", (int)m_Establisher->m_CryptoType);
 		m_Establisher->CreateEphemeralKey ();
 		boost::asio::post (m_Server.GetEstablisherService (),
 		    [s = shared_from_this ()] ()
@@ -2284,7 +2287,7 @@ namespace transport
 
 	void NTCP2Server::SetVersion (int version)
 	{
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
         m_Version = version;
 #endif
 	}

--- a/libi2pd/NTCP2.cpp
+++ b/libi2pd/NTCP2.cpp
@@ -70,7 +70,11 @@ namespace transport
         switch (version)
         {
             case 3:
+#if defined(LIBRESSL_VERSION_NUMBER)
+                 m_CryptoType = i2p::data::CRYPTO_KEY_TYPE_ECIES_X25519_AEAD; // ML-KEM-512 is not available on LibreSSL
+#else
                  m_CryptoType = i2p::data::CRYPTO_KEY_TYPE_ECIES_MLKEM512_X25519_AEAD;
+#endif
             break;
             case 4:
                  m_CryptoType = i2p::data::CRYPTO_KEY_TYPE_ECIES_MLKEM768_X25519_AEAD;
@@ -173,13 +177,22 @@ namespace transport
 #if OPENSSL_MLKEM
         if (m_CryptoType > i2p::data::CRYPTO_KEY_TYPE_ECIES_X25519_AEAD)
         {
-            uint8_t pub[32];
-            memcpy (pub, GetPub (), 32);
-            pub[31] |= 0x80; // set highest bit
-            encryption.Encrypt (pub, 32, m_IV, m_Buffer); // X
-            //  ML-KEM encap_key
             m_PQKeys = i2p::crypto::CreateMLKEMKeys (m_CryptoType);
-            m_PQKeys->GenerateKeys ();
+            if (m_PQKeys)
+            {
+                m_PQKeys->GenerateKeys ();
+                uint8_t pub[32];
+                memcpy (pub, GetPub (), 32);
+                pub[31] |= 0x80; // set highest bit
+                encryption.Encrypt (pub, 32, m_IV, m_Buffer); // X
+            }
+            else
+            {
+                LogPrint (eLogWarning, "NTCP2: ML-KEM type ", (int)m_CryptoType, " is not available, fallback to X25519");
+                m_CryptoType = i2p::data::CRYPTO_KEY_TYPE_ECIES_X25519_AEAD;
+                m_IsLongPadding = false;
+                encryption.Encrypt (GetPub (), 32, m_IV, m_Buffer); // X
+            }
         }
         else
             encryption.Encrypt (GetPub (), 32, m_IV, m_Buffer); // X
@@ -398,6 +411,11 @@ namespace transport
                 MixHash (m_Buffer + offset, keyLen + 16);
                 offset += keyLen + 16;
                 m_PQKeys = i2p::crypto::CreateMLKEMKeys (m_CryptoType);
+                if (!m_PQKeys)
+                {
+                    LogPrint (eLogWarning, "NTCP2: ML-KEM type ", (int)m_CryptoType, " is not available");
+                    return false;
+                }
                 m_PQKeys->SetPublicKey (encapsKey.data ());
             }
         }

--- a/libi2pd/NTCP2.h
+++ b/libi2pd/NTCP2.h
@@ -127,7 +127,7 @@ namespace transport
 		i2p::data::IdentHash m_RemoteIdentHash;
 		uint16_t m3p2Len;
 
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
         std::unique_ptr<i2p::crypto::MLKEMKeys> m_PQKeys;
         static constexpr size_t m_MaxMsgSize = 2*i2p::crypto::MLKEM1024_KEY_LENGTH + 160;
 #else
@@ -187,7 +187,7 @@ namespace transport
 			void HandleSessionRequestReceived (const boost::system::error_code& ecode, std::size_t bytes_transferred);
 			void ProcessSessionRequest (size_t len, bool first = true);
 			void HandleSessionRequestPaddingReceived (const boost::system::error_code& ecode, std::size_t bytes_transferred);
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
             void HandleSessionRequestMLKEMReceived (const boost::system::error_code& ecode, std::size_t bytes_transferred);
 #endif
 			void HandleSessionCreatedSent (const boost::system::error_code& ecode, std::size_t bytes_transferred);

--- a/libi2pd/PostQuantum.cpp
+++ b/libi2pd/PostQuantum.cpp
@@ -9,13 +9,16 @@
 #include "Log.h"
 #include "PostQuantum.h"
 
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 
-#ifndef LIBRESSL_VERSION_NUMBER
+#include <string.h>
+
+#if defined(LIBRESSL_VERSION_NUMBER)
+#include <cstdlib>
+#include <openssl/mlkem.h>
+#else
 #include <openssl/param_build.h>
 #include <openssl/core_names.h>
-#else
-#include<openssl/mlkem.h>
 #endif
 
 namespace i2p
@@ -23,139 +26,185 @@ namespace i2p
 namespace crypto
 {
 	MLKEMKeys::MLKEMKeys (MLKEMTypes type):
-#ifndef LIBRESSL_VERSION_NUMBER
-		m_Name (std::get<0>(MLKEMS[type])), m_KeyLen (std::get<1>(MLKEMS[type])),
-		m_CTLen (std::get<2>(MLKEMS[type])),
-#else
-		m_Name (std::get<0>(MLKEMS[eMLKEM768])), m_KeyLen (std::get<1>(MLKEMS[eMLKEM768])),
-		m_CTLen (std::get<2>(MLKEMS[eMLKEM768])),
+		m_Name (type == eMLKEM512 ? "ML-KEM-512" : type == eMLKEM768 ? "ML-KEM-768" : "ML-KEM-1024"),
+#if defined(LIBRESSL_VERSION_NUMBER)
+		m_Rank (type == eMLKEM768 ? MLKEM768_RANK : type == eMLKEM1024 ? MLKEM1024_RANK : 0),
 #endif
-		m_Pkey (nullptr)
+		m_KeyLen (
+#if defined(LIBRESSL_VERSION_NUMBER)
+			type == eMLKEM768 ? MLKEM768_KEY_LENGTH : type == eMLKEM1024 ? MLKEM1024_KEY_LENGTH : 0
+#else
+			type == eMLKEM512 ? MLKEM512_KEY_LENGTH : type == eMLKEM768 ? MLKEM768_KEY_LENGTH : MLKEM1024_KEY_LENGTH
+#endif
+		),
+		m_CTLen (
+#if defined(LIBRESSL_VERSION_NUMBER)
+			type == eMLKEM768 ? MLKEM768_CIPHER_TEXT_LENGTH : type == eMLKEM1024 ? MLKEM1024_CIPHER_TEXT_LENGTH : 0
+#else
+			type == eMLKEM512 ? MLKEM512_CIPHER_TEXT_LENGTH : type == eMLKEM768 ? MLKEM768_CIPHER_TEXT_LENGTH : MLKEM1024_CIPHER_TEXT_LENGTH
+#endif
+		)
+#if defined(LIBRESSL_VERSION_NUMBER)
+		, m_PrivateKey (nullptr), m_PublicKey (nullptr)
+#else
+		, m_Pkey (nullptr)
+#endif
 	{
+		m_PublicKeyEncoded.fill (0);
 	}
 
 	MLKEMKeys::~MLKEMKeys ()
 	{
-		FreeKeys();
-	}
-
-	void MLKEMKeys::FreeKeys ()
-	{
-#ifndef LIBRESSL_VERSION_NUMBER
-		if (m_Pkey) EVP_PKEY_free (m_Pkey);
+#if defined(LIBRESSL_VERSION_NUMBER)
+		if (m_PrivateKey) MLKEM_private_key_free (m_PrivateKey);
+		if (m_PublicKey) MLKEM_public_key_free (m_PublicKey);
 #else
-	    if (m_Pkey) MLKEM_private_key_free (m_Pkey);
+		if (m_Pkey) EVP_PKEY_free (m_Pkey);
 #endif
-		if (m_Pkey) m_Pkey = nullptr;
 	}
 
 	void MLKEMKeys::GenerateKeys ()
 	{
-		FreeKeys();
-#ifndef LIBRESSL_VERSION_NUMBER
-		m_Pkey = EVP_PKEY_Q_keygen(NULL, NULL, m_Name.c_str ());
-		LogPrint(eLogDebug, "MLKEM: GenerateKeys [ openssl ]");
-#else
-		m_Pkey = MLKEM_private_key_new( MLKEM768_RANK);
-
-		uint8_t * pub_key = nullptr;
-		size_t pub_key_len = 0;
-		uint8_t * seed = nullptr;
-		size_t seed_len = 0;
-
-		if (MLKEM_generate_key(m_Pkey, &pub_key, &pub_key_len, &seed, &seed_len) == 1)
+#if defined(LIBRESSL_VERSION_NUMBER)
+		m_PublicKeyEncoded.fill (0);
+		if (!m_Rank)
 		{
-			LogPrint(eLogDebug, "MLKEM: GenerateKeys [ libressl ] success");
-			if (pub_key_len <= sizeof(m_CachedPub))
-			{
-				memcpy(m_CachedPub, pub_key, pub_key_len);
-				m_IsPubCached = true;
-				LogPrint(eLogDebug, "MLKEM [libressl] cache the pub succes");
-			} else
-			{
-				 LogPrint(eLogError, "MLKEM: can't cache private key [libressl]");
-			}
-			OPENSSL_free(pub_key);
-			if (seed) OPENSSL_free(seed);
-		} else
-		{
-			LogPrint(eLogError, "MLKEM: GenerateKeys [ libressl ] failed");
-			MLKEM_private_key_free(m_Pkey);
-			m_Pkey = nullptr;
+			LogPrint (eLogError, "MLKEM ", m_Name, " is not supported by LibreSSL");
+			return;
 		}
+		if (m_PrivateKey) MLKEM_private_key_free (m_PrivateKey);
+		if (m_PublicKey) MLKEM_public_key_free (m_PublicKey);
+		m_PrivateKey = nullptr;
+		m_PublicKey = nullptr;
+		m_PrivateKey = MLKEM_private_key_new (m_Rank);
+		m_PublicKey = MLKEM_public_key_new (m_Rank);
+		if (!m_PrivateKey || !m_PublicKey)
+		{
+			LogPrint (eLogError, "MLKEM can't create native key objects");
+			if (m_PrivateKey) MLKEM_private_key_free (m_PrivateKey);
+			if (m_PublicKey) MLKEM_public_key_free (m_PublicKey);
+			m_PrivateKey = nullptr;
+			m_PublicKey = nullptr;
+			return;
+		}
+		uint8_t * pub = nullptr, * seed = nullptr;
+		size_t pubLen = 0, seedLen = 0;
+		if (!MLKEM_generate_key (m_PrivateKey, &pub, &pubLen, &seed, &seedLen) || !pub || pubLen != m_KeyLen)
+		{
+			LogPrint (eLogError, "MLKEM native key generation failed");
+			if (pub) OPENSSL_free (pub);
+			if (seed) OPENSSL_free (seed);
+			MLKEM_private_key_free (m_PrivateKey);
+			MLKEM_public_key_free (m_PublicKey);
+			m_PrivateKey = nullptr;
+			m_PublicKey = nullptr;
+			return;
+		}
+		if (!MLKEM_parse_public_key (m_PublicKey, pub, pubLen))
+		{
+			LogPrint (eLogError, "MLKEM can't parse generated public key");
+			OPENSSL_free (pub);
+			if (seed) OPENSSL_free (seed);
+			MLKEM_private_key_free (m_PrivateKey);
+			MLKEM_public_key_free (m_PublicKey);
+			m_PrivateKey = nullptr;
+			m_PublicKey = nullptr;
+			return;
+		}
+		memcpy (m_PublicKeyEncoded.data (), pub, pubLen);
+		OPENSSL_free (pub);
+		if (seed) OPENSSL_free (seed);
+		LogPrint (eLogDebug, "MLKEM: ", m_Name, " native key generation succeeded");
+#else
+		if (m_Pkey) EVP_PKEY_free (m_Pkey);
+		m_Pkey = EVP_PKEY_Q_keygen (NULL, NULL, m_Name.c_str ());
+		if (!m_Pkey)
+		{
+			LogPrint (eLogError, "MLKEM can't generate keypair");
+			return;
+		}
+		size_t len = m_KeyLen;
+		if (!EVP_PKEY_get_octet_string_param (m_Pkey, OSSL_PKEY_PARAM_PUB_KEY,
+			m_PublicKeyEncoded.data (), m_PublicKeyEncoded.size (), &len) || len != m_KeyLen)
+			LogPrint (eLogError, "MLKEM can't read generated public key");
 #endif
-	} // end method
+	}
 
 	void MLKEMKeys::GetPublicKey (uint8_t * pub) const
 	{
-		if (m_Pkey)
-		{
-#ifndef LIBRESSL_VERSION_NUMBER
-			size_t len = m_KeyLen;
-			EVP_PKEY_get_octet_string_param (m_Pkey, OSSL_PKEY_PARAM_PUB_KEY, pub, m_KeyLen, &len);
-#else
-			if (!m_Pkey) return;
-
-			LogPrint(eLogDebug, "MLKEM: GetPublicKey [ libressl ]");
-
-			if (m_IsPubCached)
-			{
-				memcpy(pub, m_CachedPub, MLKEM768_KEY_LENGTH);
-				LogPrint(eLogDebug,"MLKEM [libressl]: copy pubkey");
-			}
-			else
-				LogPrint(eLogError, "MLKEM: Public key not cached!");
-#endif
-		}
+		if (m_KeyLen)
+			memcpy (pub, m_PublicKeyEncoded.data (), m_KeyLen);
 	}
-
 
 	void MLKEMKeys::SetPublicKey (const uint8_t * pub)
 	{
-#ifndef LIBRESSL_VERSION_NUMBER
+#if defined(LIBRESSL_VERSION_NUMBER)
+		if (!m_Rank)
+		{
+			LogPrint (eLogError, "MLKEM ", m_Name, " is not supported by LibreSSL");
+			return;
+		}
+		if (m_PublicKey) MLKEM_public_key_free (m_PublicKey);
+		m_PublicKey = MLKEM_public_key_new (m_Rank);
+		if (!m_PublicKey)
+		{
+			LogPrint (eLogError, "MLKEM can't create native public key");
+			return;
+		}
+		if (!MLKEM_parse_public_key (m_PublicKey, pub, m_KeyLen))
+		{
+			LogPrint (eLogError, "MLKEM can't parse native public key");
+			MLKEM_public_key_free (m_PublicKey);
+			m_PublicKey = nullptr;
+			return;
+		}
+		memcpy (m_PublicKeyEncoded.data (), pub, m_KeyLen);
+#else
 		if (m_Pkey)
 		{
 			EVP_PKEY_free (m_Pkey);
 			m_Pkey = nullptr;
 		}
+		memcpy (m_PublicKeyEncoded.data (), pub, m_KeyLen);
 		OSSL_PARAM params[] =
 		{
-			OSSL_PARAM_octet_string(OSSL_PKEY_PARAM_PUB_KEY, (void*)pub, m_KeyLen),
+			OSSL_PARAM_octet_string (OSSL_PKEY_PARAM_PUB_KEY, (uint8_t *)pub, m_KeyLen),
 			OSSL_PARAM_END
 		};
-
-		EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new_from_name(NULL, m_Name.c_str(), NULL);
+		EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new_from_name (NULL, m_Name.c_str (), NULL);
 		if (ctx)
 		{
-			EVP_PKEY_fromdata_init(ctx);
-			if (EVP_PKEY_fromdata(ctx, &m_Pkey, OSSL_KEYMGMT_SELECT_PUBLIC_KEY, params) <= 0)
-				LogPrint(eLogError, "MLKEM: Failed to set public key data");
-			EVP_PKEY_CTX_free(ctx);
+			if (EVP_PKEY_fromdata_init (ctx) <= 0 ||
+				EVP_PKEY_fromdata (ctx, &m_Pkey, OSSL_KEYMGMT_SELECT_PUBLIC_KEY, params) <= 0)
+					LogPrint (eLogError, "MLKEM can't create PKEY from params");
+			EVP_PKEY_CTX_free (ctx);
 		}
 		else
-			LogPrint(eLogError, "MLKEM: can't create PKEY context");
-#else
-		MLKEM_public_key * pub_key = MLKEM_public_key_new(MLKEM768_RANK);
-		if (MLKEM_parse_public_key(pub_key, pub, m_KeyLen))
-		{
-			memcpy(m_CachedPub, pub, m_KeyLen);
-			m_IsPubCached = true;
-			LogPrint(eLogDebug, "MLKEM: SetPublicKey [ libressl ] success");
-		}
-		else
-			LogPrint(eLogError, "MLKEM: failed to parse public key");
-		if (pub_key) MLKEM_public_key_free(pub_key);
+			LogPrint (eLogError, "MLKEM can't create PKEY context");
 #endif
 	}
 
 	void MLKEMKeys::Encaps (uint8_t * ciphertext, uint8_t * shared)
 	{
-#ifndef LIBRESSL_VERSION_NUMBER
-		if (!m_Pkey)
+#if defined(LIBRESSL_VERSION_NUMBER)
+		if (!m_PublicKey) return;
+		uint8_t * ct = nullptr, * secret = nullptr;
+		size_t ctLen = 0, sharedLen = 0;
+		if (!MLKEM_encap (m_PublicKey, &ct, &ctLen, &secret, &sharedLen) || !ct || !secret ||
+			ctLen != m_CTLen || sharedLen != MLKEM_SHARED_SECRET_LENGTH)
 		{
-			LogPrint(eLogError, "MLKEM: No public key for Encaps");
+			LogPrint (eLogError, "MLKEM native encapsulation failed");
+			if (ct) OPENSSL_free (ct);
+			if (secret) OPENSSL_free (secret);
 			return;
-        }
+		}
+		memcpy (ciphertext, ct, ctLen);
+		memcpy (shared, secret, sharedLen);
+		OPENSSL_free (ct);
+		OPENSSL_free (secret);
+		LogPrint (eLogDebug, "MLKEM: ", m_Name, " native encapsulation succeeded");
+#else
+		if (!m_Pkey) return;
 		auto ctx = EVP_PKEY_CTX_new_from_pkey (NULL, m_Pkey, NULL);
 		if (ctx)
 		{
@@ -166,42 +215,27 @@ namespace crypto
 		}
 		else
 			LogPrint (eLogError, "MLKEM can't create PKEY context");
-#else
-		if (!m_IsPubCached)
-		{
-			LogPrint(eLogError, "MLKEM: No public key for Encaps");
-			return;
-		}
-		auto pub_key = MLKEM_public_key_new(MLKEM768_RANK);
-		if (MLKEM_parse_public_key (pub_key, m_CachedPub, m_KeyLen) != 1)
-		{
-			LogPrint(eLogError, "MLKEM can't parse cached public key");
-			return;
-		}
-		uint8_t * out_ct = nullptr;
-		size_t out_ct_len = 0;
-		uint8_t * out_ss = nullptr;
-		size_t out_ss_len = 0;
-		if (MLKEM_encap(pub_key, &out_ct, &out_ct_len, &out_ss, &out_ss_len) == 1)
-		{
-			memcpy(ciphertext, out_ct, out_ct_len);
-			memcpy(shared, out_ss, out_ss_len);
-			OPENSSL_cleanse(out_ct, out_ct_len);
-			OPENSSL_cleanse(out_ss, out_ss_len);
-			OPENSSL_free(out_ct);
-			OPENSSL_free(out_ss);
-			LogPrint(eLogDebug, "MLKEM [libressl] succesfully encaps");
-		}
-		else
-			LogPrint(eLogError, "MLKEM [libressl]: encapsulation failed");
-		MLKEM_public_key_free(pub_key);
 #endif
 	}
 
 	void MLKEMKeys::Decaps (const uint8_t * ciphertext, uint8_t * shared)
 	{
+#if defined(LIBRESSL_VERSION_NUMBER)
+		if (!m_PrivateKey) return;
+		uint8_t * secret = nullptr;
+		size_t sharedLen = 0;
+		if (!MLKEM_decap (m_PrivateKey, ciphertext, m_CTLen, &secret, &sharedLen) || !secret ||
+			sharedLen != MLKEM_SHARED_SECRET_LENGTH)
+		{
+			LogPrint (eLogError, "MLKEM native decapsulation failed");
+			if (secret) OPENSSL_free (secret);
+			return;
+		}
+		memcpy (shared, secret, sharedLen);
+		OPENSSL_free (secret);
+		LogPrint (eLogDebug, "MLKEM: ", m_Name, " native decapsulation succeeded");
+#else
 		if (!m_Pkey) return;
-#ifndef LIBRESSL_VERSION_NUMBER
 		auto ctx = EVP_PKEY_CTX_new_from_pkey (NULL, m_Pkey, NULL);
 		if (ctx)
 		{
@@ -212,30 +246,24 @@ namespace crypto
 		}
 		else
 			LogPrint (eLogError, "MLKEM can't create PKEY context");
-#else
-			uint8_t * out_shared_secret = nullptr;
-			size_t out_shared_secret_len = 0;
-			if (MLKEM_decap(m_Pkey, ciphertext, m_CTLen, &out_shared_secret, &out_shared_secret_len) == 1)
-			{
-				memcpy(shared, out_shared_secret, out_shared_secret_len);
-
-				OPENSSL_cleanse(out_shared_secret, out_shared_secret_len);
-
-				OPENSSL_free(out_shared_secret);
-				LogPrint(eLogDebug, "MLKEM [libressl] succesfully decrypt");
-			}
-			else
-			{
-				LogPrint(eLogError, "MLKEM [libressl]: decapsulation failed");
-			}
 #endif
 	}
 
 	std::unique_ptr<MLKEMKeys> CreateMLKEMKeys (i2p::data::CryptoKeyType type)
 	{
-		if (type <= i2p::data::CRYPTO_KEY_TYPE_ECIES_X25519_AEAD ||
-		    type - i2p::data::CRYPTO_KEY_TYPE_ECIES_X25519_AEAD > (int)MLKEMS.size ()) return nullptr;
-		return std::make_unique<MLKEMKeys>((MLKEMTypes)(type - i2p::data::CRYPTO_KEY_TYPE_ECIES_X25519_AEAD - 1));
+		switch (type)
+		{
+#if !defined(LIBRESSL_VERSION_NUMBER)
+			case i2p::data::CRYPTO_KEY_TYPE_ECIES_MLKEM512_X25519_AEAD:
+				return std::make_unique<MLKEMKeys> (eMLKEM512);
+#endif
+			case i2p::data::CRYPTO_KEY_TYPE_ECIES_MLKEM768_X25519_AEAD:
+				return std::make_unique<MLKEMKeys> (eMLKEM768);
+			case i2p::data::CRYPTO_KEY_TYPE_ECIES_MLKEM1024_X25519_AEAD:
+				return std::make_unique<MLKEMKeys> (eMLKEM1024);
+			default:
+				return nullptr;
+		}
 	}
 
 	static constexpr std::array NoiseIKInitMLKEMKeys =
@@ -283,9 +311,8 @@ namespace crypto
 
 	void InitNoiseIKStateMLKEM (NoiseSymmetricState& state, i2p::data::CryptoKeyType type, const uint8_t * pub)
 	{
-		if (type <= i2p::data::CRYPTO_KEY_TYPE_ECIES_X25519_AEAD ||
-		    type - i2p::data::CRYPTO_KEY_TYPE_ECIES_X25519_AEAD > (int)NoiseIKInitMLKEMKeys.size ()) return;
-		auto ind = type - i2p::data::CRYPTO_KEY_TYPE_ECIES_X25519_AEAD - 1;
+		auto ind = GetMLKEMIndex (type);
+		if (ind < 0) return;
 		state.Init (NoiseIKInitMLKEMKeys[ind].first.data(), NoiseIKInitMLKEMKeys[ind].second.data(), pub);
 	}
 
@@ -334,9 +361,8 @@ namespace crypto
 
 	void InitNoiseXKStateMLKEM (NoiseSymmetricState& state, i2p::data::CryptoKeyType type, const uint8_t * pub)
 	{
-		if (type <= i2p::data::CRYPTO_KEY_TYPE_ECIES_X25519_AEAD ||
-		    type - i2p::data::CRYPTO_KEY_TYPE_ECIES_X25519_AEAD > (int)NoiseXKInitMLKEMKeys.size ()) return;
-		auto ind = type - i2p::data::CRYPTO_KEY_TYPE_ECIES_X25519_AEAD - 1;
+		auto ind = GetMLKEMIndex (type);
+		if (ind < 0) return;
 		state.Init (NoiseXKInitMLKEMKeys[ind].first.data(), NoiseXKInitMLKEMKeys[ind].second.data(), pub);
 	}
 
@@ -373,11 +399,11 @@ namespace crypto
 
 	void InitNoiseXKStateMLKEM1 (NoiseSymmetricState& state, i2p::data::CryptoKeyType type, const uint8_t * pub)
 	{
-		if (type <= i2p::data::CRYPTO_KEY_TYPE_ECIES_X25519_AEAD ||
-		    type - i2p::data::CRYPTO_KEY_TYPE_ECIES_X25519_AEAD > (int)NoiseXKInitMLKEMKeys1.size ()) return;
-		auto ind = type - i2p::data::CRYPTO_KEY_TYPE_ECIES_X25519_AEAD - 1;
+		auto ind = GetMLKEMIndex (type);
+		if (ind < 0 || ind >= (int)NoiseXKInitMLKEMKeys1.size ()) return;
 		state.Init (NoiseXKInitMLKEMKeys1[ind].first.data(), NoiseXKInitMLKEMKeys1[ind].second.data(), pub);
 	}
 }
 }
+
 #endif

--- a/libi2pd/PostQuantum.h
+++ b/libi2pd/PostQuantum.h
@@ -15,11 +15,13 @@
 #include <tuple>
 #include "Crypto.h"
 #include "Identity.h"
-#ifdef LIBRESSL_VERSION_NUMBER
-#	include <openssl/mlkem.h>
-#endif
 
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
+
+#if defined(LIBRESSL_VERSION_NUMBER)
+typedef struct MLKEM_private_key_st MLKEM_private_key;
+typedef struct MLKEM_public_key_st MLKEM_public_key;
+#endif
 
 namespace i2p
 {
@@ -38,26 +40,53 @@ namespace crypto
 	constexpr size_t MLKEM768_CIPHER_TEXT_LENGTH = 1088;
 	constexpr size_t MLKEM1024_KEY_LENGTH = 1568;
 	constexpr size_t MLKEM1024_CIPHER_TEXT_LENGTH = 1568;
+	constexpr size_t MLKEM_SHARED_SECRET_LENGTH = 32;
 
+#if defined(LIBRESSL_VERSION_NUMBER)
+	constexpr std::array MLKEMS =
+	{
+		std::make_tuple ("ML-KEM-768", MLKEM768_KEY_LENGTH, MLKEM768_CIPHER_TEXT_LENGTH),
+		std::make_tuple ("ML-KEM-1024", MLKEM1024_KEY_LENGTH, MLKEM1024_CIPHER_TEXT_LENGTH)
+	};
+#else
 	constexpr std::array MLKEMS =
 	{
 		std::make_tuple ("ML-KEM-512", MLKEM512_KEY_LENGTH, MLKEM512_CIPHER_TEXT_LENGTH),
 		std::make_tuple ("ML-KEM-768", MLKEM768_KEY_LENGTH, MLKEM768_CIPHER_TEXT_LENGTH),
 		std::make_tuple ("ML-KEM-1024", MLKEM1024_KEY_LENGTH, MLKEM1024_CIPHER_TEXT_LENGTH)
 	};
+#endif
+
+	constexpr int GetMLKEMIndex (i2p::data::CryptoKeyType type)
+	{
+#if defined(LIBRESSL_VERSION_NUMBER)
+		switch (type)
+		{
+			case i2p::data::CRYPTO_KEY_TYPE_ECIES_MLKEM768_X25519_AEAD: return 0;
+			case i2p::data::CRYPTO_KEY_TYPE_ECIES_MLKEM1024_X25519_AEAD: return 1;
+			default: return -1;
+		}
+#else
+		switch (type)
+		{
+			case i2p::data::CRYPTO_KEY_TYPE_ECIES_MLKEM512_X25519_AEAD: return 0;
+			case i2p::data::CRYPTO_KEY_TYPE_ECIES_MLKEM768_X25519_AEAD: return 1;
+			case i2p::data::CRYPTO_KEY_TYPE_ECIES_MLKEM1024_X25519_AEAD: return 2;
+			default: return -1;
+		}
+#endif
+	}
 
 	constexpr size_t GetMLKEMPublicKeyLen (i2p::data::CryptoKeyType type)
 	{
-		if (type <= i2p::data::CRYPTO_KEY_TYPE_ECIES_X25519_AEAD ||
-		    type - i2p::data::CRYPTO_KEY_TYPE_ECIES_X25519_AEAD > (int)MLKEMS.size ()) return 0;
-		return std::get<1>(MLKEMS[type - i2p::data::CRYPTO_KEY_TYPE_ECIES_X25519_AEAD - 1]);
+		auto ind = GetMLKEMIndex (type);
+		return ind >= 0 ? std::get<1>(MLKEMS[ind]) : 0;
 	}
 
 	constexpr size_t GetMLKEMCipherTextLen (i2p::data::CryptoKeyType type)
 	{
-		if (type <= i2p::data::CRYPTO_KEY_TYPE_ECIES_X25519_AEAD ||
-		    type - i2p::data::CRYPTO_KEY_TYPE_ECIES_X25519_AEAD > (int)MLKEMS.size ()) return 0;
-		return std::get<2>(MLKEMS[type - i2p::data::CRYPTO_KEY_TYPE_ECIES_X25519_AEAD - 1]);
+		auto ind = GetMLKEMIndex (type);
+		return ind >= 0 ? std::get<2>(MLKEMS[ind]) : 0;
 	}
 
 	class MLKEMKeys
@@ -75,21 +104,19 @@ namespace crypto
 			void Encaps (uint8_t * ciphertext, uint8_t * shared);
 			void Decaps (const uint8_t * ciphertext, uint8_t * shared);
 
-
-		private:
-
-			void FreeKeys();
-
 		private:
 
 			const std::string m_Name;
+#if defined(LIBRESSL_VERSION_NUMBER)
+			const int m_Rank;
+#endif
 			const size_t m_KeyLen, m_CTLen;
-#ifndef LIBRESSL_VERSION_NUMBER
-			EVP_PKEY * m_Pkey;
+			std::array<uint8_t, MLKEM1024_KEY_LENGTH> m_PublicKeyEncoded;
+#if defined(LIBRESSL_VERSION_NUMBER)
+			MLKEM_private_key * m_PrivateKey;
+			MLKEM_public_key * m_PublicKey;
 #else
-			MLKEM_private_key * m_Pkey;
-			uint8_t m_CachedPub[MLKEM768_KEY_LENGTH];
-			bool m_IsPubCached = false;
+			EVP_PKEY * m_Pkey;
 #endif
 	};
 

--- a/libi2pd/PostQuantum.h
+++ b/libi2pd/PostQuantum.h
@@ -45,6 +45,7 @@ namespace crypto
 #if defined(LIBRESSL_VERSION_NUMBER)
 	constexpr std::array MLKEMS =
 	{
+		std::make_tuple ("ML-KEM-512", MLKEM512_KEY_LENGTH, MLKEM512_CIPHER_TEXT_LENGTH),
 		std::make_tuple ("ML-KEM-768", MLKEM768_KEY_LENGTH, MLKEM768_CIPHER_TEXT_LENGTH),
 		std::make_tuple ("ML-KEM-1024", MLKEM1024_KEY_LENGTH, MLKEM1024_CIPHER_TEXT_LENGTH)
 	};
@@ -62,8 +63,8 @@ namespace crypto
 #if defined(LIBRESSL_VERSION_NUMBER)
 		switch (type)
 		{
-			case i2p::data::CRYPTO_KEY_TYPE_ECIES_MLKEM768_X25519_AEAD: return 0;
-			case i2p::data::CRYPTO_KEY_TYPE_ECIES_MLKEM1024_X25519_AEAD: return 1;
+			case i2p::data::CRYPTO_KEY_TYPE_ECIES_MLKEM768_X25519_AEAD: return 1;
+			case i2p::data::CRYPTO_KEY_TYPE_ECIES_MLKEM1024_X25519_AEAD: return 2;
 			default: return -1;
 		}
 #else

--- a/libi2pd/RouterContext.cpp
+++ b/libi2pd/RouterContext.cpp
@@ -790,7 +790,7 @@ namespace i2p
 		if (ntcp2)
 		{
             int ntcp2version = 2;
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
             i2p::config::GetOption("ntcp2.version", ntcp2version);
 #endif
 			PublishNTCP2Address (port, false, v4, v6, false, ntcp2version);
@@ -837,7 +837,7 @@ namespace i2p
 				uint16_t ntcp2Port; i2p::config::GetOption ("ntcp2.port", ntcp2Port);
 				if (!ntcp2Port) ntcp2Port = port;
                 int ntcp2version = 2;
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
                 i2p::config::GetOption("ntcp2.version", ntcp2version);
 #endif
 				PublishNTCP2Address (ntcp2Port, true, v4, v6, false, ntcp2version);

--- a/libi2pd/SSU2.cpp
+++ b/libi2pd/SSU2.cpp
@@ -1563,7 +1563,7 @@ namespace transport
 
 	void SSU2Server::SetVersion (int version)
 	{
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
         m_Version = version;
 #endif
 	}

--- a/libi2pd/SSU2OutOfSession.cpp
+++ b/libi2pd/SSU2OutOfSession.cpp
@@ -263,7 +263,7 @@ namespace transport
 		SetState (eSSU2SessionStateHolePunch);
 		SetRemoteEndpoint (remoteEndpoint);
 		SetAddress (addr);
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 		if (server.GetVersion () > 2) // we support post quantum in config
 			SetVersion (addr->v);
 #endif

--- a/libi2pd/SSU2Session.cpp
+++ b/libi2pd/SSU2Session.cpp
@@ -743,9 +743,17 @@ namespace transport
 		{
 			i2p::data::CryptoKeyType cryptoType = (i2p::data::CryptoKeyType)(m_Version + 2);
 			m_PQKeys = i2p::crypto::CreateMLKEMKeys (cryptoType);
-            m_PQKeys->GenerateKeys ();
-            offset = m_PQKeys->GetKeyLen () + 16;
-			payloadSize += offset;
+			if (m_PQKeys)
+			{
+				m_PQKeys->GenerateKeys ();
+				offset = m_PQKeys->GetKeyLen () + 16;
+				payloadSize += offset;
+			}
+			else
+			{
+				LogPrint (eLogWarning, "SSU2: ML-KEM type ", (int)cryptoType, " is not available, fallback to version 2");
+				m_Version = 2;
+			}
 		}
 #endif
 		payload[payloadSize] = eSSU2BlkDateTime;
@@ -915,6 +923,11 @@ namespace transport
 			m_NoiseState->MixHash (buf + offset, keyLen + 16);
 			offset += keyLen + 16;
 			m_PQKeys = i2p::crypto::CreateMLKEMKeys (cryptoType);
+			if (!m_PQKeys)
+			{
+				LogPrint (eLogWarning, "SSU2: ML-KEM type ", (int)cryptoType, " is not available");
+				return false;
+			}
 			m_PQKeys->SetPublicKey (encapsKey.data ());
         }
 #endif
@@ -3460,7 +3473,11 @@ namespace transport
 		switch (version)
 		{
 			case 3:
+#if defined(LIBRESSL_VERSION_NUMBER)
+				m_Version = 2; // ML-KEM-512 is not available on LibreSSL
+#else
 				m_Version = 3;
+#endif
 			break;
 			case 4:
 				m_Version = (m_MaxPayloadSize >= SSU2_MLKEM768_MIN_PAYLOAD_SIZE) ? 4: 2;

--- a/libi2pd/SSU2Session.cpp
+++ b/libi2pd/SSU2Session.cpp
@@ -289,7 +289,7 @@ namespace transport
 			m_SentHandshakePacket.reset (nullptr);
 			m_SessionConfirmedFragment.reset (nullptr);
 			m_PathChallenge.reset (nullptr);
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 			m_PQKeys.reset (nullptr);
 #endif
 			if (!m_IntermediateQueue.empty ())
@@ -332,7 +332,7 @@ namespace transport
 		m_NoiseState.reset (nullptr);
 		m_SessionConfirmedFragment.reset (nullptr);
 		m_SentHandshakePacket.reset (nullptr);
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 		m_PQKeys.reset (nullptr);
 #endif
 		m_ConnectTimer.cancel ();
@@ -712,9 +712,11 @@ namespace transport
 	bool SSU2Session::SendSessionRequest (uint64_t token)
 	{
 		// we are Alice
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 		if (m_Server.GetVersion () > 2) // we support post quantum in config
 			SetVersion (m_Address->v);
+		LogPrint (eLogDebug, "SSU2: PQ selection server=", m_Server.GetVersion (),
+			" remote=", (int)m_Address->v, " effective=", (int)m_Version);
 #endif
 		m_EphemeralKeys = i2p::transport::transports.GetNextX25519KeysPair ();
 		m_SentHandshakePacket.reset (new HandshakePacket);
@@ -736,7 +738,7 @@ namespace transport
 		memcpy (headerX + 16, m_EphemeralKeys->GetPublicKey (), 32); // X
 		// payload
 		size_t payloadSize = 0, offset = 0;
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 		if (m_Version > 2)
 		{
 			i2p::data::CryptoKeyType cryptoType = (i2p::data::CryptoKeyType)(m_Version + 2);
@@ -770,7 +772,7 @@ namespace transport
 		}
 		// create and init noise state
 		if (!m_NoiseState) m_NoiseState.reset (new i2p::crypto::NoiseSymmetricState);
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 		if (m_Version > 2)
 		{
 			InitNoiseXKStateMLKEM1 (*m_NoiseState, (i2p::data::CryptoKeyType)(m_Version + 2), m_Address->s);
@@ -786,7 +788,7 @@ namespace transport
 		m_EphemeralKeys->Agree (m_Address->s, sharedSecret);
 		m_NoiseState->MixKey (sharedSecret);
 		// encrypt
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 		if (m_PQKeys)
 		{
 			size_t keyLen = m_PQKeys->GetKeyLen ();
@@ -835,7 +837,7 @@ namespace transport
 			LogPrint (eLogWarning, "SSU2: SessionRequest message too short ", len);
 			return false;
 		}
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 		if (header.h.flags[0] >= 2 && header.h.flags[0] <= 4) // ver
 		{
 			if (m_Server.GetVersion () > 2)
@@ -882,7 +884,7 @@ namespace transport
 		}
 		// create and init noise state
 		if (!m_NoiseState) m_NoiseState.reset (new i2p::crypto::NoiseSymmetricState);
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 		if (m_Version > 2)
 		{
 			InitNoiseXKStateMLKEM1 (*m_NoiseState, (i2p::data::CryptoKeyType)(m_Version + 2), i2p::context.GetSSU2StaticPublicKey ());
@@ -899,7 +901,7 @@ namespace transport
 		m_NoiseState->MixKey (sharedSecret);
 		// decrypt
 		size_t offset = 64;
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
         if (m_Version > 2)
         {
 			auto cryptoType = (i2p::data::CryptoKeyType)(m_Version + 2);
@@ -975,7 +977,7 @@ namespace transport
 		// payload
 		size_t maxPayloadSize = m_MaxPayloadSize - 48;
 		size_t payloadSize = 0, offset = 0;
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
         if (m_Version > 2 && m_PQKeys)
         {
             size_t cipherTextLen = m_PQKeys->GetCTLen ();
@@ -1072,7 +1074,7 @@ namespace transport
 		m_EphemeralKeys->Agree (headerX + 16, sharedSecret);
 		m_NoiseState->MixKey (sharedSecret);
 		size_t offset = 64;
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 		if (m_Version > 2 && m_PQKeys)
 		{
 			i2p::data::CryptoKeyType cryptoType = (i2p::data::CryptoKeyType)(m_Version + 2);
@@ -1454,7 +1456,7 @@ namespace transport
 	void SSU2Session::SendTokenRequest ()
 	{
 		// we are Alice
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 		if (m_Server.GetVersion () > 2) // we support post quantum in config
 			SetVersion (m_Address->v);
 #endif
@@ -1503,7 +1505,7 @@ namespace transport
 			LogPrint (eLogWarning, "SSU2: Incorrect TokenRequest len ", len);
 			return false;
 		}
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 		if (header.h.flags[0] >= 2 && header.h.flags[0] <= 4) // ver
 		{
 			if (m_Server.GetVersion () > 2)
@@ -1625,7 +1627,7 @@ namespace transport
 		}
 
 		if (!m_NoiseState) m_NoiseState.reset (new i2p::crypto::NoiseSymmetricState);
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 		if (m_Version > 2)
 			InitNoiseXKStateMLKEM1 (*m_NoiseState, (i2p::data::CryptoKeyType)(m_Version + 2), m_Address->s);
 		else

--- a/libi2pd/SSU2Session.h
+++ b/libi2pd/SSU2Session.h
@@ -376,7 +376,7 @@ namespace transport
 			std::unique_ptr<i2p::crypto::NoiseSymmetricState> m_NoiseState;
 			std::unique_ptr<HandshakePacket> m_SessionConfirmedFragment; // for Bob if applicable or second fragment for Alice
 			std::unique_ptr<HandshakePacket> m_SentHandshakePacket; // SessionRequest, SessionCreated or SessionConfirmed
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 			std::unique_ptr<i2p::crypto::MLKEMKeys> m_PQKeys;
 #endif
 			std::shared_ptr<const i2p::data::RouterInfo::Address> m_Address;

--- a/libi2pd/Transports.cpp
+++ b/libi2pd/Transports.cpp
@@ -212,7 +212,7 @@ namespace transport
 		m_Thread = new std::thread (std::bind (&Transports::Run, this));
 		std::string ntcp2proxy; i2p::config::GetOption("ntcp2.proxy", ntcp2proxy);
         int ntcp2version = 2, ssu2version = 2;
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
         i2p::config::GetOption("ntcp2.version", ntcp2version);
         i2p::config::GetOption("ssu2.version", ssu2version);
 #endif
@@ -718,7 +718,7 @@ namespace transport
 			if (ssu2 && (compatibleTransports & (i2p::data::RouterInfo::eSSU2V4 | i2p::data::RouterInfo::eSSU2V6)))
 			{
 				bool isSSU2PQ = false;
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 				if (m_SSU2Server && m_SSU2Server->GetVersion () > 2)
 				{
 					isSSU2PQ = true;
@@ -1613,7 +1613,7 @@ namespace transport
 				if (!ntcp2proxy.empty ()) published = false;
 			}
 			int ntcp2version = 2;
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 			i2p::config::GetOption("ntcp2.version", ntcp2version);
 #endif
 			if (published)
@@ -1645,7 +1645,7 @@ namespace transport
 		if (ssu2)
 		{
 			int ssu2version = 2;
-#if OPENSSL_PQ
+#if OPENSSL_MLKEM
 			i2p::config::GetOption("ssu2.version", ssu2version);
 #endif
 			uint16_t ssu2port; i2p::config::GetOption("ssu2.port", ssu2port);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -8,7 +8,7 @@ LIBI2PD = ../libi2pd.a
 TESTS = \
 	test-http-merge_chunked test-http-req test-http-res test-http-url test-http-url_decode \
 	test-gost test-gost-sig test-base-64 test-aeadchacha20poly1305 test-blinding \
-	test-elligator test-eddsa test-aes
+	test-elligator test-eddsa test-aes test-postquantum
 
 ifneq (, $(findstring mingw, $(SYS))$(findstring windows-gnu, $(SYS))$(findstring cygwin, $(SYS)))
 	CXXFLAGS += -DWIN32_LEAN_AND_MEAN
@@ -57,6 +57,9 @@ test-eddsa: test-eddsa.cpp $(LIBI2PD)
 	$(CXX) $(CXXFLAGS) $(NEEDED_CXXFLAGS) $(INCFLAGS) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
 test-aes: test-aes.cpp $(LIBI2PD)
+	$(CXX) $(CXXFLAGS) $(NEEDED_CXXFLAGS) $(INCFLAGS) $(LDFLAGS) -o $@ $^ $(LDLIBS)
+
+test-postquantum: test-postquantum.cpp $(LIBI2PD)
 	$(CXX) $(CXXFLAGS) $(NEEDED_CXXFLAGS) $(INCFLAGS) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
 run: $(TESTS)

--- a/tests/test-postquantum.cpp
+++ b/tests/test-postquantum.cpp
@@ -1,0 +1,41 @@
+#include <array>
+#include <cassert>
+#include <cstring>
+
+#include "PostQuantum.h"
+
+namespace
+{
+#if OPENSSL_MLKEM
+	void CheckRoundTrip (i2p::data::CryptoKeyType type)
+	{
+		auto alice = i2p::crypto::CreateMLKEMKeys (type);
+		auto bob = i2p::crypto::CreateMLKEMKeys (type);
+		assert (alice && bob);
+		alice->GenerateKeys ();
+		std::array<uint8_t, i2p::crypto::MLKEM1024_KEY_LENGTH> pub{};
+		alice->GetPublicKey (pub.data ());
+		bob->SetPublicKey (pub.data ());
+		std::array<uint8_t, i2p::crypto::MLKEM1024_CIPHER_TEXT_LENGTH> ciphertext{};
+		std::array<uint8_t, i2p::crypto::MLKEM_SHARED_SECRET_LENGTH> sharedBob{};
+		std::array<uint8_t, i2p::crypto::MLKEM_SHARED_SECRET_LENGTH> sharedAlice{};
+		bob->Encaps (ciphertext.data (), sharedBob.data ());
+		alice->Decaps (ciphertext.data (), sharedAlice.data ());
+		assert (memcmp (sharedAlice.data (), sharedBob.data (), sharedAlice.size ()) == 0);
+	}
+#endif
+}
+
+int main ()
+{
+#if OPENSSL_MLKEM
+#if defined(LIBRESSL_VERSION_NUMBER)
+	CheckRoundTrip (i2p::data::CRYPTO_KEY_TYPE_ECIES_MLKEM768_X25519_AEAD);
+#else
+	CheckRoundTrip (i2p::data::CRYPTO_KEY_TYPE_ECIES_MLKEM512_X25519_AEAD);
+	CheckRoundTrip (i2p::data::CRYPTO_KEY_TYPE_ECIES_MLKEM768_X25519_AEAD);
+#endif
+#endif
+	return 0;
+}
+


### PR DESCRIPTION
## Summary
This PR brings LibreSSL ML-KEM compatibility to parity with the OpenSSL branch intent, while keeping the OpenBSD hardening cleanup and staying rebased on top of `openssl`.

## What changed
### 1) ML-KEM / LibreSSL compatibility
- switched transport/config/ratchet PQ gating from `OPENSSL_PQ` to `OPENSSL_MLKEM`
- enabled `OPENSSL_MLKEM` for LibreSSL `>= 4.3.0`
- kept ML-DSA-specific paths under `OPENSSL_MLDSA`
- fixed ML-KEM mapping/indexing for LibreSSL variants (768/1024)
- added safe fallback paths for unsupported ML-KEM variants on LibreSSL
- added targeted NTCP2/SSU2 diagnostics for PQ selection and handshake framing

### 2) NTCP2 upstream behavior alignment
- restored intentional `ClientLogin()` random SessionRequest size variation (upstream behavior), to avoid divergence in handshake shape.

### 3) OpenBSD hardening cleanup
- preserved the minimal pledge/unveil cleanup included in this branch.

### 4) Added deterministic PQ test coverage
- added `tests/test-postquantum.cpp`
- wired into `tests/Makefile` as `test-postquantum`
- validates ML-KEM encapsulation/decapsulation roundtrip

## Validation performed in this environment
Toolchain/runtime:
- clang++ (Homebrew LLVM)
- Homebrew LibreSSL 4.3.2
- Homebrew OpenSSL 3.6.2

Checks completed:
- build and run with LibreSSL
- build and run with OpenSSL
- `test-postquantum` passed on both LibreSSL and OpenSSL builds
- long runtime windows with `ntcp2.version=4` and `ssu2.version=4`

## Current production-readiness status
- deterministic ML-KEM encaps/decaps coverage is now in-tree and passing
- SSU2 runtime remains healthy
- NTCP2 runtime still shows intermittent `SessionCreated read error` in public-peer conditions, in patterns comparable to current upstream runtime behavior

Given the above, this PR is prepared for preview/review as the compatibility-correct baseline and keeps parity with upstream behavior while improving LibreSSL correctness and testability.
