### PR TITLE
Refresh offline-signed transient on destination re-create

### DIFF
--- a/libi2pd/Destination.cpp
+++ b/libi2pd/Destination.cpp
@@ -1167,6 +1167,23 @@ namespace client
 		if (m_StreamingDestination) m_StreamingDestination->Start ();
 	}
 
+	void ClientDestination::UpdateOfflineSignature (const i2p::data::PrivateKeys& keys)
+	{
+		// Adopt a newer offline transient of the same identity in place: swap keys and
+		// republish the LeaseSet, keeping tunnels and streams (unlike SetPrivateKeys).
+		if (!keys.IsOfflineSignature () || !m_Keys.IsOfflineSignature ()) return;
+		if (keys.GetPublic ()->GetIdentHash () != GetIdentHash ()) return;
+		const uint32_t expires = bufbe32toh (keys.GetOfflineSignature ().data ());
+		if (expires <= bufbe32toh (m_Keys.GetOfflineSignature ().data ())) return; // only move forward
+		LogPrint (eLogInfo, "Destination: Refreshing offline signature for ",
+			GetIdentHash ().ToBase32 (), ", transient expires ", expires);
+		boost::asio::post (GetService (), [s = GetSharedFromThis (), keys]()
+		{
+			s->m_Keys = keys;
+			s->UpdateLeaseSet ();
+		});
+	}
+
 	void ClientDestination::HandleDataMessage (const uint8_t * buf, size_t len,
 		i2p::garlic::ECIESX25519AEADRatchetSession * from)
 	{

--- a/libi2pd/Destination.h
+++ b/libi2pd/Destination.h
@@ -186,10 +186,10 @@ namespace client
 			// I2CP
 			virtual void HandleDataMessage (const uint8_t * buf, size_t len, i2p::garlic::ECIESX25519AEADRatchetSession * from) = 0;
 			virtual void CreateNewLeaseSet (const std::vector<std::shared_ptr<i2p::tunnel::InboundTunnel> >& tunnels) = 0;
+			void UpdateLeaseSet ();
 
 		private:
 
-			void UpdateLeaseSet ();
 			std::shared_ptr<const i2p::data::LocalLeaseSet> GetLeaseSetMt ();
 			void Publish ();
 			void HandlePublishConfirmationTimer (const boost::system::error_code& ecode);
@@ -252,6 +252,7 @@ namespace client
 
 			const i2p::data::PrivateKeys& GetPrivateKeys () const { return m_Keys; };
 			void SetPrivateKeys (const i2p::data::PrivateKeys& keys);
+			void UpdateOfflineSignature (const i2p::data::PrivateKeys& keys);
 			void Sign (const uint8_t * buf, int len, uint8_t * signature) const { m_Keys.Sign (buf, len, signature); };
 
 			// ref counter

--- a/libi2pd_client/ClientContext.cpp
+++ b/libi2pd_client/ClientContext.cpp
@@ -410,6 +410,8 @@ namespace client
 		if (it != m_Destinations.end ())
 		{
 			LogPrint (eLogWarning, "Clients: Local destination ", m_AddressBook.ToAddress(keys.GetPublic ()->GetIdentHash ()), " exists");
+			if (keys.IsOfflineSignature ())
+				it->second->UpdateOfflineSignature (keys);
 			it->second->Start (); // make sure to start
 			return it->second;
 		}
@@ -425,6 +427,8 @@ namespace client
 		if (it != m_Destinations.end ())
 		{
 			LogPrint (eLogWarning, "Clients: Local destination ", m_AddressBook.ToAddress(keys.GetPublic ()->GetIdentHash ()), " exists");
+			if (keys.IsOfflineSignature ())
+				it->second->UpdateOfflineSignature (keys);
 			it->second->Start (); // make sure to start
 			return it->second;
 		}


### PR DESCRIPTION
У offline-ключей временный ключ подписи нужно периодически обновлять, не меняя адрес. Но обновить его на уже работающем десте сейчас нельзя: идентификатор деста одинаков у всех временных ключей одного мастера, поэтому при повторном SESSION CREATE просто возвращает старое назначение и тихо игнорирует новый ключ - а когда у старого истекает срок, дест незаметно уходит в офлайн (ключи становятся невалидны). Этот PR при повторном создании с более свежим временным ключом принимает его на лету (подменяет ключи и переиздаёт лизсет, не трогая туннели и соединения), так что адрес остаётся прежним и без разрыва. Полезно для богатой SAM-логики, столкнулся лично.