### PR TITLE
chore: fix issues found through static analysis

### DIFF
--- a/libi2pd/Config.h
+++ b/libi2pd/Config.h
@@ -83,7 +83,10 @@ namespace config {
 	bool GetOption(const char *name, T& value)
 	{
 		if (!m_Options.count(name))
+		{
+			value = T();
 			return false;
+		}
 		value = m_Options[name].as<T>();
 		return true;
 	}

--- a/libi2pd/TunnelConfig.cpp
+++ b/libi2pd/TunnelConfig.cpp
@@ -178,7 +178,10 @@ namespace tunnel
 	{
 		// inbound
 		CreatePeers (peers);
-		m_LastHop->SetNextIdent (i2p::context.GetIdentHash ());
+		if (m_LastHop)
+			m_LastHop->SetNextIdent (i2p::context.GetIdentHash ());
+		else
+			LogPrint (eLogError, "Tunnel: Can't create inbound tunnel config with no peers");
 	}
 
 	TunnelConfig::TunnelConfig (const std::vector<std::shared_ptr<const i2p::data::IdentityEx> >& peers,
@@ -188,8 +191,13 @@ namespace tunnel
 	{
 		// outbound
 		CreatePeers (peers);
-		m_FirstHop->isGateway = false;
-		m_LastHop->SetReplyHop (replyTunnelID, replyIdent);
+		if (m_FirstHop && m_LastHop)
+		{
+			m_FirstHop->isGateway = false;
+			m_LastHop->SetReplyHop (replyTunnelID, replyIdent);
+		}
+		else
+			LogPrint (eLogError, "Tunnel: Can't create outbound tunnel config with no peers");
 	}
 
 	void TunnelConfig::CreatePeers (const std::vector<std::shared_ptr<const i2p::data::IdentityEx> >& peers)

--- a/libi2pd/TunnelConfig.h
+++ b/libi2pd/TunnelConfig.h
@@ -180,7 +180,7 @@ namespace tunnel
 
 		private:
 
-			TunnelHopConfig * m_FirstHop, * m_LastHop;
+			TunnelHopConfig * m_FirstHop = nullptr, * m_LastHop = nullptr;
 			i2p::data::RouterInfo::CompatibleTransports m_FarEndTransports;
 	};
 

--- a/libi2pd_client/AddressBook.cpp
+++ b/libi2pd_client/AddressBook.cpp
@@ -72,7 +72,7 @@ namespace client
 
 			i2p::fs::HashedStorage storage;
 			std::string etagsPath, indexPath, localPath;
-			bool m_IsPersist;
+			bool m_IsPersist = false;
 			std::string m_HostsFile; // file to dump hosts.txt, empty if not used
 			std::unordered_map<i2p::data::IdentHash, std::pair<std::vector<uint8_t>, uint64_t> > m_FullAddressCache; // ident hash -> (full ident buffer, last access timestamp)
 			std::mutex m_FullAddressCacheMutex;

--- a/libi2pd_client/MatchedDestination.cpp
+++ b/libi2pd_client/MatchedDestination.cpp
@@ -20,6 +20,10 @@ namespace client
 		: RunnableClientDestination(keys, false, params),
 			m_RemoteName(remoteName) {}
 
+	MatchedTunnelDestination::~MatchedTunnelDestination()
+	{
+		if (m_ResolveTimer) m_ResolveTimer->cancel ();
+	}
 
 	void MatchedTunnelDestination::ResolveCurrentLeaseSet()
 	{

--- a/libi2pd_client/MatchedDestination.h
+++ b/libi2pd_client/MatchedDestination.h
@@ -24,6 +24,7 @@ namespace client
 
 			MatchedTunnelDestination(const i2p::data::PrivateKeys& keys, const std::string & remoteName,
 				const i2p::util::Mapping * params = nullptr);
+			~MatchedTunnelDestination();
 			void Start();
 			void Stop();
 


### PR DESCRIPTION
Fixes a number of small issues found using `scan-build` and `clang-tidy`.