### PR TITLE
chore: fix several memory safety issues

### DIFF
--- a/libi2pd/Family.cpp
+++ b/libi2pd/Family.cpp
@@ -164,7 +164,7 @@ namespace data
 			else
 				curve = -1;
 #endif	
-			if (!curve || curve == NID_X9_62_prime256v1)
+			if ((!curve || curve == NID_X9_62_prime256v1) && family.length () + 32 <= 100)
 			{
 				uint8_t buf[100], sign[72], signature[64];
 				size_t len = family.length ();
@@ -187,6 +187,8 @@ namespace data
 				ECDSA_SIG_free(sig1);
 				sig = ByteStreamToBase64 (signature, 64);
 			}	
+			else if (family.length () + 32 > 100)
+				LogPrint (eLogError, "Family: ", family, " is too long");
 			else
 				LogPrint (eLogWarning, "Family: elliptic curve ", curve, " is not supported");
 

--- a/libi2pd/Transports.cpp
+++ b/libi2pd/Transports.cpp
@@ -1438,6 +1438,7 @@ namespace transport
 		{
 			std::lock_guard<std::mutex> l(m_FamilyMutex);
 			auto ri = i2p::data::netdb.FindRouter(ih);
+			if (!ri) return false;
 			for (const auto & fam : m_TrustedFamilies)
 				if(ri->IsFamily(fam)) return true;
 		}

--- a/libi2pd/TunnelPool.cpp
+++ b/libi2pd/TunnelPool.cpp
@@ -43,6 +43,8 @@ namespace tunnel
 		m_IsActive (true), m_IsHighBandwidth (isHighBandwidth), m_CustomPeerSelector(nullptr),
 		m_Rng (i2p::util::GetMonotonicMicroseconds ()%1000000LL)
 	{
+		if (m_NumInboundHops > MAX_NUM_RECORDS) m_NumInboundHops = MAX_NUM_RECORDS;
+		if (m_NumOutboundHops > MAX_NUM_RECORDS) m_NumOutboundHops = MAX_NUM_RECORDS;
 		if (m_NumInboundTunnels > TUNNEL_POOL_MAX_INBOUND_TUNNELS_QUANTITY)
 			m_NumInboundTunnels = TUNNEL_POOL_MAX_INBOUND_TUNNELS_QUANTITY;
 		if (m_NumOutboundTunnels > TUNNEL_POOL_MAX_OUTBOUND_TUNNELS_QUANTITY)
@@ -123,8 +125,8 @@ namespace tunnel
 	{
 		if( inHops >= 0 && outHops >= 0 && inQuant > 0 && outQuant > 0)
 		{
-			m_NumInboundHops = inHops;
-			m_NumOutboundHops = outHops;
+			m_NumInboundHops = inHops > MAX_NUM_RECORDS ? MAX_NUM_RECORDS : inHops;
+			m_NumOutboundHops = outHops > MAX_NUM_RECORDS ? MAX_NUM_RECORDS : outHops;
 			m_NumInboundTunnels = inQuant;
 			m_NumOutboundTunnels = outQuant;
 			return true;

--- a/libi2pd_client/AddressBook.cpp
+++ b/libi2pd_client/AddressBook.cpp
@@ -1126,7 +1126,7 @@ namespace client
 		}
 		// read requested address
 		uint8_t l = buf[8];
-		char address[255];
+		char address[256];
 		memcpy (address, buf + 9, l);
 		address[l] = 0;
 		LogPrint (eLogDebug, "Addressbook: Address request ", address);

--- a/libi2pd_client/BOB.cpp
+++ b/libi2pd_client/BOB.cpp
@@ -158,6 +158,8 @@ namespace client
 
 	void BOBI2POutboundTunnel::Stop ()
 	{
+		auto localDestination = GetLocalDestination ();
+		if (localDestination) localDestination->StopAcceptingStreams ();
 		ClearHandlers ();
 	}
 

--- a/libi2pd_client/SOCKS.cpp
+++ b/libi2pd_client/SOCKS.cpp
@@ -275,7 +275,7 @@ namespace proxy
 				break;
 			case ADDR_DNS:
 				std::string address(addr.dns.value, addr.dns.size);
-				if(address.substr(addr.dns.size - 4, 4) == ".i2p") // overwrite if requested address inside I2P
+				if(addr.dns.size >= 4 && address.substr(addr.dns.size - 4, 4) == ".i2p") // overwrite if requested address inside I2P
 				{
 					m_response[3] = ADDR_IPV4;
 					size += 4;

--- a/libi2pd_client/Torrents.cpp
+++ b/libi2pd_client/Torrents.cpp
@@ -487,7 +487,7 @@ namespace torrents
 	{
 		m_LastReceiveTime = i2p::util::GetMonotonicSeconds ();
 		size_t offset = 0;
-		while (size_t len = HandleNextMsg (offset) > 0)
+		while (size_t len = HandleNextMsg (offset))
 			offset += len;
 		if (offset && offset < m_ReceiveBufferOffset)
 		{


### PR DESCRIPTION
- Adds a missing bounds check to `CreateFamilySignature`, matching the existing one in `VerifyFamily`
- Adds a missing null check in `IsRestrictedPeer`
- Clamps `m_NumInboundHops`/`m_NumOutboundHops` to `MAX_NUM_RECORDS`, fixing an out-of-bounds heap write
- Fixes an off-by-one null terminator write
- Calls `StopAcceptingStreams` before BOB tunnels are deleted, preventing a UAF
- Guards a suffix check so that a hostname under 4 characters can't underflow and throw
- Fixes an operator precedence bug so that `len` actually holds the consumed byte count