### PR TITLE
fix: macOS crash (cancel before close) + SOCKS5 IPv4 outproxy

### DIFF
--- a/libi2pd/NTCP2.cpp
+++ b/libi2pd/NTCP2.cpp
@@ -383,6 +383,7 @@ namespace transport
 			m_IsTerminated = true;
 			m_IsEstablished = false;
 			boost::system::error_code ec;
+			m_Socket.cancel ();
 			m_Socket.shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
 			if (ec)
 				LogPrint (eLogDebug, "NTCP2: Couldn't shutdown socket: ", ec.message ());

--- a/libi2pd_client/BOB.cpp
+++ b/libi2pd_client/BOB.cpp
@@ -273,6 +273,7 @@ namespace client
 
 	void BOBCommandSession::Terminate ()
 	{
+		m_Socket.cancel ();
 		m_Socket.close ();
 		m_IsOpen = false;
 	}

--- a/libi2pd_client/I2PTunnel.cpp
+++ b/libi2pd_client/I2PTunnel.cpp
@@ -141,6 +141,7 @@ namespace client
 			m_Stream.reset ();
 		}
 		boost::system::error_code ec;
+		m_Socket->cancel ();
 		m_Socket->shutdown(boost::asio::ip::tcp::socket::shutdown_send, ec); // avoid RST
 		m_Socket->close ();
 

--- a/libi2pd_client/SAM.cpp
+++ b/libi2pd_client/SAM.cpp
@@ -69,6 +69,7 @@ namespace client
 		if (m_Socket.is_open ())
 		{
 			boost::system::error_code ec;
+			m_Socket.cancel ();
 			m_Socket.shutdown (boost::asio::ip::tcp::socket::shutdown_both, ec);
 			m_Socket.close ();
 		}

--- a/libi2pd_client/SOCKS.cpp
+++ b/libi2pd_client/SOCKS.cpp
@@ -377,7 +377,7 @@ namespace proxy
 			return false;
 		}
 		// TODO: we may want to support other address types!
-		if ( m_addrtype != ADDR_DNS )
+		if ( m_addrtype != ADDR_DNS && m_addrtype != ADDR_IPV4 )
 		{
 			switch (m_socksv)
 			{
@@ -615,6 +615,14 @@ namespace proxy
 		{
 			if (m_state == READY)
 			{
+
+			if (m_addrtype == ADDR_IPV4)
+			{
+				auto ip = boost::asio::ip::address_v4(m_address.ip);
+				m_address.dns.SetString (ip.to_string());
+				m_addrtype = ADDR_DNS;
+			}
+
 				const std::string addr = m_address.dns.ToString();
 				LogPrint(eLogInfo, "SOCKS: Requested ", addr, ":" , m_port);
 				const size_t addrlen = addr.size();


### PR DESCRIPTION
## Changes

### 1. Fix macOS crash: cancel pending socket ops before close
On macOS (kqueue), boost::asio throws an exception from pending async_write/async_read handlers after the socket is closed. This exception reaches io_service::run() as an uncaught exception and terminates the process (write_some: Bad file descriptor).

Call m_Socket.cancel() before shutdown/close in NTCP2, SAM, I2PTunnel, and BOB so pending operations complete with operation_aborted on a live socket.

### 2. Support IPv4 address type in SOCKS5 outproxy mode
When outproxy.enabled=true, i2pd rejects SOCKS5 CONNECT with IPv4 address type (0x01) returning rep=8. Many SOCKS5 clients (Telegram, browsers) send IPv4 CONNECT. Added ADDR_IPV4 to allowed types and conversion to DNS string for downstream forwarding.

Fixes: #TBD