### PR TITLE
don't add config options twice on repeated Init

### DIFF
--- a/libi2pd/Config.cpp
+++ b/libi2pd/Config.cpp
@@ -40,6 +40,13 @@ namespace config {
 
 	void Init()
 	{
+		// register options once, they never change; drop stored values because
+		// store() keeps the ones set by a previous Init
+		m_Options.clear();
+		static bool optionsRegistered = false;
+		if (optionsRegistered) return;
+		optionsRegistered = true;
+
 		options_description general("General options");
 		general.add_options()
 			("help",                                                          "Show this message")


### PR DESCRIPTION
Fix for #2345.

config::Init() added every option description to the global m_OptionsDesc on each call, so a second InitI2P made every name ambiguous and parsing failed with "option '--datadir' is ambiguous". Options are now registered once. Stored values are cleared on each Init, because boost's store() keeps the value set by a previous run instead of overwriting it.

Tested on Linux, before and after: Init + ParseCmdline and InitI2P/TerminateI2P twice, full build without warnings, make -C tests, and a normal daemon run.