### PR TITLE
ИЗ виртуальной машины файл свежий проверил компилируется

### DIFF
--- a/daemon/HaikuDaemon.cpp
+++ b/daemon/HaikuDaemon.cpp
@@ -171,7 +171,7 @@ void MainWindow :: OpenHTTPInterface()
 	com << "WebPositive http://" << address << ":" << port;
 	//char * argv[] = {(char*)url.str().c_str() , NULL, NULL};
 	//BRoster{}.Launch( "application/x-vnd.Haiku-WebPositive", 2, argv);
-	std::string url_s{url.str()};
+	std::string url_s{com.str()};
 	std::thread ([url_s]() {
 		system(url_s.c_str());
 	}).detach();	

--- a/daemon/HaikuDaemon.cpp
+++ b/daemon/HaikuDaemon.cpp
@@ -166,14 +166,13 @@ void MainWindow :: OpenHTTPInterface()
 	{
 		return m_MainView->SetText("Not enabled http server");
 	}
-//	int pid;
 	std::ostringstream com;
 	com << "WebPositive http://" << address << ":" << port;
 	//char * argv[] = {(char*)url.str().c_str() , NULL, NULL};
 	//BRoster{}.Launch( "application/x-vnd.Haiku-WebPositive", 2, argv);
-	std::string url_s{com.str()};
-	std::thread ([url_s]() {
-		system(url_s.c_str());
+	std::string com_s{com.str()};
+	std::thread ([com_s]() {
+		system(com_s.c_str());
 	}).detach();	
 }
 


### PR DESCRIPTION
<img width="1024" height="768" alt="screenshot2" src="https://github.com/user-attachments/assets/d1fa256d-bfe3-4eeb-be79-fed283af2fe6" />
<img width="1024" height="768" alt="screenshot1" src="https://github.com/user-attachments/assets/e515f398-3bce-4279-90b6-e25f0789d4b6" />

Roster при передачи аргумента как тут https://www.haiku-os.org/docs/api/classBRoster.html запускает главную страницу при argc 1, при argc>1 вообще не запускает. fork + system крашает, чперез тред + detach не крашает

Страница для вебтунелей не готова, но добавлена логика где показывает destination (без .b32.i2p) при нажатии. Просто прототип