### PR TITLE
Fix deflate when last buffer is zero length

### DIFF
--- a/libi2pd/Gzip.cpp
+++ b/libi2pd/Gzip.cpp
@@ -146,23 +146,29 @@ namespace data
 				m_Deflator.avail_in = it.second;
 				m_Deflator.next_out = out + offset;
 				m_Deflator.avail_out = outLen - offset;
-				auto flush = (it == bufs.back ()) ? Z_FINISH : Z_NO_FLUSH;
-				err = deflate (&m_Deflator, flush);
-				if (err)
-				{
-					if (flush && err == Z_STREAM_END)
-					{
-						out[9] = 0xff; // OS is always unknown
-						return outLen - m_Deflator.avail_out;
-					}
-					break;
-				}
+				err = deflate (&m_Deflator, Z_NO_FLUSH);
+				if (err) break;
 				offset = outLen - m_Deflator.avail_out;
 			}
 		}
-		// else
+		if (!err)
+		{
+			// finish the stream
+			m_Deflator.next_in = nullptr;
+			m_Deflator.avail_in = 0;
+			m_Deflator.next_out = out + offset;
+			m_Deflator.avail_out = outLen - offset;
+			err = deflate (&m_Deflator, Z_FINISH);
+			if (err == Z_STREAM_END)
+			{
+				out[9] = 0xff; // OS is always unknown
+				return outLen - m_Deflator.avail_out;
+			}
+		}
 		if (err)
 			LogPrint (eLogError, "Gzip: Deflate error ", err);
+		else
+			LogPrint (eLogError, "Gzip: Deflate error, output buffer is too small");
 		return 0;
 	}
 


### PR DESCRIPTION
Столкнулся с залипанием udp-туннеля. Цикл сжатия пропускает буфер нулевой длины, а Z_FINISH выдаётся только при обработке последнего буфера списка, поэтому если последний буфер пустой (а это payload любой ack-only и reset-path датаграммы datagram3), поток zlib никогда не завершается. Итого при включённом gzip (дефолт для udpclient) не уходят ни подтверждения, ни восстановление пути.