### PR TITLE
Udp tunnel performance

### DIFF
--- a/libi2pd/Crypto.cpp
+++ b/libi2pd/Crypto.cpp
@@ -20,6 +20,7 @@
 #if (OPENSSL_VERSION_NUMBER >= 0x030000000) // since 3.0.0
 #include <openssl/param_build.h>
 #include <openssl/core_names.h>
+#include <openssl/params.h>
 #endif
 #include "CPU.h"
 #include "Crypto.h"
@@ -778,7 +779,7 @@ namespace crypto
 
 	uint32_t RandUint32 ()
 	{
-		// RAND_bytes for four bytes at a time costs more than the drawn randomness itself
+		// buffered, a RAND_bytes call per four bytes costs more than the randomness itself
 		static thread_local uint8_t buf[256];
 		static thread_local size_t offset = sizeof (buf);
 		if (offset + 4 > sizeof (buf))
@@ -794,12 +795,33 @@ namespace crypto
 
 	static void HMACSHA256 (const uint8_t * key, size_t keyLen, const uint8_t * buf, size_t len, uint8_t * out)
 	{
-		// a context per call costs an algorithm fetch in openssl 3, and this runs per garlic message
+		// a context per call costs an algorithm fetch
+#if (OPENSSL_VERSION_NUMBER >= 0x030000000) // since 3.0.0
+		static thread_local std::unique_ptr<EVP_MAC_CTX, void (*)(EVP_MAC_CTX *)> ctx (nullptr, EVP_MAC_CTX_free);
+		if (ctx)
+			EVP_MAC_init (ctx.get (), key, keyLen, nullptr); // digest is already set
+		else
+		{
+			std::unique_ptr<EVP_MAC, void (*)(EVP_MAC *)> mac (EVP_MAC_fetch (nullptr, "HMAC", nullptr), EVP_MAC_free);
+			ctx.reset (EVP_MAC_CTX_new (mac.get ()));
+			char digest[] = "SHA256";
+			OSSL_PARAM params[] =
+			{
+				OSSL_PARAM_construct_utf8_string (OSSL_MAC_PARAM_DIGEST, digest, 0),
+				OSSL_PARAM_construct_end ()
+			};
+			EVP_MAC_init (ctx.get (), key, keyLen, params);
+		}
+		size_t outLen = 32;
+		if (len) EVP_MAC_update (ctx.get (), buf, len);
+		EVP_MAC_final (ctx.get (), out, &outLen, 32);
+#else
 		static thread_local std::unique_ptr<HMAC_CTX, void (*)(HMAC_CTX *)> ctx (HMAC_CTX_new (), HMAC_CTX_free);
 		unsigned int outLen;
 		HMAC_Init_ex (ctx.get (), key, keyLen, EVP_sha256 (), nullptr);
 		if (len) HMAC_Update (ctx.get (), buf, len);
 		HMAC_Final (ctx.get (), out, &outLen);
+#endif
 	}
 
 	void HKDF (const uint8_t * salt, const uint8_t * key, size_t keyLen, std::string_view info,

--- a/libi2pd/Crypto.cpp
+++ b/libi2pd/Crypto.cpp
@@ -776,29 +776,59 @@ namespace crypto
 		ChaCha20 (m_Ctx, msg, msgLen, key, nonce, out);
 	}
 
+	uint32_t RandUint32 ()
+	{
+		// RAND_bytes for four bytes at a time costs more than the drawn randomness itself
+		static thread_local uint8_t buf[256];
+		static thread_local size_t offset = sizeof (buf);
+		if (offset + 4 > sizeof (buf))
+		{
+			RAND_bytes (buf, sizeof (buf));
+			offset = 0;
+		}
+		uint32_t v;
+		memcpy (&v, buf + offset, 4);
+		offset += 4;
+		return v;
+	}
+
+	static void HMACSHA256 (const uint8_t * key, size_t keyLen, const uint8_t * buf, size_t len, uint8_t * out)
+	{
+		// a context per call costs an algorithm fetch in openssl 3, and this runs per garlic message
+		static thread_local std::unique_ptr<HMAC_CTX, void (*)(HMAC_CTX *)> ctx (HMAC_CTX_new (), HMAC_CTX_free);
+		unsigned int outLen;
+		HMAC_Init_ex (ctx.get (), key, keyLen, EVP_sha256 (), nullptr);
+		if (len) HMAC_Update (ctx.get (), buf, len);
+		HMAC_Final (ctx.get (), out, &outLen);
+	}
+
 	void HKDF (const uint8_t * salt, const uint8_t * key, size_t keyLen, std::string_view info,
 		uint8_t * out, size_t outLen)
 	{
-		EVP_PKEY_CTX * pctx = EVP_PKEY_CTX_new_id (EVP_PKEY_HKDF, nullptr);
-		EVP_PKEY_derive_init (pctx);
-		EVP_PKEY_CTX_set_hkdf_md (pctx, EVP_sha256());
-		if (key && keyLen)
+		uint8_t prk[32];
+		HMACSHA256 (salt, 32, key, keyLen, prk); // extract
+		uint8_t t[32], buf[32 + 64 + 1];
+		size_t offset = 0;
+		for (uint8_t counter = 1; offset < outLen; counter++)
 		{
-			EVP_PKEY_CTX_set1_hkdf_salt (pctx, salt, 32);
-			EVP_PKEY_CTX_set1_hkdf_key (pctx, key, keyLen);
+			size_t len = 0;
+			if (counter > 1)
+			{
+				memcpy (buf, t, 32);
+				len = 32;
+			}
+			if (!info.empty ())
+			{
+				memcpy (buf + len, info.data (), info.length ());
+				len += info.length ();
+			}
+			buf[len] = counter; len++;
+			HMACSHA256 (prk, 32, buf, len, t); // expand
+			size_t l = outLen - offset;
+			if (l > 32) l = 32;
+			memcpy (out + offset, t, l);
+			offset += l;
 		}
-		else
-		{
-			// zerolen
-			EVP_PKEY_CTX_hkdf_mode (pctx, EVP_PKEY_HKDEF_MODE_EXPAND_ONLY);
-			uint8_t tempKey[32]; unsigned int len;
-			HMAC(EVP_sha256(), salt, 32, nullptr, 0, tempKey, &len);
-			EVP_PKEY_CTX_set1_hkdf_key (pctx, tempKey, len);
-		}
-		if (info.length () > 0)
-			EVP_PKEY_CTX_add1_hkdf_info (pctx, (const uint8_t *)info.data (), info.length ());
-		EVP_PKEY_derive (pctx, out, &outLen);
-		EVP_PKEY_CTX_free (pctx);
 	}
 
 // Noise

--- a/libi2pd/Crypto.h
+++ b/libi2pd/Crypto.h
@@ -243,6 +243,10 @@ namespace crypto
 			EVP_CIPHER_CTX * m_Ctx;	
 	};
 	
+// random
+
+	uint32_t RandUint32 ();
+
 // HKDF
 
 	void HKDF (const uint8_t * salt, const uint8_t * key, size_t keyLen, std::string_view info, uint8_t * out, size_t outLen = 64); // salt - 32, out - 32 or 64, info <= 32

--- a/libi2pd/Datagram.cpp
+++ b/libi2pd/Datagram.cpp
@@ -785,6 +785,12 @@ namespace datagram
 				routingPath->outboundTunnel->SendTunnelDataMsgs(send);
 			}
 		}
+		else
+		{
+			m_NumDroppedNoPath += m_SendQueue.size ();
+			LogPrint (eLogWarning, "Datagram: No routing path, dropped ", m_SendQueue.size (), " messages, ",
+				m_NumDroppedNoPath, " total");
+		}
 		m_SendQueue.clear();
 	}
 }

--- a/libi2pd/Datagram.h
+++ b/libi2pd/Datagram.h
@@ -84,9 +84,12 @@ namespace datagram
 			DatagramVersion GetVersion () const { return m_Version; }
 			void SetVersion (DatagramVersion version) { m_Version = version; }
 
-			void DropSharedRoutingPath () { if (m_RoutingSession) m_RoutingSession->SetSharedRoutingPath (nullptr); }
+			void DropSharedRoutingPath () { if (m_RoutingSession) { m_RoutingSession->SetSharedRoutingPath (nullptr); m_NumPathDrops++; } }
 			// request LeaseSet update from floodfill in case our copy contains dead leases
 			void RequestUpdatedLeaseSet ();
+
+			uint32_t GetNumPathDrops () const { return m_NumPathDrops; }
+			uint32_t GetNumDroppedNoPath () const { return m_NumDroppedNoPath; }
 
 		struct Info
 		{
@@ -123,6 +126,7 @@ namespace datagram
 			uint64_t m_LastUse, m_LastFlush; // milliseconds
 			bool m_RequestingLS;
 			DatagramVersion m_Version;
+			uint32_t m_NumPathDrops = 0, m_NumDroppedNoPath = 0;
 	};
 
 	typedef std::shared_ptr<DatagramSession> DatagramSession_ptr;

--- a/libi2pd/I2NPProtocol.cpp
+++ b/libi2pd/I2NPProtocol.cpp
@@ -52,7 +52,7 @@ namespace i2p
 	void I2NPMessage::FillI2NPMessageHeader (I2NPMessageType msgType, uint32_t replyMsgID, bool checksum)
 	{
 		SetTypeID (msgType);
-		if (!replyMsgID) RAND_bytes ((uint8_t *)&replyMsgID, 4);
+		if (!replyMsgID) replyMsgID = i2p::crypto::RandUint32 ();
 		SetMsgID (replyMsgID);
 		SetExpiration (i2p::util::GetMillisecondsSinceEpoch () + I2NP_MESSAGE_EXPIRATION_TIMEOUT);
 		UpdateSize ();
@@ -61,9 +61,7 @@ namespace i2p
 
 	void I2NPMessage::RenewI2NPMessageHeader ()
 	{
-		uint32_t msgID;
-		RAND_bytes ((uint8_t *)&msgID, 4);
-		SetMsgID (msgID);
+		SetMsgID (i2p::crypto::RandUint32 ());
 		SetExpiration (i2p::util::GetMillisecondsSinceEpoch () + I2NP_MESSAGE_EXPIRATION_TIMEOUT);
 	}
 

--- a/libi2pd/NTCP2.cpp
+++ b/libi2pd/NTCP2.cpp
@@ -1706,7 +1706,7 @@ namespace transport
 			SendQueue ();
 		else if (m_SendQueue.size () > NTCP2_MAX_OUTGOING_QUEUE_SIZE)
 		{
-			// drop the oldest, a slow peer must not cost us the session
+			// drop the oldest instead of terminating the session
 			while (m_SendQueue.size () > NTCP2_MAX_OUTGOING_QUEUE_SIZE)
 			{
 				if (m_SendQueue.front ()) m_SendQueue.front ()->Drop ();

--- a/libi2pd/NTCP2.cpp
+++ b/libi2pd/NTCP2.cpp
@@ -1706,9 +1706,17 @@ namespace transport
 			SendQueue ();
 		else if (m_SendQueue.size () > NTCP2_MAX_OUTGOING_QUEUE_SIZE)
 		{
-			LogPrint (eLogWarning, "NTCP2: Outgoing messages queue size to ",
-				GetIdentHashBase64(), " exceeds ", NTCP2_MAX_OUTGOING_QUEUE_SIZE);
-			Terminate ();
+			// drop the oldest, a slow peer must not cost us the session
+			while (m_SendQueue.size () > NTCP2_MAX_OUTGOING_QUEUE_SIZE)
+			{
+				if (m_SendQueue.front ()) m_SendQueue.front ()->Drop ();
+				m_SendQueue.pop_front ();
+				m_NumDroppedOverflow++;
+			}
+			if (m_NumDroppedOverflow == 1 || !(m_NumDroppedOverflow % 1000))
+				LogPrint (eLogWarning, "NTCP2: Outgoing messages queue size to ",
+					GetIdentHashBase64(), " exceeds ", NTCP2_MAX_OUTGOING_QUEUE_SIZE,
+					", dropped ", m_NumDroppedOverflow, " messages");
 		}
 		SetSendQueueSize (m_SendQueue.size ());
 	}

--- a/libi2pd/NTCP2.h
+++ b/libi2pd/NTCP2.h
@@ -248,6 +248,7 @@ namespace transport
 			i2p::I2NPMessagesHandler m_Handler;
 
 			bool m_IsSending, m_IsReceiving;
+			uint32_t m_NumDroppedOverflow = 0;
 			std::list<std::shared_ptr<I2NPMessage> > m_SendQueue;
 			uint64_t m_NextRouterInfoResendTime; // seconds since epoch
 

--- a/libi2pd/SSU2Session.cpp
+++ b/libi2pd/SSU2Session.cpp
@@ -633,7 +633,7 @@ namespace transport
 		}
 		// resend data packets
 		if (m_SentPackets.empty ()) return 0;
-		// packet numbers grow with send time, so nothing can be due before the oldest packet is
+		// packet numbers grow with send time, so the oldest packet is due first
 		if (ts < m_SentPackets.begin ()->second->sendTime + m_RTO) return 0;
 		std::map<uint32_t, std::shared_ptr<SSU2SentPacket> > resentPackets;
 		for (auto it = m_SentPackets.begin (); it != m_SentPackets.end (); )
@@ -2071,8 +2071,7 @@ namespace transport
 					else
 					{
 						if (m_MinRTTCandidate == SSU2_UNKNOWN_RTT || rtt < m_MinRTTCandidate) m_MinRTTCandidate = rtt;
-						// windowed minimum: the best sample of the last interval, so a path that got
-						// slower is picked up while our own queueing delay is not taken for path delay
+						// windowed minimum, so queueing delay is not taken for path delay
 						if (ts > m_MinRTTUpdateTime + SSU2_MIN_RTT_EXPIRATION_TIMEOUT)
 						{
 							m_MinRTT = m_MinRTTCandidate;
@@ -2116,7 +2115,7 @@ namespace transport
 		m_NumAckedPackets = 0;
 		m_DeliveryRateUpdateTime = ts;
 		m_DeliveryRate = (rate > m_DeliveryRate) ? rate : (3*m_DeliveryRate + rate)/4;
-		// as many packets as fit into the path at its own delay, queueing excluded
+		// bandwidth-delay product at path delay, queueing excluded
 		size_t bdp = SSU2_WINDOW_GAIN * m_DeliveryRate * m_MinRTT / 1000;
 		if (bdp < SSU2_MIN_MAX_WINDOW_SIZE) bdp = SSU2_MIN_MAX_WINDOW_SIZE;
 		if (bdp > SSU2_MAX_WINDOW_SIZE) bdp = SSU2_MAX_WINDOW_SIZE;

--- a/libi2pd/SSU2Session.cpp
+++ b/libi2pd/SSU2Session.cpp
@@ -87,10 +87,12 @@ namespace transport
 		m_RemoteVersion (0), m_DestConnID (0), m_SourceConnID (0), m_State (eSSU2SessionStateUnknown),
 		m_SendPacketNum (0), m_ReceivePacketNum (0), m_LastDatetimeSentPacketNum (0),
 		m_IsDataReceived (false), m_IsInvalidMessage (false), m_RTT (SSU2_UNKNOWN_RTT),
+		m_MinRTT (SSU2_UNKNOWN_RTT), m_MinRTTCandidate (SSU2_UNKNOWN_RTT),
 		m_MsgLocalExpirationTimeout (I2NP_MESSAGE_LOCAL_EXPIRATION_TIMEOUT_MAX),
 		m_MsgLocalSemiExpirationTimeout (I2NP_MESSAGE_LOCAL_EXPIRATION_TIMEOUT_MAX / 2),
-		m_WindowSize (SSU2_MIN_WINDOW_SIZE),
-		m_RTO (SSU2_INITIAL_RTO), m_RelayTag (0),m_ConnectTimer (server.GetService ()),
+		m_WindowSize (SSU2_MIN_WINDOW_SIZE), m_MaxWindowSize (SSU2_MIN_MAX_WINDOW_SIZE),
+		m_RTO (SSU2_INITIAL_RTO), m_MinRTTUpdateTime (0), m_DeliveryRateUpdateTime (0),
+		m_NumAckedPackets (0), m_DeliveryRate (0), m_RelayTag (0),m_ConnectTimer (server.GetService ()),
 		m_TerminationReason (eSSU2TerminationReasonNormalClose),
 		m_MaxPayloadSize (SSU2_MAX_PACKET_SIZE - IPV6_HEADER_SIZE - UDP_HEADER_SIZE - 32), // max size
 		m_LastResendTime (0), m_LastResendAttemptTime (0), m_NextRouterInfoResendTime(0),
@@ -631,6 +633,8 @@ namespace transport
 		}
 		// resend data packets
 		if (m_SentPackets.empty ()) return 0;
+		// packet numbers grow with send time, so nothing can be due before the oldest packet is
+		if (ts < m_SentPackets.begin ()->second->sendTime + m_RTO) return 0;
 		std::map<uint32_t, std::shared_ptr<SSU2SentPacket> > resentPackets;
 		for (auto it = m_SentPackets.begin (); it != m_SentPackets.end (); )
 			if (ts >= it->second->sendTime + (it->second->numResends + 1) * m_RTO)
@@ -2020,7 +2024,9 @@ namespace transport
 		// acnt
 		uint32_t ackThrough = bufbe32toh (buf);
 		uint32_t firstPacketNum = ackThrough > buf[4] ? ackThrough - buf[4] : 0;
-		HandleAckRange (firstPacketNum, ackThrough, i2p::util::GetMillisecondsSinceEpoch ()); // acnt
+		uint64_t ts = i2p::util::GetMillisecondsSinceEpoch ();
+		HandleAckRange (firstPacketNum, ackThrough, ts); // acnt
+		UpdateMaxWindowSize (ts);
 		// ranges
 		len -= 5;
 		if (!len || m_SentPackets.empty ()) return; // don't handle ranges if nothing to acknowledge
@@ -2056,6 +2062,24 @@ namespace transport
 						m_RTT = SSU2_RTT_EWMA_ALPHA * rtt + (1.0 - SSU2_RTT_EWMA_ALPHA) * m_RTT;
 					else
 						m_RTT = rtt;
+					if (m_MinRTT == SSU2_UNKNOWN_RTT || rtt < m_MinRTT)
+					{
+						m_MinRTT = rtt;
+						m_MinRTTCandidate = rtt;
+						m_MinRTTUpdateTime = ts;
+					}
+					else
+					{
+						if (m_MinRTTCandidate == SSU2_UNKNOWN_RTT || rtt < m_MinRTTCandidate) m_MinRTTCandidate = rtt;
+						// windowed minimum: the best sample of the last interval, so a path that got
+						// slower is picked up while our own queueing delay is not taken for path delay
+						if (ts > m_MinRTTUpdateTime + SSU2_MIN_RTT_EXPIRATION_TIMEOUT)
+						{
+							m_MinRTT = m_MinRTTCandidate;
+							m_MinRTTCandidate = SSU2_UNKNOWN_RTT;
+							m_MinRTTUpdateTime = ts;
+						}
+					}
 					m_RTO = m_RTT*SSU2_kAPPA;
 					m_MsgLocalExpirationTimeout = std::max (I2NP_MESSAGE_LOCAL_EXPIRATION_TIMEOUT_MIN,
 						std::min (I2NP_MESSAGE_LOCAL_EXPIRATION_TIMEOUT_MAX,
@@ -2072,9 +2096,31 @@ namespace transport
 		m_SentPackets.erase (it, it1);
 		if (numPackets > 0)
 		{
+			m_NumAckedPackets += numPackets;
 			m_WindowSize += numPackets;
-			if (m_WindowSize > SSU2_MAX_WINDOW_SIZE) m_WindowSize = SSU2_MAX_WINDOW_SIZE;
+			if (m_WindowSize > m_MaxWindowSize) m_WindowSize = m_MaxWindowSize;
 		}
+	}
+
+	void SSU2Session::UpdateMaxWindowSize (uint64_t ts)
+	{
+		if (m_MinRTT == SSU2_UNKNOWN_RTT) return;
+		if (!m_DeliveryRateUpdateTime)
+		{
+			m_DeliveryRateUpdateTime = ts;
+			return;
+		}
+		uint64_t interval = ts - m_DeliveryRateUpdateTime;
+		if (interval < SSU2_DELIVERY_RATE_INTERVAL) return;
+		size_t rate = m_NumAckedPackets * 1000 / interval;
+		m_NumAckedPackets = 0;
+		m_DeliveryRateUpdateTime = ts;
+		m_DeliveryRate = (rate > m_DeliveryRate) ? rate : (3*m_DeliveryRate + rate)/4;
+		// as many packets as fit into the path at its own delay, queueing excluded
+		size_t bdp = SSU2_WINDOW_GAIN * m_DeliveryRate * m_MinRTT / 1000;
+		if (bdp < SSU2_MIN_MAX_WINDOW_SIZE) bdp = SSU2_MIN_MAX_WINDOW_SIZE;
+		if (bdp > SSU2_MAX_WINDOW_SIZE) bdp = SSU2_MAX_WINDOW_SIZE;
+		m_MaxWindowSize = bdp;
 	}
 
 	void SSU2Session::HandleAddress (const uint8_t * buf, size_t len)

--- a/libi2pd/SSU2Session.h
+++ b/libi2pd/SSU2Session.h
@@ -51,7 +51,7 @@ namespace transport
 	const size_t SSU2_MIN_WINDOW_SIZE = 16; // in packets
 	const size_t SSU2_MIN_MAX_WINDOW_SIZE = 256; // in packets
 	const size_t SSU2_MAX_WINDOW_SIZE = 2048; // in packets
-	const size_t SSU2_WINDOW_GAIN = 2; // how many bandwidth-delay products window is allowed to reach
+	const size_t SSU2_WINDOW_GAIN = 2; // in bandwidth-delay products
 	const uint64_t SSU2_MIN_RTT_EXPIRATION_TIMEOUT = 15000; // in milliseconds
 	const uint64_t SSU2_DELIVERY_RATE_INTERVAL = 200; // in milliseconds
 	const size_t SSU2_MIN_RTO = 100; // in milliseconds
@@ -408,7 +408,7 @@ namespace transport
 			std::list<std::shared_ptr<I2NPMessage> > m_IntermediateQueue; // from transports
 			mutable std::mutex m_IntermediateQueueMutex;
 			bool m_IsDataReceived, m_IsInvalidMessage;
-			double m_RTT, m_MinRTT, m_MinRTTCandidate; // m_MinRTT is path propagation delay, without queueing
+			double m_RTT, m_MinRTT, m_MinRTTCandidate; // m_MinRTT is path delay, without queueing
 			int m_MsgLocalExpirationTimeout;
 			int m_MsgLocalSemiExpirationTimeout;
 			size_t m_WindowSize, m_MaxWindowSize, m_RTO;

--- a/libi2pd/SSU2Session.h
+++ b/libi2pd/SSU2Session.h
@@ -49,7 +49,11 @@ namespace transport
 	const int SSU2_ROUTERINFO_RESEND_INTERVAL = 20*60*1000; // in milliseconds
 	const int SSU2_ROUTERINFO_RESEND_INTERVAL_VARIANCE = 30*60*1000; // in milliseconds
 	const size_t SSU2_MIN_WINDOW_SIZE = 16; // in packets
-	const size_t SSU2_MAX_WINDOW_SIZE = 256; // in packets
+	const size_t SSU2_MIN_MAX_WINDOW_SIZE = 256; // in packets
+	const size_t SSU2_MAX_WINDOW_SIZE = 2048; // in packets
+	const size_t SSU2_WINDOW_GAIN = 2; // how many bandwidth-delay products window is allowed to reach
+	const uint64_t SSU2_MIN_RTT_EXPIRATION_TIMEOUT = 15000; // in milliseconds
+	const uint64_t SSU2_DELIVERY_RATE_INTERVAL = 200; // in milliseconds
 	const size_t SSU2_MIN_RTO = 100; // in milliseconds
 	const size_t SSU2_INITIAL_RTO = 540; // in milliseconds
 	const size_t SSU2_MAX_RTO = 2500; // in milliseconds
@@ -349,6 +353,7 @@ namespace transport
 			void HandleRouterInfo (const uint8_t * buf, size_t len);
 			void HandleAck (const uint8_t * buf, size_t len);
 			void HandleAckRange (uint32_t firstPacketNum, uint32_t lastPacketNum, uint64_t ts);
+			void UpdateMaxWindowSize (uint64_t ts);
 			virtual void HandleAddress (const uint8_t * buf, size_t len);
 			size_t CreateEndpoint (uint8_t * buf, size_t len, const boost::asio::ip::udp::endpoint& ep);
 			std::shared_ptr<const i2p::data::RouterInfo::Address> FindLocalAddress () const;
@@ -403,10 +408,12 @@ namespace transport
 			std::list<std::shared_ptr<I2NPMessage> > m_IntermediateQueue; // from transports
 			mutable std::mutex m_IntermediateQueueMutex;
 			bool m_IsDataReceived, m_IsInvalidMessage;
-			double m_RTT;
+			double m_RTT, m_MinRTT, m_MinRTTCandidate; // m_MinRTT is path propagation delay, without queueing
 			int m_MsgLocalExpirationTimeout;
 			int m_MsgLocalSemiExpirationTimeout;
-			size_t m_WindowSize, m_RTO;
+			size_t m_WindowSize, m_MaxWindowSize, m_RTO;
+			uint64_t m_MinRTTUpdateTime, m_DeliveryRateUpdateTime; // in milliseconds
+			size_t m_NumAckedPackets, m_DeliveryRate; // acked packets per second
 			uint32_t m_RelayTag; // between Bob and Charlie
 			OnEstablished m_OnEstablished; // callback from Established
 			boost::asio::steady_timer m_ConnectTimer;

--- a/libi2pd/TunnelPool.cpp
+++ b/libi2pd/TunnelPool.cpp
@@ -356,14 +356,20 @@ namespace tunnel
 				if (it.second.first->GetState () == eTunnelStateTestFailed)
 				{
 					it.second.first->SetState (eTunnelStateFailed);
-					std::unique_lock<std::mutex> l(m_OutboundTunnelsMutex);
-					if (m_OutboundTunnels.size () > 1) // don't fail last tunnel
-						m_OutboundTunnels.erase (it.second.first);
-					else
+					bool recreate = false;
 					{
-						it.second.first->SetState (eTunnelStateTestFailed);
-						CreateOutboundTunnel (ts); // create new tunnel immediately because last one failed
+						std::unique_lock<std::mutex> l(m_OutboundTunnelsMutex);
+						if (m_OutboundTunnels.size () > 1) // don't fail last tunnel
+							m_OutboundTunnels.erase (it.second.first);
+						else
+						{
+							it.second.first->SetState (eTunnelStateTestFailed);
+							recreate = true;
+						}
 					}
+					// zero hops tunnel is created synchronously and locks the same mutex
+					if (recreate)
+						CreateOutboundTunnel (ts); // create new tunnel immediately because last one failed
 				}
 				else if (it.second.first->GetState () != eTunnelStateExpiring)
 					it.second.first->SetState (eTunnelStateTestFailed);
@@ -374,7 +380,7 @@ namespace tunnel
 				{
 					it.second.second->SetState (eTunnelStateFailed);
 					{
-						bool failed = false;
+						bool failed = false, recreate = false;
 						{
 							std::unique_lock<std::mutex> l(m_InboundTunnelsMutex);
 							if (m_InboundTunnels.size () > 1) // don't fail last tunnel
@@ -385,9 +391,11 @@ namespace tunnel
 							else
 							{
 								it.second.second->SetState (eTunnelStateTestFailed);
-								CreateInboundTunnel (ts); // create new tunnel immediately because last one failed
+								recreate = true;
 							}
 						}
+						if (recreate)
+							CreateInboundTunnel (ts); // create new tunnel immediately because last one failed
 						if (failed && m_LocalDestination)
 							m_LocalDestination->SetLeaseSetUpdated (true);
 					}

--- a/libi2pd_client/ClientContext.cpp
+++ b/libi2pd_client/ClientContext.cpp
@@ -564,6 +564,14 @@ namespace client
 			options.Insert (I2CP_PARAM_STREAMING_MAX_RESENDS, value);
 	}
 
+	static size_t GetUDPTunnelMaxWindow (const boost::property_tree::ptree& section)
+	{
+		size_t w = section.get<size_t> (UDP_TUNNEL_MAX_WINDOW, I2P_UDP_DEFAULT_MAX_NUM_UNACKED_DATAGRAMS);
+		if (w < I2P_UDP_MIN_MAX_NUM_UNACKED_DATAGRAMS) w = I2P_UDP_MIN_MAX_NUM_UNACKED_DATAGRAMS;
+		if (w > I2P_UDP_MAX_NUM_UNACKED_DATAGRAMS) w = I2P_UDP_MAX_NUM_UNACKED_DATAGRAMS;
+		return w;
+	}
+
 	void ClientContext::ReadTunnels ()
 	{
 		int numClientTunnels = 0, numServerTunnels = 0;
@@ -686,6 +694,7 @@ namespace client
 						int datagramVersion = (i2p::datagram::DatagramVersion)section.second.get (UDP_CLIENT_TUNNEL_DATAGRAM_VERSION, (int)i2p::datagram::eDatagramV3);
 						auto clientTunnel = std::make_shared<I2PUDPClientTunnel> (name, dest, end,
 							localDestination, destinationPort, gzip, (i2p::datagram::DatagramVersion)datagramVersion);
+						clientTunnel->SetMaxWindow (GetUDPTunnelMaxWindow (section.second));
 
 						uint32_t keepAlive = section.second.get<uint32_t>(I2P_CLIENT_TUNNEL_KEEP_ALIVE_INTERVAL, 0);
 						if (keepAlive)
@@ -864,6 +873,7 @@ namespace client
 						}
 						auto localAddress = boost::asio::ip::make_address(address);
 						auto serverTunnel = std::make_shared<I2PUDPServerTunnel>(name, localDestination, localAddress, endpoint, inPort, gzip);
+						serverTunnel->SetMaxWindow (GetUDPTunnelMaxWindow (section.second));
 						if(!isUniqueLocal)
 						{
 							LogPrint(eLogInfo, "Clients: Disabling loopback address mapping");

--- a/libi2pd_client/ClientContext.h
+++ b/libi2pd_client/ClientContext.h
@@ -69,6 +69,7 @@ namespace client
 	const char I2P_SERVER_TUNNEL_ENABLE_UNIQUE_LOCAL[] = "enableuniquelocal";
 	const char I2P_SERVER_TUNNEL_SSL[] = "ssl";
 	const char UDP_CLIENT_TUNNEL_DATAGRAM_VERSION[] = "datagramversion";
+	const char UDP_TUNNEL_MAX_WINDOW[] = "maxwindow";
 	const char TORRENTS_TUNNEL_KEYS[] = "keys";
 	const char TORRENTS_TUNNEL_SIGNATURE_TYPE[] = "signaturetype";
 	const char TORRENTS_TUNNEL_TORRENTS_DIR[] = "torrentsdir";

--- a/libi2pd_client/UDPTunnel.cpp
+++ b/libi2pd_client/UDPTunnel.cpp
@@ -30,6 +30,7 @@ namespace client
 	{
 		if (!m_LastSession || m_LastSession->Identity.GetLL()[0] != from.GetIdentHash ().GetLL()[0] || (fromPort && fromPort != m_LastSession->RemotePort))
 			m_LastSession = ObtainUDPSession(from, toPort, fromPort);
+		m_LastSession->m_LastReceivedTime = i2p::util::GetMillisecondsSinceEpoch ();
 		boost::system::error_code ec;
 		if (len > 0)
 			m_LastSession->IPSocket.send_to(boost::asio::buffer(buf, len), m_RemoteEndpoint, 0, ec);
@@ -73,6 +74,12 @@ namespace client
 				m_LastSession = it->second;
 			else
 				m_LastSession = nullptr;
+		}
+		if (!m_LastSession)
+		{
+			m_NumRawNoSession++;
+			LogPrint (eLogWarning, "UDP Server: No session for raw datagram from port ", fromPort, " to ", toPort,
+				", dropped, ", m_NumRawNoSession, " total");
 		}
 		if (m_LastSession)
 		{
@@ -147,6 +154,7 @@ namespace client
 
 		auto s = std::make_shared<UDPSession>(boost::asio::ip::udp::endpoint(addr, 0),
 			m_LocalDest, m_RemoteEndpoint, ih, localPort, remotePort);
+		s->SetMaxWindow (m_MaxWindow);
 		std::lock_guard<std::mutex> lock(m_SessionsMutex);
 		m_Sessions.emplace (idx, s);
 		return s;
@@ -165,6 +173,7 @@ namespace client
 			if (seqn >= m_AckTimerSeqn)
 			{
 				m_AckTimerSeqn = 0;
+				m_NumAckTimeoutsInRow = 0;
 				m_AckTimer.cancel ();
 			}
 		}
@@ -178,20 +187,121 @@ namespace client
 			if (it->first > seqn) break;
 			 if (it->first == seqn && m_IsSendingAllowed) // ignore first ack after path change
 			{
-				auto rtt = i2p::util::GetMillisecondsSinceEpoch () - it->second;
-				m_RTT = m_RTT ? (m_RTT + rtt)/2 : rtt;
+				auto ts = i2p::util::GetMillisecondsSinceEpoch ();
+				UpdateRTT (ts - it->second, ts);
+				m_NumAckTimeoutsInRow = 0;
 				acknowledged = true;
 			}
 			it++;
 		}
 		m_UnackedDatagrams.erase (m_UnackedDatagrams.begin (), it);
 		m_IsSendingAllowed = true; // if we recieve ack after path change, now can send new datagrams
-		if (acknowledged && !m_UnackedDatagrams.empty ())
+		if (!m_UnackedDatagrams.empty ())
 		{
-			m_AckTimer.cancel ();
-			m_AckTimerSeqn = 0;
+			// keep the timer armed while anything is unacked, otherwise a full window can't be unblocked
+			if (acknowledged)
+			{
+				m_AckTimer.cancel ();
+				m_AckTimerSeqn = 0;
+			}
 			ScheduleAckTimer (m_UnackedDatagrams.back ().first);
 		}
+	}
+
+	void UDPConnection::UpdateRTT (uint64_t rtt, uint64_t ts)
+	{
+		if (m_RTT)
+		{
+			uint64_t diff = (rtt > m_RTT) ? rtt - m_RTT : m_RTT - rtt;
+			m_RTTVar = (3*m_RTTVar + diff)/4;
+			m_RTT = (7*m_RTT + rtt)/8;
+		}
+		else
+		{
+			m_RTT = rtt;
+			m_RTTVar = rtt/2;
+		}
+		if (!m_MinRTT || rtt < m_MinRTT)
+		{
+			m_MinRTT = rtt;
+			m_MinRTTCandidate = rtt;
+			m_MinRTTUpdateTime = ts;
+		}
+		else
+		{
+			if (!m_MinRTTCandidate || rtt < m_MinRTTCandidate) m_MinRTTCandidate = rtt;
+			// windowed minimum: the best sample of the last interval, so a path that got slower
+			// is picked up while our own queueing delay is not mistaken for path delay
+			if (ts > m_MinRTTUpdateTime + I2P_UDP_MIN_RTT_EXPIRATION_TIMEOUT)
+			{
+				m_MinRTT = m_MinRTTCandidate;
+				m_MinRTTCandidate = 0;
+				m_MinRTTUpdateTime = ts;
+			}
+		}
+	}
+
+	void UDPConnection::UpdateSendRate (uint32_t numDatagrams, uint64_t ts)
+	{
+		m_NumSentSinceRateUpdate += numDatagrams;
+		if (!m_SendRateUpdateTime)
+		{
+			m_SendRateUpdateTime = ts;
+			return;
+		}
+		uint64_t interval = ts - m_SendRateUpdateTime;
+		if (interval < I2P_UDP_SEND_RATE_INTERVAL) return;
+		uint32_t rate = m_NumSentSinceRateUpdate * 1000 / interval;
+		m_NumSentSinceRateUpdate = 0;
+		m_SendRateUpdateTime = ts;
+		// a window sized from the current rate shrinks as soon as the rate dips, which shrinks
+		// the rate further, so keep the best rate of the last few seconds instead
+		if (rate >= m_SendRate || ts > m_SendRateMaxTime + I2P_UDP_SEND_RATE_EXPIRATION_TIMEOUT)
+		{
+			m_SendRate = rate;
+			m_SendRateMaxTime = ts;
+		}
+	}
+
+	size_t UDPConnection::GetMaxNumUnackedDatagrams () const
+	{
+		if (!m_MinRTT || !m_SendRate) return I2P_UDP_MIN_MAX_NUM_UNACKED_DATAGRAMS;
+		// an ack can't arrive sooner than one path delay plus one repliable interval,
+		// so that's how much data the path holds when it's not queueing
+		size_t w = I2P_UDP_WINDOW_GAIN * m_SendRate * (m_MinRTT + I2P_UDP_REPLIABLE_DATAGRAM_INTERVAL) / 1000;
+		if (w < I2P_UDP_MIN_MAX_NUM_UNACKED_DATAGRAMS) w = I2P_UDP_MIN_MAX_NUM_UNACKED_DATAGRAMS;
+		if (w > m_MaxWindow) w = m_MaxWindow;
+		return w;
+	}
+
+	bool UDPConnection::IsWindowFull () const
+	{
+		return !m_UnackedDatagrams.empty () &&
+			m_NextSendPacketNum > m_UnackedDatagrams.front ().first + GetMaxNumUnackedDatagrams ();
+	}
+
+	void UDPConnection::ExpireUnackedDatagrams (uint64_t ts)
+	{
+		// an ack this old is never coming, and while it stays the window base it blocks the tunnel for good
+		while (!m_UnackedDatagrams.empty () &&
+			ts > m_UnackedDatagrams.front ().second + I2P_UDP_MAX_UNACKED_DATAGRAM_TIME)
+			m_UnackedDatagrams.pop_front ();
+	}
+
+	uint64_t UDPConnection::GetRTO () const
+	{
+		if (!m_RTT) return I2P_UDP_MAX_UNACKED_DATAGRAM_TIME;
+		uint64_t rto = m_RTT + 4*m_RTTVar;
+		if (rto < I2P_UDP_MIN_ACK_TIMEOUT) rto = I2P_UDP_MIN_ACK_TIMEOUT;
+		if (rto > I2P_UDP_MAX_UNACKED_DATAGRAM_TIME) rto = I2P_UDP_MAX_UNACKED_DATAGRAM_TIME;
+		return rto;
+	}
+
+	uint64_t UDPConnection::GetWindowProbeInterval () const
+	{
+		// an ack can't come back sooner than one RTT, probing more often is pointless
+		if (!m_RTT) return GetRTO ();
+		return (m_RTT > I2P_UDP_MIN_WINDOW_PROBE_INTERVAL) ? m_RTT : I2P_UDP_MIN_WINDOW_PROBE_INTERVAL;
 	}
 
 	void UDPConnection::ScheduleAckTimer (uint32_t seqn)
@@ -199,24 +309,48 @@ namespace client
 		if (!m_AckTimerSeqn)
 		{
 			m_AckTimerSeqn = seqn;
-			m_AckTimer.expires_after (std::chrono::milliseconds (m_RTT ? 2*m_RTT : I2P_UDP_MAX_UNACKED_DATAGRAM_TIME));
+			uint32_t shift = m_NumAckTimeoutsInRow;
+			if (shift > I2P_UDP_MAX_NUM_ACK_TIMEOUTS) shift = I2P_UDP_MAX_NUM_ACK_TIMEOUTS;
+			uint64_t timeout = GetRTO () << shift;
+			if (timeout > I2P_UDP_MAX_UNACKED_DATAGRAM_TIME) timeout = I2P_UDP_MAX_UNACKED_DATAGRAM_TIME;
+			m_AckTimer.expires_after (std::chrono::milliseconds (timeout));
 			m_AckTimer.async_wait ([this](const boost::system::error_code& ecode)
 				{
 					if (ecode != boost::asio::error::operation_aborted)
 					{
-						LogPrint (eLogInfo, "UDP Connection: Packet ", m_AckTimerSeqn, " was not acked");
+						auto ts = i2p::util::GetMillisecondsSinceEpoch ();
+						m_NumAckTimeouts++; m_NumAckTimeoutsInRow++;
+						// timeouts alone mean nothing: they are what congestion looks like. only a peer
+						// gone silent proves the path is dead and is worth rebuilding
+						bool resetPath = m_NumAckTimeoutsInRow >= I2P_UDP_MAX_NUM_ACK_TIMEOUTS &&
+							ts > m_LastReceivedTime + I2P_UDP_MAX_UNACKED_DATAGRAM_TIME;
+						bool resetPeerPath = resetPath && ts > m_LastReceivedTime + I2P_UDP_PEER_PATH_RESET_TIMEOUT;
+						LogPrint (eLogWarning, "UDP Connection: Packet ", m_AckTimerSeqn, " was not acked, rtt ",
+							m_RTT, "/", m_RTTVar, "ms, ", m_NumAckTimeoutsInRow, " in a row, ", m_NumAckTimeouts,
+							" total", resetPath ? ", resetting path" : "");
 						if (m_IsFirstPacket) m_IsSendingAllowed = false; // stop sending only if session is not established yet
 						m_AckTimerSeqn = 0;
-						m_RTT = 0;
-						if (!m_UnackedDatagrams.empty ()) ScheduleAckTimer (0); // try again if failed
-						// send empty packet with reset path flag
+						// probe the peer, reset path only after several timeouts in a row
+						uint8_t flags = UDP_SESSION_FLAG_ACK_REQUESTED;
+						if (resetPeerPath) flags |= UDP_SESSION_FLAG_RESET_PATH | UDP_SESSION_FLAG_RESET_SEQN;
 						i2p::util::Mapping options;
-						options.Put (UDP_SESSION_FLAGS, UDP_SESSION_FLAG_RESET_PATH | UDP_SESSION_FLAG_ACK_REQUESTED);
+						options.Put (UDP_SESSION_FLAGS, flags);
+						// the probe must carry a seqn, otherwise the peer acks its stale one
+						// and a full window can never be unblocked
+						options.Put (UDP_SESSION_SEQN, m_NextSendPacketNum);
+						m_NextSendPacketNum++;
+						// only keep probing while real data is outstanding, otherwise probes feed
+						// themselves: each one arms the timer whose timeout sends the next
+						if (!m_UnackedDatagrams.empty ()) ScheduleAckTimer (0);
 						auto session = GetDatagramSession ();
 						if (session)
 						{
-							session->DropSharedRoutingPath ();
-							session->RequestUpdatedLeaseSet (); // in case current leases are dead
+							if (resetPath)
+							{
+								session->DropSharedRoutingPath ();
+								session->RequestUpdatedLeaseSet (); // in case current leases are dead
+								m_NumAckTimeoutsInRow = 0;
+							}
 							m_Destination->SendDatagram (session, nullptr, 0, 0, 0, &options);
 						}
 					}
@@ -246,7 +380,8 @@ namespace client
 	{
 		SetIdentity (to);
 		Start ();
-		IPSocket.set_option (boost::asio::socket_base::receive_buffer_size (I2P_UDP_MAX_MTU ));
+		IPSocket.set_option (boost::asio::socket_base::receive_buffer_size (I2P_UDP_SOCKET_BUFFER_SIZE));
+		IPSocket.set_option (boost::asio::socket_base::send_buffer_size (I2P_UDP_SOCKET_BUFFER_SIZE));
 		IPSocket.non_blocking (true);
 		Receive();
 	}
@@ -262,23 +397,30 @@ namespace client
 	{
 		if(!ecode)
 		{
-			if (!m_UnackedDatagrams.empty () && m_NextSendPacketNum > m_UnackedDatagrams.front ().first + I2P_UDP_MAX_NUM_UNACKED_DATAGRAMS)
+			ExpireUnackedDatagrams (i2p::util::GetMillisecondsSinceEpoch ());
+			bool isWindowFull = IsWindowFull ();
+			if (isWindowFull && i2p::util::GetMillisecondsSinceEpoch () < m_LastWindowProbeTime + GetWindowProbeInterval ())
 			{
 				// window is full, drop packet
+				m_NumWindowDrops++;
+				if (m_NumWindowDrops == 1 || !(m_NumWindowDrops % 100))
+					LogPrint (eLogWarning, "UDP Server: Window full (front=", m_UnackedDatagrams.front ().first,
+						" next=", m_NextSendPacketNum, "), dropped ", m_NumWindowDrops, " packets");
 				Receive ();
 				return;
 			}
 			LogPrint(eLogDebug, "UDPSession: Forward ", len, "B from ", FromEndpoint);
 			auto ts = i2p::util::GetMillisecondsSinceEpoch();
+			if (isWindowFull) m_LastWindowProbeTime = ts;
 			auto session = GetDatagramSession ();
 			uint64_t repliableDatagramInterval = I2P_UDP_REPLIABLE_DATAGRAM_INTERVAL;
 			if (m_RTT && m_RTT >= I2P_UDP_REPLIABLE_DATAGRAM_INTERVAL && m_RTT < I2P_UDP_REPLIABLE_DATAGRAM_INTERVAL*10) repliableDatagramInterval = m_RTT/10; // 10 - 100 ms
-			if (ts > m_LastRepliableDatagramTime + repliableDatagramInterval)
+			if (isWindowFull || ts > m_LastRepliableDatagramTime + repliableDatagramInterval)
 			{
 				if (session->GetVersion () == i2p::datagram::eDatagramV3)
 				{
 					uint8_t flags = 0;
-					if (!m_RTT || !m_AckTimerSeqn || (!m_UnackedDatagrams.empty () &&
+					if (isWindowFull || !m_RTT || !m_AckTimerSeqn || (!m_UnackedDatagrams.empty () &&
 						ts > m_UnackedDatagrams.back ().second + repliableDatagramInterval)) // last ack request
 					{
 						flags |= UDP_SESSION_FLAG_ACK_REQUESTED;
@@ -315,6 +457,7 @@ namespace client
 			if (numPackets > 0)
 				LogPrint(eLogDebug, "UDPSession: Forward more ", numPackets, "packets B from ", FromEndpoint);
 			m_NextSendPacketNum += numPackets + 1;
+			UpdateSendRate (numPackets + 1, ts);
 			m_Destination->FlushSendQueue (session);
 			LastActivity = ts;
 			Receive();
@@ -349,10 +492,44 @@ namespace client
 			std::bind (&I2PUDPServerTunnel::HandleRecvFromI2PRaw, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4),
 			m_inPort
 		);
+		m_StatsTimer.reset (new boost::asio::steady_timer (m_LocalDest->GetService ()));
+		ScheduleStatsTimer ();
+	}
+
+	void I2PUDPServerTunnel::ScheduleStatsTimer ()
+	{
+		if (m_StatsTimer)
+		{
+			m_StatsTimer->expires_after (std::chrono::seconds (10));
+			m_StatsTimer->async_wait (std::bind (&I2PUDPServerTunnel::HandleStatsTimer,
+				this, std::placeholders::_1));
+		}
+	}
+
+	void I2PUDPServerTunnel::HandleStatsTimer (const boost::system::error_code& ecode)
+	{
+		if (ecode != boost::asio::error::operation_aborted)
+		{
+			std::lock_guard<std::mutex> lock (m_SessionsMutex);
+			for (const auto& it: m_Sessions)
+			{
+				auto& s = it.second;
+				auto session = s->GetDatagramSession ();
+				LogPrint (eLogWarning, "UDP Server: stats port=", s->RemotePort, " rtt=", s->m_RTT, "/",
+					s->m_RTTVar, "/", s->m_MinRTT, "ms rto=", s->GetRTO (), "ms rate=", s->m_SendRate,
+					"/s window=", s->GetMaxNumUnackedDatagrams (), " unacked=", s->m_UnackedDatagrams.size (),
+					" nextSeqn=", s->m_NextSendPacketNum, " lastRecvSeqn=", s->m_LastReceivedPacketNum,
+					" winDrops=", s->m_NumWindowDrops, " ackTimeouts=", s->m_NumAckTimeouts,
+					" pathDrops=", session ? session->GetNumPathDrops () : 0,
+					" noPathDrops=", session ? session->GetNumDroppedNoPath () : 0);
+			}
+			ScheduleStatsTimer ();
+		}
 	}
 
 	void I2PUDPServerTunnel::Stop ()
 	{
+		if (m_StatsTimer) m_StatsTimer->cancel ();
 		auto dgram = m_LocalDest->GetDatagramDestination ();
 		if (dgram) {
 			dgram->ResetReceiver (m_inPort);
@@ -410,7 +587,8 @@ namespace client
 		if (m_cancel_resolve) m_cancel_resolve = false;
 
 		m_LocalSocket.reset (new boost::asio::ip::udp::socket (m_LocalDest->GetService (), m_LocalEndpoint));
-		m_LocalSocket->set_option (boost::asio::socket_base::receive_buffer_size (I2P_UDP_MAX_MTU));
+		m_LocalSocket->set_option (boost::asio::socket_base::receive_buffer_size (I2P_UDP_SOCKET_BUFFER_SIZE));
+		m_LocalSocket->set_option (boost::asio::socket_base::send_buffer_size (I2P_UDP_SOCKET_BUFFER_SIZE));
 		m_LocalSocket->set_option (boost::asio::socket_base::reuse_address (true));
 		m_LocalSocket->non_blocking (true);
 
@@ -431,11 +609,15 @@ namespace client
 
 		if (m_KeepAliveInterval)
 			ScheduleKeepAliveTimer ();
+
+		m_StatsTimer.reset (new boost::asio::steady_timer (m_LocalDest->GetService ()));
+		ScheduleStatsTimer ();
 	}
 
 	void I2PUDPClientTunnel::Stop ()
 	{
 		if (m_KeepAliveTimer) m_KeepAliveTimer->cancel ();
+		if (m_StatsTimer) m_StatsTimer->cancel ();
 
 		auto dgram = m_LocalDest->GetDatagramDestination ();
 		if (dgram)
@@ -507,9 +689,15 @@ namespace client
 				// else fall through and send new first packet, previous one wasn't acked in time
 			}
 		}
-		if (!m_UnackedDatagrams.empty () && m_NextSendPacketNum > m_UnackedDatagrams.front ().first + I2P_UDP_MAX_NUM_UNACKED_DATAGRAMS)
+		ExpireUnackedDatagrams (i2p::util::GetMillisecondsSinceEpoch ());
+		bool isWindowFull = IsWindowFull ();
+		if (isWindowFull && i2p::util::GetMillisecondsSinceEpoch () < m_LastWindowProbeTime + GetWindowProbeInterval ())
 		{
 			// window is full, drop packet
+			m_NumWindowDrops++;
+			if (m_NumWindowDrops == 1 || !(m_NumWindowDrops % 100))
+				LogPrint (eLogWarning, "UDP Client: Window full (front=", m_UnackedDatagrams.front ().first,
+					" next=", m_NextSendPacketNum, "), dropped ", m_NumWindowDrops, " packets");
 			RecvFromLocal ();
 			return;
 		}
@@ -529,16 +717,17 @@ namespace client
 		}
 		// send off to remote i2p destination
 		auto ts = i2p::util::GetMillisecondsSinceEpoch ();
+		if (isWindowFull) m_LastWindowProbeTime = ts;
 		LogPrint (eLogDebug, "UDP Client: Send ", transferred, " to ", Identity.ToBase32 (), ":", RemotePort);
 		auto session = GetDatagramSession ();
 		uint64_t repliableDatagramInterval = I2P_UDP_REPLIABLE_DATAGRAM_INTERVAL;
 		if (m_RTT && m_RTT >= I2P_UDP_REPLIABLE_DATAGRAM_INTERVAL && m_RTT < I2P_UDP_REPLIABLE_DATAGRAM_INTERVAL*10) repliableDatagramInterval = m_RTT/10; // 10 - 100 ms
-		if (ts > m_LastRepliableDatagramTime + repliableDatagramInterval)
+		if (isWindowFull || ts > m_LastRepliableDatagramTime + repliableDatagramInterval)
 		{
 			if (m_DatagramVersion == i2p::datagram::eDatagramV3)
 			{
 				uint8_t flags = 0;
-				if (!m_RTT || !m_AckTimerSeqn || (!m_UnackedDatagrams.empty () &&
+				if (isWindowFull || !m_RTT || !m_AckTimerSeqn || (!m_UnackedDatagrams.empty () &&
 					ts > m_UnackedDatagrams.back ().second + repliableDatagramInterval)) // last ack request
 				{
 					flags |= UDP_SESSION_FLAG_ACK_REQUESTED;
@@ -577,6 +766,7 @@ namespace client
 		if (numPackets)
 			LogPrint (eLogDebug, "UDP Client: Sent ", numPackets, " more packets to ", Identity.ToBase32 ());
 		m_NextSendPacketNum += numPackets + 1;
+		UpdateSendRate (numPackets + 1, ts);
 		m_Destination->FlushSendQueue (session);
 
 		// mark convo as active
@@ -627,6 +817,7 @@ namespace client
 	{
 		if (isIdentity && from.GetIdentHash() == Identity)
 		{
+			m_LastReceivedTime = i2p::util::GetMillisecondsSinceEpoch ();
 			if (options)
 			{
 				uint32_t seqn = 0;
@@ -658,6 +849,7 @@ namespace client
 
 	void I2PUDPClientTunnel::HandleRecvFromI2PRaw (uint16_t fromPort, uint16_t toPort, const uint8_t * buf, size_t len)
 	{
+		m_LastReceivedTime = i2p::util::GetMillisecondsSinceEpoch ();
 		std::shared_ptr<UDPConvo> convo;
 		{
 			std::lock_guard<std::mutex> lock (m_SessionsMutex);
@@ -709,6 +901,32 @@ namespace client
 			if (i2p::util::GetMillisecondsSinceEpoch () > m_LastRepliableDatagramTime + m_KeepAliveInterval*1000)
 				HandleRecvFromLocal (boost::system::error_code(), 0); // send empty packet like it was received from local
 			ScheduleKeepAliveTimer ();
+		}
+	}
+
+	void I2PUDPClientTunnel::ScheduleStatsTimer ()
+	{
+		if (m_StatsTimer)
+		{
+			m_StatsTimer->expires_after (std::chrono::seconds (10));
+			m_StatsTimer->async_wait (std::bind (&I2PUDPClientTunnel::HandleStatsTimer,
+				this, std::placeholders::_1));
+		}
+	}
+
+	void I2PUDPClientTunnel::HandleStatsTimer (const boost::system::error_code& ecode)
+	{
+		if (ecode != boost::asio::error::operation_aborted)
+		{
+			auto session = GetDatagramSession ();
+			LogPrint (eLogWarning, "UDP Client: stats rtt=", m_RTT, "/", m_RTTVar, "/", m_MinRTT, "ms rto=", GetRTO (),
+				"ms rate=", m_SendRate, "/s window=", GetMaxNumUnackedDatagrams (),
+				" unacked=", m_UnackedDatagrams.size (),
+				" nextSeqn=", m_NextSendPacketNum, " winDrops=", m_NumWindowDrops,
+				" ackTimeouts=", m_NumAckTimeouts,
+				" pathDrops=", session ? session->GetNumPathDrops () : 0,
+				" noPathDrops=", session ? session->GetNumDroppedNoPath () : 0);
+			ScheduleStatsTimer ();
 		}
 	}
 }

--- a/libi2pd_client/UDPTunnel.cpp
+++ b/libi2pd_client/UDPTunnel.cpp
@@ -198,7 +198,7 @@ namespace client
 		m_IsSendingAllowed = true; // if we recieve ack after path change, now can send new datagrams
 		if (!m_UnackedDatagrams.empty ())
 		{
-			// keep the timer armed while anything is unacked, otherwise a full window can't be unblocked
+			// keep armed while anything is unacked, otherwise a full window can't be unblocked
 			if (acknowledged)
 			{
 				m_AckTimer.cancel ();
@@ -230,8 +230,7 @@ namespace client
 		else
 		{
 			if (!m_MinRTTCandidate || rtt < m_MinRTTCandidate) m_MinRTTCandidate = rtt;
-			// windowed minimum: the best sample of the last interval, so a path that got slower
-			// is picked up while our own queueing delay is not mistaken for path delay
+			// windowed minimum, so queueing delay is not taken for path delay
 			if (ts > m_MinRTTUpdateTime + I2P_UDP_MIN_RTT_EXPIRATION_TIMEOUT)
 			{
 				m_MinRTT = m_MinRTTCandidate;
@@ -254,8 +253,7 @@ namespace client
 		uint32_t rate = m_NumSentSinceRateUpdate * 1000 / interval;
 		m_NumSentSinceRateUpdate = 0;
 		m_SendRateUpdateTime = ts;
-		// a window sized from the current rate shrinks as soon as the rate dips, which shrinks
-		// the rate further, so keep the best rate of the last few seconds instead
+		// best rate of the last few seconds, a rate following every dip would shrink the window
 		if (rate >= m_SendRate || ts > m_SendRateMaxTime + I2P_UDP_SEND_RATE_EXPIRATION_TIMEOUT)
 		{
 			m_SendRate = rate;
@@ -266,8 +264,7 @@ namespace client
 	size_t UDPConnection::GetMaxNumUnackedDatagrams () const
 	{
 		if (!m_MinRTT || !m_SendRate) return I2P_UDP_MIN_MAX_NUM_UNACKED_DATAGRAMS;
-		// an ack can't arrive sooner than one path delay plus one repliable interval,
-		// so that's how much data the path holds when it's not queueing
+		// bandwidth-delay product for one path delay plus one repliable interval
 		size_t w = I2P_UDP_WINDOW_GAIN * m_SendRate * (m_MinRTT + I2P_UDP_REPLIABLE_DATAGRAM_INTERVAL) / 1000;
 		if (w < I2P_UDP_MIN_MAX_NUM_UNACKED_DATAGRAMS) w = I2P_UDP_MIN_MAX_NUM_UNACKED_DATAGRAMS;
 		if (w > m_MaxWindow) w = m_MaxWindow;
@@ -282,7 +279,7 @@ namespace client
 
 	void UDPConnection::ExpireUnackedDatagrams (uint64_t ts)
 	{
-		// an ack this old is never coming, and while it stays the window base it blocks the tunnel for good
+		// such an ack is never coming and would keep the window blocked
 		while (!m_UnackedDatagrams.empty () &&
 			ts > m_UnackedDatagrams.front ().second + I2P_UDP_MAX_UNACKED_DATAGRAM_TIME)
 			m_UnackedDatagrams.pop_front ();
@@ -299,7 +296,7 @@ namespace client
 
 	uint64_t UDPConnection::GetWindowProbeInterval () const
 	{
-		// an ack can't come back sooner than one RTT, probing more often is pointless
+		// an ack can't come back sooner than one rtt
 		if (!m_RTT) return GetRTO ();
 		return (m_RTT > I2P_UDP_MIN_WINDOW_PROBE_INTERVAL) ? m_RTT : I2P_UDP_MIN_WINDOW_PROBE_INTERVAL;
 	}
@@ -320,8 +317,7 @@ namespace client
 					{
 						auto ts = i2p::util::GetMillisecondsSinceEpoch ();
 						m_NumAckTimeouts++; m_NumAckTimeoutsInRow++;
-						// timeouts alone mean nothing: they are what congestion looks like. only a peer
-						// gone silent proves the path is dead and is worth rebuilding
+						// timeouts happen under congestion, only silence means the path is dead
 						bool resetPath = m_NumAckTimeoutsInRow >= I2P_UDP_MAX_NUM_ACK_TIMEOUTS &&
 							ts > m_LastReceivedTime + I2P_UDP_MAX_UNACKED_DATAGRAM_TIME;
 						bool resetPeerPath = resetPath && ts > m_LastReceivedTime + I2P_UDP_PEER_PATH_RESET_TIMEOUT;
@@ -335,12 +331,10 @@ namespace client
 						if (resetPeerPath) flags |= UDP_SESSION_FLAG_RESET_PATH | UDP_SESSION_FLAG_RESET_SEQN;
 						i2p::util::Mapping options;
 						options.Put (UDP_SESSION_FLAGS, flags);
-						// the probe must carry a seqn, otherwise the peer acks its stale one
-						// and a full window can never be unblocked
+						// without seqn the peer acks a stale one and a full window stays blocked
 						options.Put (UDP_SESSION_SEQN, m_NextSendPacketNum);
 						m_NextSendPacketNum++;
-						// only keep probing while real data is outstanding, otherwise probes feed
-						// themselves: each one arms the timer whose timeout sends the next
+						// probe only while real data is outstanding, otherwise probes feed themselves
 						if (!m_UnackedDatagrams.empty ()) ScheduleAckTimer (0);
 						auto session = GetDatagramSession ();
 						if (session)
@@ -515,7 +509,7 @@ namespace client
 			{
 				auto& s = it.second;
 				auto session = s->GetDatagramSession ();
-				LogPrint (eLogWarning, "UDP Server: stats port=", s->RemotePort, " rtt=", s->m_RTT, "/",
+				LogPrint (eLogDebug, "UDP Server: stats port=", s->RemotePort, " rtt=", s->m_RTT, "/",
 					s->m_RTTVar, "/", s->m_MinRTT, "ms rto=", s->GetRTO (), "ms rate=", s->m_SendRate,
 					"/s window=", s->GetMaxNumUnackedDatagrams (), " unacked=", s->m_UnackedDatagrams.size (),
 					" nextSeqn=", s->m_NextSendPacketNum, " lastRecvSeqn=", s->m_LastReceivedPacketNum,
@@ -919,7 +913,7 @@ namespace client
 		if (ecode != boost::asio::error::operation_aborted)
 		{
 			auto session = GetDatagramSession ();
-			LogPrint (eLogWarning, "UDP Client: stats rtt=", m_RTT, "/", m_RTTVar, "/", m_MinRTT, "ms rto=", GetRTO (),
+			LogPrint (eLogDebug, "UDP Client: stats rtt=", m_RTT, "/", m_RTTVar, "/", m_MinRTT, "ms rto=", GetRTO (),
 				"ms rate=", m_SendRate, "/s window=", GetMaxNumUnackedDatagrams (),
 				" unacked=", m_UnackedDatagrams.size (),
 				" nextSeqn=", m_NextSendPacketNum, " winDrops=", m_NumWindowDrops,

--- a/libi2pd_client/UDPTunnel.h
+++ b/libi2pd_client/UDPTunnel.h
@@ -32,11 +32,23 @@ namespace client
 	const uint64_t I2P_UDP_SESSION_TIMEOUT = 1000 * 60 * 2;
 	const uint64_t I2P_UDP_REPLIABLE_DATAGRAM_INTERVAL = 100; // in milliseconds
 	const uint64_t I2P_UDP_MAX_UNACKED_DATAGRAM_TIME = 8000; // in milliseconds
+	const uint64_t I2P_UDP_MIN_ACK_TIMEOUT = 500; // in milliseconds
+	const uint64_t I2P_UDP_MIN_WINDOW_PROBE_INTERVAL = 50; // in milliseconds
 	const uint64_t I2P_UDP_FIRST_PACKET_RESEND_INTERVAL = 1000; // in milliseconds
-	const size_t I2P_UDP_MAX_NUM_UNACKED_DATAGRAMS = 500;
+	const size_t I2P_UDP_MIN_MAX_NUM_UNACKED_DATAGRAMS = 500;
+	const size_t I2P_UDP_MAX_NUM_UNACKED_DATAGRAMS = 8192;
+	const size_t I2P_UDP_WINDOW_GAIN = 2; // how many bandwidth-delay products window is allowed to reach
+	const uint64_t I2P_UDP_MIN_RTT_EXPIRATION_TIMEOUT = 15000; // in milliseconds
+	const uint64_t I2P_UDP_SEND_RATE_INTERVAL = 200; // in milliseconds
+	const uint64_t I2P_UDP_SEND_RATE_EXPIRATION_TIMEOUT = 5000; // in milliseconds
+	const uint32_t I2P_UDP_MAX_NUM_ACK_TIMEOUTS = 3; // in a row, before routing path gets reset
+	// asking the peer to drop its return path costs us every ack until it rebuilds one, so it's a last resort
+	const uint64_t I2P_UDP_PEER_PATH_RESET_TIMEOUT = 4*I2P_UDP_MAX_UNACKED_DATAGRAM_TIME; // silence, in milliseconds
 
 	/** max size for i2p udp */
 	const size_t I2P_UDP_MAX_MTU = 64*1024;
+	/** local socket buffers, not datagram size */
+	const size_t I2P_UDP_SOCKET_BUFFER_SIZE = 4*1024*1024;
 
 	struct UDPConnection
 	{
@@ -47,16 +59,25 @@ namespace client
 		bool isIdentity = false;
 		uint32_t m_NextSendPacketNum = 1, m_LastReceivedPacketNum = 0;
 		std::list<std::pair<uint32_t, uint64_t> > m_UnackedDatagrams; // list of sent but not acked repliable datagrams(seqn, timestamp) in ascending order
-		uint64_t m_RTT = 0; // milliseconds
+		uint64_t m_RTT = 0, m_RTTVar = 0; // milliseconds, smoothed
+		uint64_t m_MinRTT = 0, m_MinRTTCandidate = 0, m_MinRTTUpdateTime = 0; // m_MinRTT is path delay, without queueing
+		uint64_t m_LastReceivedTime = 0; // milliseconds, anything from the peer
+		uint64_t m_SendRateUpdateTime = 0, m_SendRateMaxTime = 0; // milliseconds
+		uint32_t m_NumSentSinceRateUpdate = 0, m_SendRate = 0; // datagrams per second, best of the last few seconds
+		size_t m_MaxWindow = I2P_UDP_MIN_MAX_NUM_UNACKED_DATAGRAMS;
 
 		boost::asio::steady_timer m_AckTimer;
 		uint32_t m_AckTimerSeqn = 0;
 		bool m_IsSendingAllowed = true;
 		bool m_IsFirstPacket = true;
+		uint32_t m_NumAckTimeoutsInRow = 0;
+		uint64_t m_LastWindowProbeTime = 0; // milliseconds
+		uint32_t m_NumWindowDrops = 0, m_NumAckTimeouts = 0;
 
 		UDPConnection (boost::asio::io_context& service, std::shared_ptr<i2p::datagram::DatagramDestination> destination):
 			m_Destination (destination), m_LastRepliableDatagramTime (0), m_AckTimer (service) {};
 		void SetIdentity (const i2p::data::IdentHash& ident) { Identity = ident; isIdentity = true; };
+		void SetMaxWindow (size_t w) { m_MaxWindow = w; };
 
 		virtual ~UDPConnection () { Stop (); };
 		virtual void Start () {};
@@ -64,6 +85,13 @@ namespace client
 
 		void Acked (uint32_t seqn);
 		void ScheduleAckTimer (uint32_t seqn);
+		void UpdateRTT (uint64_t rtt, uint64_t ts);
+		void UpdateSendRate (uint32_t numDatagrams, uint64_t ts);
+		uint64_t GetRTO () const;
+		uint64_t GetWindowProbeInterval () const;
+		size_t GetMaxNumUnackedDatagrams () const;
+		bool IsWindowFull () const;
+		void ExpireUnackedDatagrams (uint64_t ts);
 
 		std::shared_ptr<i2p::datagram::DatagramSession> GetDatagramSession ();
 	};
@@ -132,6 +160,7 @@ namespace client
 			std::shared_ptr<ClientDestination> GetLocalDestination () const { return m_LocalDest; }
 
 			void SetUniqueLocal (bool isUniqueLocal = true) { m_IsUniqueLocal = isUniqueLocal; }
+			void SetMaxWindow (size_t w) { m_MaxWindow = w; }
 
 		private:
 
@@ -140,6 +169,9 @@ namespace client
 			void HandleRecvFromI2PRaw (uint16_t fromPort, uint16_t toPort, const uint8_t * buf, size_t len);
 			UDPSessionPtr ObtainUDPSession (const i2p::data::IdentityEx& from, uint16_t localPort, uint16_t remotePort);
 			uint32_t GetSessionIndex (uint16_t fromPort, uint16_t toPort) const { return ((uint32_t)fromPort << 16) + toPort; }
+
+			void ScheduleStatsTimer ();
+			void HandleStatsTimer (const boost::system::error_code& ecode);
 
 		private:
 
@@ -153,6 +185,9 @@ namespace client
 			UDPSessionPtr m_LastSession;
 			uint16_t m_inPort;
 			bool m_Gzip;
+			uint32_t m_NumRawNoSession = 0;
+			size_t m_MaxWindow = I2P_UDP_MIN_MAX_NUM_UNACKED_DATAGRAMS;
+			std::unique_ptr<boost::asio::steady_timer> m_StatsTimer;
 
 		public:
 
@@ -199,6 +234,9 @@ namespace client
 			void ScheduleKeepAliveTimer ();
 			void HandleKeepAliveTimer (const boost::system::error_code& ecode);
 
+			void ScheduleStatsTimer ();
+			void HandleStatsTimer (const boost::system::error_code& ecode);
+
 		private:
 
 			const std::string m_Name;
@@ -218,6 +256,7 @@ namespace client
 			std::shared_ptr<UDPConvo> m_LastSession;
 			uint32_t m_KeepAliveInterval = 0;
 			std::unique_ptr<boost::asio::steady_timer> m_KeepAliveTimer;
+			std::unique_ptr<boost::asio::steady_timer> m_StatsTimer;
 
 		public:
 

--- a/libi2pd_client/UDPTunnel.h
+++ b/libi2pd_client/UDPTunnel.h
@@ -37,12 +37,11 @@ namespace client
 	const uint64_t I2P_UDP_FIRST_PACKET_RESEND_INTERVAL = 1000; // in milliseconds
 	const size_t I2P_UDP_MIN_MAX_NUM_UNACKED_DATAGRAMS = 500;
 	const size_t I2P_UDP_MAX_NUM_UNACKED_DATAGRAMS = 8192;
-	const size_t I2P_UDP_WINDOW_GAIN = 2; // how many bandwidth-delay products window is allowed to reach
+	const size_t I2P_UDP_WINDOW_GAIN = 2; // in bandwidth-delay products
 	const uint64_t I2P_UDP_MIN_RTT_EXPIRATION_TIMEOUT = 15000; // in milliseconds
 	const uint64_t I2P_UDP_SEND_RATE_INTERVAL = 200; // in milliseconds
 	const uint64_t I2P_UDP_SEND_RATE_EXPIRATION_TIMEOUT = 5000; // in milliseconds
 	const uint32_t I2P_UDP_MAX_NUM_ACK_TIMEOUTS = 3; // in a row, before routing path gets reset
-	// asking the peer to drop its return path costs us every ack until it rebuilds one, so it's a last resort
 	const uint64_t I2P_UDP_PEER_PATH_RESET_TIMEOUT = 4*I2P_UDP_MAX_UNACKED_DATAGRAM_TIME; // silence, in milliseconds
 
 	/** max size for i2p udp */
@@ -60,10 +59,10 @@ namespace client
 		uint32_t m_NextSendPacketNum = 1, m_LastReceivedPacketNum = 0;
 		std::list<std::pair<uint32_t, uint64_t> > m_UnackedDatagrams; // list of sent but not acked repliable datagrams(seqn, timestamp) in ascending order
 		uint64_t m_RTT = 0, m_RTTVar = 0; // milliseconds, smoothed
-		uint64_t m_MinRTT = 0, m_MinRTTCandidate = 0, m_MinRTTUpdateTime = 0; // m_MinRTT is path delay, without queueing
-		uint64_t m_LastReceivedTime = 0; // milliseconds, anything from the peer
+		uint64_t m_MinRTT = 0, m_MinRTTCandidate = 0, m_MinRTTUpdateTime = 0; // path delay, without queueing
+		uint64_t m_LastReceivedTime = 0; // milliseconds, any datagram from the peer
 		uint64_t m_SendRateUpdateTime = 0, m_SendRateMaxTime = 0; // milliseconds
-		uint32_t m_NumSentSinceRateUpdate = 0, m_SendRate = 0; // datagrams per second, best of the last few seconds
+		uint32_t m_NumSentSinceRateUpdate = 0, m_SendRate = 0; // datagrams per second
 		size_t m_MaxWindow = I2P_UDP_MIN_MAX_NUM_UNACKED_DATAGRAMS;
 
 		boost::asio::steady_timer m_AckTimer;

--- a/libi2pd_client/UDPTunnel.h
+++ b/libi2pd_client/UDPTunnel.h
@@ -36,6 +36,7 @@ namespace client
 	const uint64_t I2P_UDP_MIN_WINDOW_PROBE_INTERVAL = 50; // in milliseconds
 	const uint64_t I2P_UDP_FIRST_PACKET_RESEND_INTERVAL = 1000; // in milliseconds
 	const size_t I2P_UDP_MIN_MAX_NUM_UNACKED_DATAGRAMS = 500;
+	const size_t I2P_UDP_DEFAULT_MAX_NUM_UNACKED_DATAGRAMS = 1000;
 	const size_t I2P_UDP_MAX_NUM_UNACKED_DATAGRAMS = 8192;
 	const size_t I2P_UDP_WINDOW_GAIN = 2; // in bandwidth-delay products
 	const uint64_t I2P_UDP_MIN_RTT_EXPIRATION_TIMEOUT = 15000; // in milliseconds


### PR DESCRIPTION
Длительный акт шизофрении, выводящий UDP-туннели (Wireguard) на длине 0-0 до 120Mbsec (в пике) в режиме ntcp2 only и до 75 Mbsec на ssu2 only. Пинги на ssu2 почти клирнет, на ntcp2 - x2 от клирнета. Всё проверено на практике, в том числе обычные стандартные туннели - регрессии нет.