### PR TITLE
chore: fix memory safety issues

### DIFF
--- a/daemon/I2PControl.cpp
+++ b/daemon/I2PControl.cpp
@@ -286,7 +286,7 @@ namespace client
 					response << "{\"code\":-32601,\"message\":\"Method not found\"},";
 					response << "\"jsonrpc\":\"2.0\"}\n";
 				}
-				SendResponse (socket, buf, response, isHtml);
+				SendResponse (socket, response, isHtml);
 			}
 			catch (std::exception& ex)
 			{
@@ -295,7 +295,7 @@ namespace client
 				response << "{\"id\":null,\"error\":";
 				response << "{\"code\":-32700,\"message\":\"" << ex.what () << "\"},";
 				response << "\"jsonrpc\":\"2.0\"}\n";
-				SendResponse (socket, buf, response, isHtml);
+				SendResponse (socket, response, isHtml);
 			}
 			catch (...)
 			{
@@ -306,28 +306,27 @@ namespace client
 
 	template<typename ssl_socket>
 	void I2PControlService::SendResponse (std::shared_ptr<ssl_socket> socket,
-		std::shared_ptr<I2PControlBuffer> buf, std::ostringstream& response, bool isHtml)
+		std::ostringstream& response, bool isHtml)
 	{
-		size_t len = response.str ().length (), offset = 0;
+		auto message = std::make_shared<std::string> ();
 		if (isHtml)
 		{
 			std::ostringstream header;
 			header << "HTTP/1.1 200 OK\r\n";
 			header << "Connection: close\r\n";
-			header << "Content-Length: " << std::to_string(len) << "\r\n";
+			header << "Content-Length: " << std::to_string (response.str ().length ()) << "\r\n";
 			header << "Content-Type: application/json\r\n";
 			header << "Date: ";
 			std::time_t t = std::time (nullptr);
     		std::tm tm = *std::gmtime (&t);
 			header << std::put_time(&tm, "%a, %d %b %Y %T GMT") << "\r\n";
 			header << "\r\n";
-			offset = header.str ().size ();
-			memcpy (buf->data (), header.str ().c_str (), offset);
+			*message = header.str ();
 		}
-		memcpy (buf->data () + offset, response.str ().c_str (), len);
-		boost::asio::async_write (*socket, boost::asio::buffer (buf->data (), offset + len),
+		*message += response.str ();
+		boost::asio::async_write (*socket, boost::asio::buffer (*message),
 			boost::asio::transfer_all (),
-		    [socket, buf](const boost::system::error_code& ecode, std::size_t bytes_transferred)
+		    [socket, message](const boost::system::error_code& ecode, std::size_t bytes_transferred)
 		    {
 				if (ecode)
 					LogPrint (eLogError, "I2PControl: Write error: ", ecode.message ());

--- a/daemon/I2PControl.h
+++ b/daemon/I2PControl.h
@@ -58,7 +58,7 @@ namespace client
 				std::shared_ptr<ssl_socket> socket, std::shared_ptr<I2PControlBuffer> buf);
 			template<typename ssl_socket>
 			void SendResponse (std::shared_ptr<ssl_socket> socket,
-				std::shared_ptr<I2PControlBuffer> buf, std::ostringstream& response, bool isHtml);
+				std::ostringstream& response, bool isHtml);
 
 			void CreateCertificate (const char *crt_path, const char *key_path);
 

--- a/libi2pd/Blinding.cpp
+++ b/libi2pd/Blinding.cpp
@@ -249,11 +249,6 @@ namespace data
 		size_t publicKeyLength = 0;
 		switch (m_SigType)
 		{
-			case i2p::data::SIGNING_KEY_TYPE_ECDSA_SHA256_P256:
-			case i2p::data::SIGNING_KEY_TYPE_ECDSA_SHA384_P384:
-			case i2p::data::SIGNING_KEY_TYPE_ECDSA_SHA512_P521:
-				publicKeyLength = BlindECDSA (m_SigType, GetPublicKey (), seed, BlindEncodedPublicKeyECDSA, blindedKey);
-			break;
 			case i2p::data::SIGNING_KEY_TYPE_REDDSA_SHA512_ED25519:
 			case i2p::data::SIGNING_KEY_TYPE_EDDSA_SHA512_ED25519:
 				i2p::crypto::GetEd25519 ()->BlindPublicKey (GetPublicKey (), seed, blindedKey);
@@ -272,11 +267,6 @@ namespace data
 		size_t publicKeyLength = 0;
 		switch (m_SigType)
 		{
-			case i2p::data::SIGNING_KEY_TYPE_ECDSA_SHA256_P256:
-			case i2p::data::SIGNING_KEY_TYPE_ECDSA_SHA384_P384:
-			case i2p::data::SIGNING_KEY_TYPE_ECDSA_SHA512_P521:
-				publicKeyLength = BlindECDSA (m_SigType, priv, seed, BlindEncodedPrivateKeyECDSA, blindedPriv, blindedPub);
-			break;
 			case i2p::data::SIGNING_KEY_TYPE_REDDSA_SHA512_ED25519:
 				i2p::crypto::GetEd25519 ()->BlindPrivateKey (priv, seed, blindedPriv, blindedPub);
 				publicKeyLength = i2p::crypto::EDDSA25519_PUBLIC_KEY_LENGTH;
@@ -310,7 +300,7 @@ namespace data
 	i2p::data::IdentHash BlindedPublicKey::GetStoreHash (const char * date) const
 	{
 		i2p::data::IdentHash hash;
-		uint8_t blinded[128];
+		uint8_t blinded[i2p::crypto::EDDSA25519_PUBLIC_KEY_LENGTH]; // 32 max
 		size_t publicKeyLength = 0;
 		if (date)
 			publicKeyLength = GetBlindedKey (date, blinded);

--- a/libi2pd/Datagram.cpp
+++ b/libi2pd/Datagram.cpp
@@ -136,6 +136,7 @@ namespace datagram
 		if (!identityLen) return;
 		const uint8_t * signature = buf + identityLen;
 		size_t headerLen = identityLen + identity.GetSignatureLen ();
+		if (headerLen > len) return;
 
 		std::shared_ptr<i2p::data::LeaseSet> ls;
 		bool verified = false;

--- a/libi2pd/LeaseSet.cpp
+++ b/libi2pd/LeaseSet.cpp
@@ -15,6 +15,7 @@
 #include "NetDb.hpp"
 #include "Tunnel.h"
 #include "CryptoKey.h"
+#include "Signature.h"
 #include "LeaseSet.h"
 
 namespace i2p
@@ -1001,7 +1002,7 @@ namespace data
 		auto timestamp = i2p::util::GetSecondsSinceEpoch ();
 		char date[9];
 		i2p::util::GetDateString (timestamp, date);
-		uint8_t blindedPriv[64], blindedPub[128]; // 64 and 128 max
+		uint8_t blindedPriv[i2p::crypto::EDDSA25519_PRIVATE_KEY_LENGTH], blindedPub[i2p::crypto::EDDSA25519_PUBLIC_KEY_LENGTH]; // 32 and 32 max
 		size_t publicKeyLen = blindedKey.BlindPrivateKey (keys.GetSigningPrivateKey (), date, blindedPriv, blindedPub);
 		std::unique_ptr<i2p::crypto::Signer> blindedSigner (i2p::data::PrivateKeys::CreateSigner (blindedKey.GetBlindedSigType (), blindedPriv));
 		if (!blindedSigner)


### PR DESCRIPTION
- Fixes some incorrect blinding buffer sizes, causing a stack overflow
- Fixes a potential heap overflow in the `I2PControl` response writer
- Mitigates an integer underflow when handling datagrams