### PR TITLE
chore: fix more memory safety issues

### DIFF
--- a/libi2pd/Family.cpp
+++ b/libi2pd/Family.cpp
@@ -92,7 +92,7 @@ namespace data
 		}
 
 		for (const std::string & file : files) {
-			if (file.compare(file.size() - 4, 4, ".crt") != 0) {
+			if (file.size () < 4 || file.compare(file.size() - 4, 4, ".crt") != 0) {
 				LogPrint(eLogWarning, "Family: ignoring file ", file);
 				continue;
 			}

--- a/libi2pd/Gzip.cpp
+++ b/libi2pd/Gzip.cpp
@@ -193,6 +193,7 @@ namespace data
 	size_t GzipNoCompression (const std::vector<std::pair<const uint8_t *, size_t> >& bufs, uint8_t * out, size_t outLen)
 	{
 		static const uint8_t gzipHeader[11] = { 0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x01 };
+		if (outLen < 23) return 0;
 		memcpy (out, gzipHeader, 11);
 		uint32_t crc = 0;
 		size_t len = 0;

--- a/libi2pd/HTTP.cpp
+++ b/libi2pd/HTTP.cpp
@@ -557,7 +557,7 @@ namespace http
 			if (c == '%')
 			{
 				decoded.append (url, start, i - start);
-				if (i + 2 <= url.length ())
+				if (i + 3 <= url.length ())
 				{
 					unsigned char ch;
 					auto res = std::from_chars(url.data() + i + 1, url.data() + i + 3, ch, 16);

--- a/libi2pd/RouterInfo.cpp
+++ b/libi2pd/RouterInfo.cpp
@@ -93,7 +93,7 @@ namespace data
 		}
 		// verify signature since we have identity already
 		int l = len - m_RouterIdentity->GetSignatureLen ();
-		if (m_RouterIdentity->Verify (buf, l, buf + l))
+		if (l >= 0 && m_RouterIdentity->Verify (buf, l, buf + l))
 		{
 			// clean up
 			m_IsUpdated = true;

--- a/libi2pd/util.cpp
+++ b/libi2pd/util.cpp
@@ -261,6 +261,7 @@ namespace util
 
 	std::string_view Mapping::ExtractString (const uint8_t * buf, size_t len)
 	{
+		if (!len) return { };
 		uint8_t l = buf[0];
 		if (l > len) l = len;
 		return { (const char *)(buf + 1), l };
@@ -282,6 +283,7 @@ namespace util
 
 	size_t Mapping::WriteString (std::string_view str, uint8_t * buf, size_t len)
 	{
+		if (!len) return 0;
 		auto l = str.length ();
 		if (l + 1 >= len) l = len - 1;
 		if (l > 255) l = 255; // 1 byte max

--- a/libi2pd_client/I2CP.cpp
+++ b/libi2pd_client/I2CP.cpp
@@ -836,18 +836,21 @@ namespace client
 
 	void I2CPSession::CreateLeaseSetMessageHandler (const uint8_t * buf, size_t len)
 	{
+		size_t offset = 2 + i2p::crypto::DSA_PRIVATE_KEY_LENGTH + 256;
+		if (len < offset)
+		{
+			LogPrint (eLogError, "I2CP: CreateLeaseSetMessage is too short ", len);
+			return;
+		}
 		uint16_t sessionID = bufbe16toh (buf);
 		if (sessionID == m_SessionID)
 		{
-			size_t offset = 2;
 			if (m_Destination)
 			{
-				offset += i2p::crypto::DSA_PRIVATE_KEY_LENGTH; // skip signing private key
 				// we always assume this field as 20 bytes (DSA) regardless actual size
 				// instead of
 				//offset += m_Destination->GetIdentity ()->GetSigningPrivateKeyLen ();
-				m_Destination->SetEncryptionPrivateKey (i2p::data::CRYPTO_KEY_TYPE_ELGAMAL, buf + offset);
-				offset += 256;
+				m_Destination->SetEncryptionPrivateKey (i2p::data::CRYPTO_KEY_TYPE_ELGAMAL, buf + 2 + i2p::crypto::DSA_PRIVATE_KEY_LENGTH);
 				m_Destination->LeaseSetCreated (buf + offset, len - offset);
 			}
 		}


### PR DESCRIPTION
- Adds a check to prevent underflows when parsing certificate file names
- Adds a missing buffer check before `memcpy` in `GzipNoCompression`
- Fixes an off-by-one error in `UrlDecode`'s existing bounds check
- Adds a missing length check in `RouterInfo::Update`
- Adds missing checks in `Mapping::{Extract,Write}String`
- Validates that the payload is at least as long as the fields before touching them in `CreateLeaseSetMessageHandler`, preventing an underflow