### PR TITLE
protect addressbook addresses with mutex

### DIFF
--- a/libi2pd_client/AddressBook.cpp
+++ b/libi2pd_client/AddressBook.cpp
@@ -482,6 +482,7 @@ namespace client
 
 	std::shared_ptr<const Address> AddressBook::FindAddress (std::string_view address)
 	{
+		std::lock_guard<std::mutex> l(m_AddressBookMutex);
 		auto it = m_Addresses.find (address);
 		if (it != m_Addresses.end ())
 			return it->second;
@@ -513,6 +514,7 @@ namespace client
 
 	void AddressBook::InsertAddress (const std::string& address, const std::string& jump)
 	{
+		std::lock_guard<std::mutex> l(m_AddressBookMutex);
 		auto pos = jump.find(".b32.i2p");
 		if (pos != std::string::npos)
 		{
@@ -909,7 +911,10 @@ namespace client
 			// TODO: verify from
 			i2p::data::IdentHash hash(buf + 8);
 			if (!hash.IsZero ())
+			{
+				std::lock_guard<std::mutex> l(m_AddressBookMutex);
 				m_Addresses[address] = std::make_shared<Address>(hash);
+			}
 			else
 				LogPrint (eLogInfo, "AddressBook: Lookup response: ", address, " not found");
 		}


### PR DESCRIPTION
Fix for #2330.

m_Addresses is a std::map shared between threads, but m_AddressBookMutex was taken in LoadHostsFromStream only. FindAddress walks the tree with no lock and is called from the proxy thread on every request, so a lookup can run while the subscription thread rebalances the tree after an insert.

Now FindAddress, InsertAddress and the write in HandleLookupResponse take the same mutex. No caller of them holds it, and the locked part of LoadHostsFromStream does not call them, so there is no recursion.

Tested on Linux under ThreadSanitizer with proxy traffic and an address book subscription: 8 reports on m_Addresses became 0, distinct races in that scenario went from 28 to 19. Full build without warnings, make -C tests, normal daemon run.
