### PR TITLE
SAM crash on shared destination teardown

### DIFF
--- a/libi2pd/Destination.cpp
+++ b/libi2pd/Destination.cpp
@@ -1113,6 +1113,9 @@ namespace client
 
 	void ClientDestination::Start ()
 	{
+		// Idempotent: a second Start() on a running destination must not re-create
+		// m_StreamingDestination (orphaning the live one) nor re-arm leaseset/pool.
+		if (m_StreamingDestination) return;
 		LeaseSetDestination::Start ();
 		m_StreamingDestination = std::make_shared<i2p::stream::StreamingDestination> (GetSharedFromThis ()); // TODO:
 		m_StreamingDestination->Start ();

--- a/libi2pd_client/SAM.cpp
+++ b/libi2pd_client/SAM.cpp
@@ -1378,7 +1378,9 @@ namespace client
 
 	void SAMSingleSession::StopLocalDestination ()
 	{
-		localDestination->Release ();
+		// Destination is ref-counted and may be shared by sessions whose SESSION
+		// CREATEs resolve to the same identity hash; only its last user may stop it.
+		if (localDestination->Release () > 0) return;
 		// stop accepting new streams
 		localDestination->StopAcceptingStreams ();
 		// terminate existing streams


### PR DESCRIPTION
Столкнулся с багом при разработке приложения, которое использует SAM с оффлайн-ключами. Флоу: SAM поднимает локальный дест, через некоторое время происходит поднятие второго аналогичного деста с обновленной датой истечения (замена деста на новые оффлайн ключи). Когда один SAM-дест отключался, происходил сегфолт i2pd. Локализовал проблему, проверил локально - теперь не крашится.