### PR TITLE
openrc: create needed directories before checkpath

### DIFF
--- a/contrib/openrc/i2pd.openrc
+++ b/contrib/openrc/i2pd.openrc
@@ -30,6 +30,8 @@ start_pre() {
     exit 1
   fi
 
+  checkpath -d -m 0755 -o i2pd:adm /var/log/i2pd
+  checkpath -d -m 0755 -o i2pd:adm /run/i2pd
   checkpath -f -o i2pd:adm $logfile
   checkpath -f -o i2pd:adm $pidfile
 


### PR DESCRIPTION
Fixes a bug in the OpenRC init script where files are created without first creating the parent directories. This can cause the daemon to fail to start after a system reboot.