### PR TITLE
libi2pd: reset config state on initialization

### DIFF
--- a/libi2pd/Config.cpp
+++ b/libi2pd/Config.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <fstream>
 #include <map>
+#include <memory>
 #include <string>
 #include <boost/program_options/cmdline.hpp>
 #include <boost/program_options/options_description.hpp>
@@ -25,7 +26,7 @@ using namespace boost::program_options;
 
 namespace i2p {
 namespace config {
-	options_description m_OptionsDesc;
+	std::unique_ptr<options_description> m_OptionsDesc = std::make_unique<options_description> ();
 	variables_map m_Options;
 
 #if defined(_WIN32)
@@ -40,6 +41,9 @@ namespace config {
 
 	void Init()
 	{
+		m_OptionsDesc = std::make_unique<options_description> ();
+		m_Options.clear ();
+
 		options_description general("General options");
 		general.add_options()
 			("help",                                                          "Show this message")
@@ -406,8 +410,7 @@ namespace config {
 			;
 #endif
 
-		m_OptionsDesc
-			.add(general)
+		m_OptionsDesc->add(general)
 			.add(limits)
 			.add(httpserver)
 			.add(httpproxy)
@@ -447,9 +450,9 @@ namespace config {
 			           | boost::program_options::command_line_style::allow_long_disguise;
 			style &=   ~ boost::program_options::command_line_style::allow_guessing;
 			if (ignoreUnknown)
-				store(command_line_parser(argc, argv).options(m_OptionsDesc).style (style).allow_unregistered().run(), m_Options);
+				store(command_line_parser(argc, argv).options(*m_OptionsDesc).style (style).allow_unregistered().run(), m_Options);
 			else
-				store(parse_command_line(argc, argv, m_OptionsDesc, style), m_Options);
+				store(parse_command_line(argc, argv, *m_OptionsDesc, style), m_Options);
 		}
 		catch (boost::program_options::error& e)
 		{
@@ -461,7 +464,7 @@ namespace config {
 		if (!ignoreUnknown && (m_Options.count("help") || m_Options.count("h")))
 		{
 			std::cout << "i2pd version " << I2PD_VERSION << " (" << I2P_VERSION << ")" << std::endl;
-			std::cout << m_OptionsDesc;
+			std::cout << *m_OptionsDesc;
 			exit(EXIT_SUCCESS);
 		}
 		else if (m_Options.count("version"))
@@ -498,7 +501,7 @@ namespace config {
 
 		try
 		{
-			store(boost::program_options::parse_config_file(config, m_OptionsDesc), m_Options);
+			store(boost::program_options::parse_config_file(config, *m_OptionsDesc), m_Options);
 		}
 		catch (boost::program_options::error& e)
 		{

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,6 +37,10 @@ set(test-http-url_SRCS
   test-http-url.cpp
 )
 
+set(test-config_SRCS
+  test-config.cpp
+)
+
 set(test-base-64_SRCS
   test-base-64.cpp
 )
@@ -74,6 +78,7 @@ add_executable(test-http-req ${test-http-req_SRCS})
 add_executable(test-http-res ${test-http-res_SRCS})
 add_executable(test-http-url_decode ${test-http-url_decode_SRCS})
 add_executable(test-http-url ${test-http-url_SRCS})
+add_executable(test-config ${test-config_SRCS})
 add_executable(test-base-64 ${test-base-64_SRCS})
 add_executable(test-gost ${test-gost_SRCS})
 add_executable(test-gost-sig ${test-gost-sig_SRCS})
@@ -99,6 +104,7 @@ target_link_libraries(test-http-req ${LIBS})
 target_link_libraries(test-http-res ${LIBS})
 target_link_libraries(test-http-url_decode ${LIBS})
 target_link_libraries(test-http-url ${LIBS})
+target_link_libraries(test-config ${LIBS})
 target_link_libraries(test-base-64 ${LIBS})
 target_link_libraries(test-gost ${LIBS})
 target_link_libraries(test-gost-sig ${LIBS})
@@ -113,6 +119,7 @@ add_test(test-http-req ${TEST_PATH}/test-http-req)
 add_test(test-http-res ${TEST_PATH}/test-http-res)
 add_test(test-http-url_decode ${TEST_PATH}/test-http-url_decode)
 add_test(test-http-url ${TEST_PATH}/test-http-url)
+add_test(test-config ${TEST_PATH}/test-config)
 add_test(test-base-64 ${TEST_PATH}/test-base-64)
 add_test(test-gost ${TEST_PATH}/test-gost)
 add_test(test-gost-sig ${TEST_PATH}/test-gost-sig)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -7,6 +7,7 @@ LIBI2PD = ../libi2pd.a
 
 TESTS = \
 	test-http-merge_chunked test-http-req test-http-res test-http-url test-http-url_decode \
+	test-config \
 	test-gost test-gost-sig test-base-64 test-aeadchacha20poly1305 test-blinding \
 	test-elligator test-eddsa test-aes
 
@@ -33,6 +34,9 @@ $(LIBI2PD):
 	@echo "Building libi2pd.a ..." && cd .. && $(MAKE) libi2pd.a
 
 test-http-%: test-http-%.cpp $(LIBI2PD)
+	$(CXX) $(CXXFLAGS) $(NEEDED_CXXFLAGS) $(INCFLAGS) $(LDFLAGS) -o $@ $^ $(LDLIBS)
+
+test-config: test-config.cpp $(LIBI2PD)
 	$(CXX) $(CXXFLAGS) $(NEEDED_CXXFLAGS) $(INCFLAGS) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
 test-base-%: test-base-%.cpp $(LIBI2PD)

--- a/tests/test-config.cpp
+++ b/tests/test-config.cpp
@@ -1,0 +1,24 @@
+#include <cassert>
+#include <string>
+
+#include "Config.h"
+
+int main ()
+{
+	char program[] = "test-config";
+	char datadirOption[] = "--datadir=/tmp/i2pd-test";
+	char * argv[] = { program, datadirOption };
+
+	for (int i = 0; i < 2; i++)
+	{
+		i2p::config::Init ();
+		i2p::config::ParseCmdline (2, argv);
+		i2p::config::Finalize ();
+
+		std::string datadir;
+		assert (i2p::config::GetOption ("datadir", datadir));
+		assert (datadir == "/tmp/i2pd-test");
+	}
+
+	return 0;
+}


### PR DESCRIPTION
Reset the config parser state before registering options.

Add a regression test for parsing command-line options after configuration reinitialization.

Fixes #2345.