### PR TITLE
Udp tunnels optimisation

### DIFF
--- a/libi2pd/Datagram.cpp
+++ b/libi2pd/Datagram.cpp
@@ -617,7 +617,8 @@ namespace datagram
 			}
 		}
 
-		if (!m_RoutingSession || m_RoutingSession->IsTerminated () || !m_RoutingSession->IsReadyToSend ())
+		if (!m_RoutingSession || m_RoutingSession->IsTerminated () || !m_RoutingSession->IsReadyToSend () ||
+		    (m_RoutingSession->GetLastActivityTimestamp () && m_RoutingSession->IsInactive (i2p::util::GetSecondsSinceEpoch ()))) // request new garlic session if established session became inactive
 		{
 			bool found = false;
 			if (!m_PendingRoutingSessions.empty ())
@@ -657,7 +658,8 @@ namespace datagram
 		{
 			LogPrint (eLogDebug, "Datagram: path reset");
 			m_RoutingSession->SetSharedRoutingPath (nullptr);
-			path = nullptr;
+			m_RoutingSession = nullptr; // re-query garlic session, it gets restarted if inactive
+			return GetSharedRoutingPath ();
 		}
 
 		if (path)

--- a/libi2pd/Datagram.cpp
+++ b/libi2pd/Datagram.cpp
@@ -747,6 +747,15 @@ namespace datagram
 		if(ls && ls->GetExpirationTime() > oldExpire) m_RemoteLeaseSet = ls;
 	}
 
+	void DatagramSession::RequestUpdatedLeaseSet ()
+	{
+		if (!m_RequestingLS)
+		{
+			m_RequestingLS = true;
+			m_LocalDestination->RequestDestination(m_RemoteIdent, std::bind(&DatagramSession::HandleLeaseSetUpdated, this, std::placeholders::_1));
+		}
+	}
+
 	void DatagramSession::FlushSendQueue ()
 	{
 		if (m_SendQueue.empty ()) return;

--- a/libi2pd/Datagram.h
+++ b/libi2pd/Datagram.h
@@ -85,6 +85,8 @@ namespace datagram
 			void SetVersion (DatagramVersion version) { m_Version = version; }
 
 			void DropSharedRoutingPath () { if (m_RoutingSession) m_RoutingSession->SetSharedRoutingPath (nullptr); }
+			// request LeaseSet update from floodfill in case our copy contains dead leases
+			void RequestUpdatedLeaseSet ();
 
 		struct Info
 		{

--- a/libi2pd/ECIESX25519AEADRatchetSession.h
+++ b/libi2pd/ECIESX25519AEADRatchetSession.h
@@ -185,7 +185,7 @@ namespace garlic
 			const i2p::data::IdentHash * GetDestinationPtr () const { return m_Destination ? m_Destination.get () : nullptr; }; // for pongs
 			bool CheckExpired (uint64_t ts); // true is expired
 			bool CanBeRestarted (uint64_t ts) const { return ts > m_SessionCreatedTimestamp + ECIESX25519_RESTART_TIMEOUT; }
-			bool IsInactive (uint64_t ts) const { return ts > m_LastActivityTimestamp + ECIESX25519_INACTIVITY_TIMEOUT && CanBeRestarted (ts); }
+			bool IsInactive (uint64_t ts) const override { return ts > m_LastActivityTimestamp + ECIESX25519_INACTIVITY_TIMEOUT && CanBeRestarted (ts); }
 			void CleanupReceiveNSRKeys (); // called from ReceiveRatchetTagSet at Alice's side
 			bool IsResponseRequired () const { return m_State == eSessionStateNewSessionReceived || m_SendReverseKey || !m_AckRequests.empty (); };
 

--- a/libi2pd/Garlic.h
+++ b/libi2pd/Garlic.h
@@ -117,6 +117,7 @@ namespace garlic
 			virtual bool IsRatchets () const { return false; };
 			virtual bool IsReadyToSend () const { return true; };
 			virtual bool IsTerminated () const { return !GetOwner (); };
+			virtual bool IsInactive (uint64_t ts) const { return false; }; // override in ECIESX25519AEADRatchetSession
 			virtual uint64_t GetLastActivityTimestamp () const { return 0; }; // non-zero for rathets only
 			virtual void SetAckRequestInterval (int interval) {}; // in milliseconds, override in ECIESX25519AEADRatchetSession
 			virtual std::vector<std::shared_ptr<I2NPMessage> > WrapMultipleMessages (const std::vector<std::shared_ptr<const I2NPMessage> >& msgs);

--- a/libi2pd_client/UDPTunnel.cpp
+++ b/libi2pd_client/UDPTunnel.cpp
@@ -213,8 +213,11 @@ namespace client
 						i2p::util::Mapping options;
 						options.Put (UDP_SESSION_FLAGS, UDP_SESSION_FLAG_RESET_PATH | UDP_SESSION_FLAG_ACK_REQUESTED);
 						auto session = GetDatagramSession ();
-						session->DropSharedRoutingPath ();
-						m_Destination->SendDatagram (session, nullptr, 0, 0, 0, &options);
+						if (session)
+						{
+							session->DropSharedRoutingPath ();
+							m_Destination->SendDatagram (session, nullptr, 0, 0, 0, &options);
+						}
 					}
 				});
 		}

--- a/libi2pd_client/UDPTunnel.cpp
+++ b/libi2pd_client/UDPTunnel.cpp
@@ -216,6 +216,7 @@ namespace client
 						if (session)
 						{
 							session->DropSharedRoutingPath ();
+							session->RequestUpdatedLeaseSet (); // in case current leases are dead
 							m_Destination->SendDatagram (session, nullptr, 0, 0, 0, &options);
 						}
 					}

--- a/libi2pd_client/UDPTunnel.cpp
+++ b/libi2pd_client/UDPTunnel.cpp
@@ -483,7 +483,8 @@ namespace client
 		}
 		if (!m_IsSendingAllowed)
 		{
-			if (!m_IsFirstPacket && i2p::util::GetMillisecondsSinceEpoch () >  m_LastRepliableDatagramTime + I2P_UDP_SESSION_TIMEOUT)
+			const auto ts1 = i2p::util::GetMillisecondsSinceEpoch ();
+			if (!m_IsFirstPacket && ts1 > m_LastRepliableDatagramTime + I2P_UDP_SESSION_TIMEOUT)
 			{
 				//  reset session
 				m_IsFirstPacket = true;
@@ -494,8 +495,12 @@ namespace client
 			}
 			if (!m_IsSendingAllowed)
 			{
-				RecvFromLocal ();
-				return;
+				if (!(m_IsFirstPacket && ts1 > m_LastRepliableDatagramTime + I2P_UDP_FIRST_PACKET_RESEND_INTERVAL))
+				{
+					RecvFromLocal ();
+					return;
+				}
+				// else fall through and send new first packet, previous one wasn't acked in time
 			}
 		}
 		if (!m_UnackedDatagrams.empty () && m_NextSendPacketNum > m_UnackedDatagrams.front ().first + I2P_UDP_MAX_NUM_UNACKED_DATAGRAMS)

--- a/libi2pd_client/UDPTunnel.cpp
+++ b/libi2pd_client/UDPTunnel.cpp
@@ -205,7 +205,7 @@ namespace client
 					if (ecode != boost::asio::error::operation_aborted)
 					{
 						LogPrint (eLogInfo, "UDP Connection: Packet ", m_AckTimerSeqn, " was not acked");
-						m_IsSendingAllowed = false; // stop sending datagrams
+						if (m_IsFirstPacket) m_IsSendingAllowed = false; // stop sending only if session is not established yet
 						m_AckTimerSeqn = 0;
 						m_RTT = 0;
 						if (!m_UnackedDatagrams.empty ()) ScheduleAckTimer (0); // try again if failed

--- a/libi2pd_client/UDPTunnel.h
+++ b/libi2pd_client/UDPTunnel.h
@@ -32,6 +32,7 @@ namespace client
 	const uint64_t I2P_UDP_SESSION_TIMEOUT = 1000 * 60 * 2;
 	const uint64_t I2P_UDP_REPLIABLE_DATAGRAM_INTERVAL = 100; // in milliseconds
 	const uint64_t I2P_UDP_MAX_UNACKED_DATAGRAM_TIME = 8000; // in milliseconds
+	const uint64_t I2P_UDP_FIRST_PACKET_RESEND_INTERVAL = 1000; // in milliseconds
 	const size_t I2P_UDP_MAX_NUM_UNACKED_DATAGRAMS = 500;
 
 	/** max size for i2p udp */

--- a/libi2pd_client/UDPTunnel.h
+++ b/libi2pd_client/UDPTunnel.h
@@ -216,7 +216,7 @@ namespace client
 			bool m_Gzip;
 			i2p::datagram::DatagramVersion m_DatagramVersion;
 			std::shared_ptr<UDPConvo> m_LastSession;
-			uint32_t m_KeepAliveInterval;
+			uint32_t m_KeepAliveInterval = 0;
 			std::unique_ptr<boost::asio::steady_timer> m_KeepAliveTimer;
 
 		public:


### PR DESCRIPTION
Набор точечных исправлений стабильности udpclient. Тестировал под WireGuard (в горячих путях проблем не нашел). Главное - устранен дедлок установления сессии: если первый пакет или его подтверждение терялись, клиент переставал слать трафик и туннель зависал (иногда до полной потери связи). Теперь клиент повторяет попытку установления раз в секунду вместо того, чтобы молча дропать пакеты. Также убрана жесткая блокировка отправки в уже работающем потоке при потере одного подтверждения - это устраняет многосекундные "затыки", в случае WG консистентность канала восстанавливается хорошо без вмешательства на нашей стороне (всего скорее именно этот кейс некоторые юзеры описывают как периодический затык). В остальном, исправления повышают скорость восстановления при рестарте сервера (вместо 10 минут локально получил около двух минут), а также пара тривиальных фиксов.