### PR TITLE
webconsole: fix action note grammar

### DIFF
--- a/contrib/i18n/English.po
+++ b/contrib/i18n/English.po
@@ -481,7 +481,7 @@ msgstr ""
 
 #: daemon/HTTPServer.cpp:767
 msgid ""
-"<b>Note:</b> any action done here are not persistent and not changes your "
+"<b>Note:</b> any action performed here is not persistent and does not change "
 "config files."
 msgstr ""
 

--- a/daemon/HTTPServer.cpp
+++ b/daemon/HTTPServer.cpp
@@ -849,7 +849,7 @@ namespace http {
 		s << "  <a href=\"" << webroot << "?cmd=" << HTTP_COMMAND_RELOAD_CSS << "&token=" << token << "\">" << tr("Reload external CSS styles") << "</a>\r\n";
 		s << "</div>";
 
-		s << "<br>\r\n<small>" << tr("<b>Note:</b> any action done here are not persistent and not changes your config files.") << "</small>\r\n<br>\r\n";
+		s << "<br>\r\n<small>" << tr("<b>Note:</b> any action performed here is not persistent and does not change your config files.") << "</small>\r\n<br>\r\n";
 
 		auto loglevel = i2p::log::Logger().GetLogLevel();
 		s << "<b>" << tr("Logging level") << "</b><br>\r\n";

--- a/i18n/Armenian.cpp
+++ b/i18n/Armenian.cpp
@@ -128,7 +128,7 @@ namespace armenian // language namespace
 		{"Start graceful shutdown", "Սկսել սահուն անջատումը"},
 		{"Force shutdown", "Հարկադիր անջատում"},
 		{"Reload external CSS styles", "Վերաբեռնեք CSS ոճաթերթը"},
-		{"<b>Note:</b> any action done here are not persistent and not changes your config files.", "<b> Նշում․ </b> այստեղ կատարված ցանկացած գործողություն մշտական ​​չէ և չի փոխում ձեր կազմաձևման ֆայլերը։"},
+		{"<b>Note:</b> any action performed here is not persistent and does not change your config files.", "<b> Նշում․ </b> այստեղ կատարված ցանկացած գործողություն մշտական ​​չէ և չի փոխում ձեր կազմաձևման ֆայլերը։"},
 		{"Logging level", "Գրառման աստիճանը"},
 		{"Transit tunnels limit", "Տարանցիկ թունելների սահմանափակում"},
 		{"Change", "Փոփոխել"},

--- a/i18n/Chinese.cpp
+++ b/i18n/Chinese.cpp
@@ -134,7 +134,7 @@ namespace chinese // language namespace
 		{"Start graceful shutdown", "平滑关闭"},
 		{"Force shutdown", "强制停止"},
 		{"Reload external CSS styles", "重载外部 CSS 样式"},
-		{"<b>Note:</b> any action done here are not persistent and not changes your config files.", "<b>注意：</b> 此处完成的任何操作都不是永久的，不会更改您的配置文件。"},
+		{"<b>Note:</b> any action performed here is not persistent and does not change your config files.", "<b>注意：</b> 此处完成的任何操作都不是永久的，不会更改您的配置文件。"},
 		{"Logging level", "日志级别"},
 		{"Transit tunnels limit", "中转隧道限制"},
 		{"Change", "修改"},

--- a/i18n/Czech.cpp
+++ b/i18n/Czech.cpp
@@ -134,7 +134,7 @@ namespace czech // language namespace
 		{"Start graceful shutdown", "Zahájit hladké vypnutí"},
 		{"Force shutdown", "Vynutit vypnutí"},
 		{"Reload external CSS styles", "Znovu načíst externí CSS"},
-		{"<b>Note:</b> any action done here are not persistent and not changes your config files.", "<b>Poznámka:</b> žádná vykonaná akce zde není trvalá a nemění konfigurační soubory."},
+		{"<b>Note:</b> any action performed here is not persistent and does not change your config files.", "<b>Poznámka:</b> žádná vykonaná akce zde není trvalá a nemění konfigurační soubory."},
 		{"Logging level", "Úroveň logování"},
 		{"Transit tunnels limit", "Limit tranzitních tunelů"},
 		{"Change", "Změnit"},

--- a/i18n/Esperanto.cpp
+++ b/i18n/Esperanto.cpp
@@ -134,7 +134,7 @@ namespace esperanto // language namespace
 		{"Start graceful shutdown", "Startigi la pravan haltigon"},
 		{"Force shutdown", "Perforte haltigi"},
 		{"Reload external CSS styles", "Reŝargi eksterajn stilojn de CSS"},
-		{"<b>Note:</b> any action done here are not persistent and not changes your config files.", "<b>Rimarko:</b> ĉiu ago estante tie ne estas konstanta kaj ne ŝanĝis viajn dosierojn de la agordoj."},
+		{"<b>Note:</b> any action performed here is not persistent and does not change your config files.", "<b>Rimarko:</b> ĉiu ago estante tie ne estas konstanta kaj ne ŝanĝis viajn dosierojn de la agordoj."},
 		{"Logging level", "Nivelo de loka-raportado"},
 		{"Transit tunnels limit", "Limigo de transitaj tuneloj"},
 		{"Change", "Ŝanĝi"},

--- a/i18n/Filipino.cpp
+++ b/i18n/Filipino.cpp
@@ -134,7 +134,7 @@ namespace filipino // language namespace
 		{"Start graceful shutdown", "Simulan ang graceful shutdown"},
 		{"Force shutdown", "Pwersahang mag-shutdown"},
 		{"Reload external CSS styles", "I-reload ang mga external na istilio ng CSS"},
-		{"<b>Note:</b> any action done here are not persistent and not changes your config files.", "<b>Tandaan:</b> hindi mananatili ang mga pagbabago na ginawa dito at hindi babaguhin ang mga config file."},
+		{"<b>Note:</b> any action performed here is not persistent and does not change your config files.", "<b>Tandaan:</b> hindi mananatili ang mga pagbabago na ginawa dito at hindi babaguhin ang mga config file."},
 		{"Logging level", "Antas ng pag-log"},
 		{"Transit tunnels limit", "Pinakamataas na transit tunnel"},
 		{"Change", "Palitan"},

--- a/i18n/Finnish.cpp
+++ b/i18n/Finnish.cpp
@@ -134,7 +134,7 @@ namespace finnish // language namespace
 		{"Start graceful shutdown", "Käynnistä hallittu sulkeminen"},
 		{"Force shutdown", "Pakota sammutus"},
 		{"Reload external CSS styles", "Lataa ulkoiset CSS-tyylit uudelleen"},
-		{"<b>Note:</b> any action done here are not persistent and not changes your config files.", "<b>Huom:</b> täällä tehdyt toimet eivät ole pysyviä, eikä niillä muuteta asetustiedostojasi."},
+		{"<b>Note:</b> any action performed here is not persistent and does not change your config files.", "<b>Huom:</b> täällä tehdyt toimet eivät ole pysyviä, eikä niillä muuteta asetustiedostojasi."},
 		{"Logging level", "Lokitustaso"},
 		{"Transit tunnels limit", "Läpikulkutunneleiden enimmäismäärä"},
 		{"Change", "Vaihda"},

--- a/i18n/French.cpp
+++ b/i18n/French.cpp
@@ -134,7 +134,7 @@ namespace french // language namespace
 		{"Start graceful shutdown", "Démarrer l'arrêt gracieux"},
 		{"Force shutdown", "Forcer l'arrêt"},
 		{"Reload external CSS styles", "Rafraîchir les styles CSS externes"},
-		{"<b>Note:</b> any action done here are not persistent and not changes your config files.", "<b>Note :</b> Toute action effectuée ici n'est pas permanente et ne modifie pas vos fichiers de configuration."},
+		{"<b>Note:</b> any action performed here is not persistent and does not change your config files.", "<b>Note :</b> Toute action effectuée ici n'est pas permanente et ne modifie pas vos fichiers de configuration."},
 		{"Logging level", "Niveau de journalisation"},
 		{"Transit tunnels limit", "Limite sur les tunnels transitoires"},
 		{"Change", "Changer"},

--- a/i18n/German.cpp
+++ b/i18n/German.cpp
@@ -131,7 +131,7 @@ namespace german // language namespace
 		{"Start graceful shutdown", "Starte das kontrollierte Herunterfahren"},
 		{"Force shutdown", "Herunterfahren erzwingen"},
 		{"Reload external CSS styles", "Lade externe CSS-Stile neu"},
-		{"<b>Note:</b> any action done here are not persistent and not changes your config files.", "<b>Hinweis:</b> Alle hier durchgeführten Aktionen sind nicht dauerhaft und ändern die Konfigurationsdateien nicht."},
+		{"<b>Note:</b> any action performed here is not persistent and does not change your config files.", "<b>Hinweis:</b> Alle hier durchgeführten Aktionen sind nicht dauerhaft und ändern die Konfigurationsdateien nicht."},
 		{"Logging level", "Protokollierungslevel"},
 		{"Transit tunnels limit", "Limit für Transittunnel"},
 		{"Change", "Ändern"},

--- a/i18n/Hebrew.cpp
+++ b/i18n/Hebrew.cpp
@@ -120,7 +120,7 @@ namespace hebrew // language namespace
 		{"Start graceful shutdown", "הפעל כיבוי עדין"},
 		{"Force shutdown", "הפעל כיבוי מיידי"},
 		{"Reload external CSS styles", "טען מחדש סגנונות CSS חיצוניים"},
-		{"<b>Note:</b> any action done here are not persistent and not changes your config files.", "<b>הערה</b> כל פעולה אשר מבוצעת כאן אינה המשכית ולא משנה את קובצי התצורה שלך."},
+		{"<b>Note:</b> any action performed here is not persistent and does not change your config files.", "<b>הערה</b> כל פעולה אשר מבוצעת כאן אינה המשכית ולא משנה את קובצי התצורה שלך."},
 		{"Logging level", "דרגת רישום יומן"},
 		{"Transit tunnels limit", "מגבלת מנהרות מעבר"},
 		{"Change", "אישור"},

--- a/i18n/Hindi.cpp
+++ b/i18n/Hindi.cpp
@@ -134,7 +134,7 @@ namespace hindi // language namespace
 		{"Start graceful shutdown", "सौम्य समापन प्रारंभ करें"},
 		{"Force shutdown", "बाध्य अवसान"},
 		{"Reload external CSS styles", "बाह्य CSS शैलियों को पुनः लोड करें"},
-		{"<b>Note:</b> any action done here are not persistent and not changes your config files.", "<b>टिप्पणी:</b> यहाँ किए गए कोई भी क्रियाएँ स्थायी नहीं हैं और आपके विन्यास संचिका में कोई परिवर्तन नहीं करतीं।"},
+		{"<b>Note:</b> any action performed here is not persistent and does not change your config files.", "<b>टिप्पणी:</b> यहाँ किए गए कोई भी क्रियाएँ स्थायी नहीं हैं और आपके विन्यास संचिका में कोई परिवर्तन नहीं करतीं।"},
 		{"Logging level", "लॉगिंग स्तर"},
 		{"Transit tunnels limit", "संचरण सुरंगों की सीमा"},
 		{"Change", "बदलना"},

--- a/i18n/Italian.cpp
+++ b/i18n/Italian.cpp
@@ -134,7 +134,7 @@ namespace italian // language namespace
 		{"Start graceful shutdown", "Avvia l'interruzione controllata"},
 		{"Force shutdown", "Forza l'arresto"},
 		{"Reload external CSS styles", "Ricarica gli stili CSS esterni"},
-		{"<b>Note:</b> any action done here are not persistent and not changes your config files.", "<b>Nota:</b> qualsiasi azione effettuata qui non è persistente e non modifica i file di configurazione."},
+		{"<b>Note:</b> any action performed here is not persistent and does not change your config files.", "<b>Nota:</b> qualsiasi azione effettuata qui non è persistente e non modifica i file di configurazione."},
 		{"Logging level", "Livello di log"},
 		{"Transit tunnels limit", "Limite di tunnel di transito"},
 		{"Change", "Modifica"},

--- a/i18n/Persian.cpp
+++ b/i18n/Persian.cpp
@@ -134,7 +134,7 @@ namespace persian // language namespace
 		{"Start graceful shutdown", "شروع خاموش‌سازی امن"},
 		{"Force shutdown", "خاموش کردن اجباری"},
 		{"Reload external CSS styles", "بارگذاری دوباره سبک‌های CSS خارجی"},
-		{"<b>Note:</b> any action done here are not persistent and not changes your config files.", "<b>نکته:</b> هر تغییری که در اینجا انجام شود ماندگار نیست و تغییری در فایل‌های پیکربندی شما ایجاد نمی‌کند."},
+		{"<b>Note:</b> any action performed here is not persistent and does not change your config files.", "<b>نکته:</b> هر تغییری که در اینجا انجام شود ماندگار نیست و تغییری در فایل‌های پیکربندی شما ایجاد نمی‌کند."},
 		{"Logging level", "سطح ثبت گزارش"},
 		{"Transit tunnels limit", "محدودیت تونل‌های عبوری"},
 		{"Change", "تغییر"},

--- a/i18n/Polish.cpp
+++ b/i18n/Polish.cpp
@@ -134,7 +134,7 @@ namespace polish // language namespace
 		{"Start graceful shutdown", "Rozpocznij łagodne wyłączenie"},
 		{"Force shutdown", "Wymuś wyłączenie"},
 		{"Reload external CSS styles", "Odśwież zewnętrzne style CSS"},
-		{"<b>Note:</b> any action done here are not persistent and not changes your config files.", "<b>Uwaga:</b> każda akcja wykonana tutaj nie jest trwała i nie zmienia Twoich plików konfiguracyjnych."},
+		{"<b>Note:</b> any action performed here is not persistent and does not change your config files.", "<b>Uwaga:</b> każda akcja wykonana tutaj nie jest trwała i nie zmienia Twoich plików konfiguracyjnych."},
 		{"Logging level", "Poziom logowania"},
 		{"Transit tunnels limit", "Limit tuneli tranzytowych"},
 		{"Change", "Zmień"},

--- a/i18n/Portuguese.cpp
+++ b/i18n/Portuguese.cpp
@@ -134,7 +134,7 @@ namespace portuguese // language namespace
 		{"Start graceful shutdown", "Iniciar desligamento gracioso"},
 		{"Force shutdown", "Forçar desligamento"},
 		{"Reload external CSS styles", "Recarregar estilos CSS externos"},
-		{"<b>Note:</b> any action done here are not persistent and not changes your config files.", "<b> Nota: </b> Qualquer ação feita aqui não será permanente e não altera os seus arquivos de configuração."},
+		{"<b>Note:</b> any action performed here is not persistent and does not change your config files.", "<b> Nota: </b> Qualquer ação feita aqui não será permanente e não altera os seus arquivos de configuração."},
 		{"Logging level", "Nível de registro"},
 		{"Transit tunnels limit", "Limite de túneis de trânsito"},
 		{"Change", "Mudar"},

--- a/i18n/Russian.cpp
+++ b/i18n/Russian.cpp
@@ -134,7 +134,7 @@ namespace russian // language namespace
 		{"Start graceful shutdown", "Запустить плавную остановку"},
 		{"Force shutdown", "Принудительная остановка"},
 		{"Reload external CSS styles", "Перезагрузить внешние CSS стили"},
-		{"<b>Note:</b> any action done here are not persistent and not changes your config files.", "<b>Примечание:</b> любое действие произведенное здесь не является постоянным и не изменяет ваши конфигурационные файлы."},
+		{"<b>Note:</b> any action performed here is not persistent and does not change your config files.", "<b>Примечание:</b> любое действие произведенное здесь не является постоянным и не изменяет ваши конфигурационные файлы."},
 		{"Logging level", "Уровень логирования"},
 		{"Transit tunnels limit", "Лимит транзитных туннелей"},
 		{"Change", "Изменить"},

--- a/i18n/Spanish.cpp
+++ b/i18n/Spanish.cpp
@@ -134,7 +134,7 @@ namespace spanish // language namespace
 		{"Start graceful shutdown", "Iniciar apagado con gracia"},
 		{"Force shutdown", "Forzar apagado"},
 		{"Reload external CSS styles", "Recargar estilos CSS externos"},
-		{"<b>Note:</b> any action done here are not persistent and not changes your config files.", "<b>Nota:</b> cualquier acción hecha aquí no es persistente y no cambia tus archivos de configuración."},
+		{"<b>Note:</b> any action performed here is not persistent and does not change your config files.", "<b>Nota:</b> cualquier acción hecha aquí no es persistente y no cambia tus archivos de configuración."},
 		{"Logging level", "Nivel de registro de errores"},
 		{"Transit tunnels limit", "Límite de túneles de tránsito"},
 		{"Change", "Cambiar"},

--- a/i18n/Swedish.cpp
+++ b/i18n/Swedish.cpp
@@ -132,7 +132,7 @@ namespace swedish // language namespace
 		{"Start graceful shutdown", "Påbörja välvillig avstängning"},
 		{"Force shutdown", "Tvingad avstängning"},
 		{"Reload external CSS styles", "Ladda om externa CSS-stilar"},
-		{"<b>Note:</b> any action done here are not persistent and not changes your config files.", "<b>Uppmärksamma:</b> inga ändringar här är beständiga eller påverkar dina inställningsfiler."},
+		{"<b>Note:</b> any action performed here is not persistent and does not change your config files.", "<b>Uppmärksamma:</b> inga ändringar här är beständiga eller påverkar dina inställningsfiler."},
 		{"Logging level", "Protokollförningsnivå"},
 		{"Transit tunnels limit", "Begränsa förmedlande tunnlar"},
 		{"Change", "Ändra"},

--- a/i18n/Turkish.cpp
+++ b/i18n/Turkish.cpp
@@ -81,7 +81,7 @@ namespace turkish // language namespace
 		{"Start graceful shutdown", "Düzgün durdurmayı başlat"},
 		{"Force shutdown", "Durdurmaya zorla"},
 		{"Reload external CSS styles", "Harici CSS stilini yeniden yükle"},
-		{"<b>Note:</b> any action done here are not persistent and not changes your config files.", "<b>Not:</b> burada yapılan ayarların hiçbiri kalıcı değildir ve ayar dosyalarınızı değiştirmez."},
+		{"<b>Note:</b> any action performed here is not persistent and does not change your config files.", "<b>Not:</b> burada yapılan ayarların hiçbiri kalıcı değildir ve ayar dosyalarınızı değiştirmez."},
 		{"Logging level", "Kayıt tutma seviyesi"},
 		{"Transit tunnels limit", "Transit tünel limiti"},
 		{"Change", "Değiştir"},

--- a/i18n/Turkmen.cpp
+++ b/i18n/Turkmen.cpp
@@ -127,7 +127,7 @@ namespace turkmen // language namespace
 		{"Start graceful shutdown", "Tekiz durmak"},
 		{"Force shutdown", "Mejbury duralga"},
 		{"Reload external CSS styles", "Daşarky CSS stillerini täzeden ýükläň"},
-		{"<b>Note:</b> any action done here are not persistent and not changes your config files.", "<b>Bellik:</b> Bu ýerde öndürilen islendik çäre hemişelik däl we konfigurasiýa faýllaryňyzy üýtgetmeýär."},
+		{"<b>Note:</b> any action performed here is not persistent and does not change your config files.", "<b>Bellik:</b> Bu ýerde öndürilen islendik çäre hemişelik däl we konfigurasiýa faýllaryňyzy üýtgetmeýär."},
 		{"Logging level", "Giriş derejesi"},
 		{"Transit tunnels limit", "Tranzit tunelleriniň çägi"},
 		{"Change", "Üýtgetmek"},

--- a/i18n/Ukrainian.cpp
+++ b/i18n/Ukrainian.cpp
@@ -134,7 +134,7 @@ namespace ukrainian // language namespace
 		{"Start graceful shutdown", "Запустити плавну зупинку"},
 		{"Force shutdown", "Примусова зупинка"},
 		{"Reload external CSS styles", "Перезавантажити зовнішні стилі CSS"},
-		{"<b>Note:</b> any action done here are not persistent and not changes your config files.", "<b>Примітка:</b> будь-яка зроблена тут дія не є постійною та не змінює ваші конфігураційні файли."},
+		{"<b>Note:</b> any action performed here is not persistent and does not change your config files.", "<b>Примітка:</b> будь-яка зроблена тут дія не є постійною та не змінює ваші конфігураційні файли."},
 		{"Logging level", "Рівень логування"},
 		{"Transit tunnels limit", "Обмеження транзитних тунелів"},
 		{"Change", "Змінити"},

--- a/i18n/Uzbek.cpp
+++ b/i18n/Uzbek.cpp
@@ -134,7 +134,7 @@ namespace uzbek // language namespace
 		{"Start graceful shutdown", "Yumshoq to'xtashni boshlash"},
 		{"Force shutdown", "Majburiy to'xtatish"},
 		{"Reload external CSS styles", "Tashqi CSS uslublarini qayta yuklang"},
-		{"<b>Note:</b> any action done here are not persistent and not changes your config files.", "<b>Eslatma:</b> shu yerda qilingan har qanday harakat doimiy emas va konfiguratsiya fayllarini o'zgartirmaydi."},
+		{"<b>Note:</b> any action performed here is not persistent and does not change your config files.", "<b>Eslatma:</b> shu yerda qilingan har qanday harakat doimiy emas va konfiguratsiya fayllarini o'zgartirmaydi."},
 		{"Logging level", "Jurnal darajasi"},
 		{"Transit tunnels limit", "Tranzit tunellarning chegarasi"},
 		{"Change", "O'zgartirish"},


### PR DESCRIPTION
Fix grammar in the commands page note.

Keep the existing localized text by updating the source keys.

Fixes #2173.