### PR TITLE
chore: fix memory leaks

### DIFF
--- a/libi2pd/Destination.cpp
+++ b/libi2pd/Destination.cpp
@@ -166,6 +166,7 @@ namespace client
 		m_CleanupTimer.cancel ();
 		m_PublishConfirmationTimer.cancel ();
 		m_PublishVerificationTimer.cancel ();
+		m_PublishDelayTimer.cancel ();
 		if (m_Pool)
 		{
 			m_Pool->SetLocalDestination (nullptr);

--- a/libi2pd/SSU2OutOfSession.cpp
+++ b/libi2pd/SSU2OutOfSession.cpp
@@ -170,6 +170,7 @@ namespace transport
 		header.h.flags[2] = 0; // flag
 		memcpy (h, header.buf, 16);
 		htobuf64 (h + 16, GetSourceConnID ()); // source id
+		memset (h + 24, 0, 8); // header token
 		// payload
 		payload[0] = eSSU2BlkDateTime;
 		htobe16buf (payload + 1, 4);


### PR DESCRIPTION
Fixes two memory leaks found with `valgrind`.