### PR TITLE
Remove pidfile on shutdown fix (UnixDaemon)

### DIFF
--- a/daemon/UnixDaemon.cpp
+++ b/daemon/UnixDaemon.cpp
@@ -148,7 +148,7 @@ namespace i2p
 
 			// Pidfile
 			// this code is c-styled and a bit ugly, but we need fd for locking pidfile
-			std::string pidfile; i2p::config::GetOption("pidfile", pidfile);
+			i2p::config::GetOption("pidfile", pidfile);
 			if (pidfile == "") {
 				pidfile = i2p::fs::DataDirPath("i2pd.pid");
 			}


### PR DESCRIPTION
Объявление локальной переменной затеняло [мембера](https://github.com/PurpleI2P/i2pd/blob/openssl/daemon/Daemon.h#L132), в stop() звался Remove("") из-за чего пид-файл под линуксом не удалялся.