### PR TITLE
fix: cancel pending socket ops before close to prevent macOS crash

### DIFF
--- a/libi2pd/NTCP2.cpp
+++ b/libi2pd/NTCP2.cpp
@@ -574,6 +574,9 @@ namespace transport
 		{
 			m_IsEstablished = false;
 			boost::system::error_code ec;
+			#ifdef MAC_OSX
+				m_Socket.cancel ();
+			#endif
 			m_Socket.shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
 			if (ec)
 				LogPrint (eLogDebug, "NTCP2: Couldn't shutdown socket: ", ec.message ());

--- a/libi2pd_client/BOB.cpp
+++ b/libi2pd_client/BOB.cpp
@@ -275,6 +275,9 @@ namespace client
 
 	void BOBCommandSession::Terminate ()
 	{
+		#ifdef MAC_OSX
+			m_Socket.cancel ();
+		#endif
 		m_Socket.close ();
 		m_IsOpen = false;
 	}

--- a/libi2pd_client/I2PTunnel.cpp
+++ b/libi2pd_client/I2PTunnel.cpp
@@ -180,6 +180,10 @@ namespace client
 		if (m_Socket && m_Socket->is_open ())
 		{
 			boost::system::error_code ec;
+		boost::system::error_code ec;
+		#ifdef MAC_OSX
+			m_Socket->cancel ();
+		#endif
 			m_Socket->shutdown(boost::asio::ip::tcp::socket::shutdown_send, ec); // avoid RST
 			m_Socket->close ();
 		}

--- a/libi2pd_client/SAM.cpp
+++ b/libi2pd_client/SAM.cpp
@@ -69,6 +69,9 @@ namespace client
 		if (m_Socket.is_open ())
 		{
 			boost::system::error_code ec;
+			#ifdef MAC_OSX
+				m_Socket.cancel ();
+			#endif
 			m_Socket.shutdown (boost::asio::ip::tcp::socket::shutdown_both, ec);
 			m_Socket.close ();
 		}


### PR DESCRIPTION
## Problem

On macOS (kqueue), boost::asio throws an exception from pending async_write/async_read handlers after the socket is closed. This reaches io_service::run() as an uncaught exception and terminates the process.

### Crash log (macOS 26, i2pd 2.61)


## Fix

Call m_Socket.cancel() before shutdown/close in NTCP2, SAM, I2PTunnel, and BOB so pending operations complete with operation_aborted on a live socket.

This is a kqueue-specific issue. On Linux (epoll), close() alone cancels pending operations correctly. The fix is defensive on Linux and required on macOS.

Boost docs reference:
https://www.boost.org/doc/libs/1_84_0/doc/html/boost_asio/reference/basic_stream_socket/close/overload1.html
> Any asynchronous send, receive or connect operations will be cancelled immediately,
> and will complete with the boost::asio::error::operation_aborted error.

This works on Linux. On macOS kqueue, the kernel completes the operation after the fd is closed, and boost::asio's reactor throws instead of delivering to the handler.