### PR TITLE
keep streaming packets pool alive for streams

### DIFF
--- a/libi2pd/Streaming.cpp
+++ b/libi2pd/Streaming.cpp
@@ -112,7 +112,7 @@ namespace stream
 		m_IsWinDropped (true), m_IsChoking2 (false), m_IsChoking3 (false), m_IsClientChoked (false), m_IsClientChoked2 (false),
 		m_IsTimeOutResend (false), m_IsImmediateAckRequested (false), m_IsRemoteLeaseChangeInProgress (false),
 		m_IsBufferEmpty (false), m_IsJavaClient (false), m_DontSign (local.GetOwner ()->IsStreamingDontSign ()),
-		m_LocalDestination (local), m_RemoteLeaseSet (remote), m_ReceiveTimer (m_Service),
+		m_LocalDestination (local), m_PacketsPool (local.GetPacketsPool ()), m_RemoteLeaseSet (remote), m_ReceiveTimer (m_Service),
 		m_SendTimer (m_Service), m_ResendTimer (m_Service), m_AckSendTimer (m_Service), m_NumSentBytes (0),
 		m_NumReceivedBytes (0), m_Port (port), m_RTT (INITIAL_RTT), m_MinRTT (INITIAL_RTT),
 		m_SlowRTT (INITIAL_RTT), m_FastRTT (INITIAL_RTT), m_WindowSize (INITIAL_WINDOW_SIZE),
@@ -146,7 +146,7 @@ namespace stream
 		m_IsWinDropped (true), m_IsChoking2 (false), m_IsChoking3 (false), m_IsClientChoked (false), m_IsClientChoked2 (false),
 		m_IsTimeOutResend (false), m_IsImmediateAckRequested (false), m_IsRemoteLeaseChangeInProgress (false),
 		m_IsBufferEmpty (false), m_IsJavaClient (false), m_DontSign (local.GetOwner ()->IsStreamingDontSign ()),
-		m_LocalDestination (local),m_ReceiveTimer (m_Service), m_SendTimer (m_Service),
+		m_LocalDestination (local), m_PacketsPool (local.GetPacketsPool ()), m_ReceiveTimer (m_Service), m_SendTimer (m_Service),
 		m_ResendTimer (m_Service), m_AckSendTimer (m_Service),m_NumSentBytes (0), m_NumReceivedBytes (0),
 		m_Port (0), m_RTT (INITIAL_RTT), m_MinRTT (INITIAL_RTT), m_SlowRTT (INITIAL_RTT), m_FastRTT (INITIAL_RTT),
 		m_WindowSize (INITIAL_WINDOW_SIZE), m_MaxWindowSize (local.GetOwner ()->GetStreamingMaxWindowSize ()),
@@ -204,17 +204,17 @@ namespace stream
 		{
 			auto packet = m_ReceiveQueue.front ();
 			m_ReceiveQueue.pop ();
-			m_LocalDestination.DeletePacket (packet);
+			m_PacketsPool->Release (packet);
 		}
 
 		m_NACKedPackets.clear ();
 
 		for (auto it: m_SentPackets)
-			m_LocalDestination.DeletePacket (it);
+			m_PacketsPool->Release (it);
 		m_SentPackets.clear ();
 
 		for (auto it: m_SavedPackets)
-			m_LocalDestination.DeletePacket (it);
+			m_PacketsPool->Release (it);
 		m_SavedPackets.clear ();
 	}
 
@@ -2134,6 +2134,7 @@ namespace stream
 	}
 
 	StreamingDestination::StreamingDestination (std::shared_ptr<i2p::client::ClientDestination> owner, uint16_t localPort, bool gzip):
+		m_PacketsPool (std::make_shared<i2p::util::MemoryPool<Packet> >()),
 		m_Owner (owner), m_LocalPort (localPort), m_Gzip (gzip),
 		m_PendingIncomingTimer (m_Owner->GetService ()),
 		m_LastCleanupTime (i2p::util::GetSecondsSinceEpoch ())
@@ -2358,7 +2359,7 @@ namespace stream
 		auto ts = i2p::util::GetSecondsSinceEpoch ();
 		if (m_Streams.empty () || ts > m_LastCleanupTime + STREAMING_DESTINATION_POOLS_CLEANUP_INTERVAL)
 		{
-			m_PacketsPool.CleanUp ();
+			m_PacketsPool->CleanUp ();
 			m_I2NPMsgsPool.CleanUp ();
 			if (!m_NumIncomingConnectionsPerSecond.empty ())
 			{

--- a/libi2pd/Streaming.h
+++ b/libi2pd/Streaming.h
@@ -284,6 +284,8 @@ namespace stream
 				m_IsClientChoked2, m_IsTimeOutResend, m_IsImmediateAckRequested,
 				m_IsRemoteLeaseChangeInProgress, m_IsBufferEmpty, m_IsJavaClient, m_DontSign;
 			StreamingDestination& m_LocalDestination;
+			// own reference to the pool: the destination can be gone by the time we are destroyed
+			std::shared_ptr<i2p::util::MemoryPool<Packet> > m_PacketsPool;
 			std::shared_ptr<const i2p::data::IdentityEx> m_RemoteIdentity;
 			std::shared_ptr<const i2p::crypto::Verifier> m_TransientVerifier; // in case of offline key
 			std::shared_ptr<const i2p::data::LeaseSet> m_RemoteLeaseSet;
@@ -347,8 +349,10 @@ namespace stream
 			void HandleDataMessagePayload (const uint8_t * buf, size_t len, i2p::garlic::ECIESX25519AEADRatchetSession * from);
 			std::shared_ptr<I2NPMessage> CreateDataMessage (const uint8_t * payload, size_t len, uint16_t toPort, bool checksum = true, bool gzip = false);
 
-			Packet * NewPacket () { return m_PacketsPool.Acquire(); }
-			void DeletePacket (Packet * p) { return m_PacketsPool.Release(p); }
+			Packet * NewPacket () { return m_PacketsPool->Acquire(); }
+			void DeletePacket (Packet * p) { return m_PacketsPool->Release(p); }
+			// streams keep the pool alive: pending handlers may outlive this destination
+			std::shared_ptr<i2p::util::MemoryPool<Packet> > GetPacketsPool () const { return m_PacketsPool; }
 			uint32_t GetRandom ();
 
 		private:
@@ -361,7 +365,7 @@ namespace stream
 
 		private:
 
-            i2p::util::MemoryPool<Packet> m_PacketsPool;
+            std::shared_ptr<i2p::util::MemoryPool<Packet> > m_PacketsPool;
 			i2p::util::MemoryPool<I2NPMessageBuffer<I2NP_MAX_SHORT_MESSAGE_SIZE> > m_I2NPMsgsPool;
 
 			std::shared_ptr<i2p::client::ClientDestination> m_Owner;


### PR DESCRIPTION
Fix for a heap-use-after-free during config reload, found with AddressSanitizer by uu.

ClientDestination::Stop clears m_StreamingDestinationsByPorts, so a StreamingDestination and its packets pool are destroyed. The io_context of the destination is destroyed later, because RunnableClientDestination lists RunnableService before ClientDestination and bases are destroyed in reverse order. Handlers still queued in that io_context hold streams, so ~Stream runs after the pool is gone and CleanUp returns packets into freed memory. The base order cannot simply be swapped: ClientDestination is constructed from GetIOService of RunnableService.

The pool is still one per StreamingDestination and is still created once, in its constructor. It is held by a shared_ptr now, and a stream copies that pointer instead of reaching the pool through the destination, so the pool outlives the destination for as long as any stream can still return packets into it. No pool is ever created per stream, and nothing changes per packet. Only CleanUp is changed to use it directly, the other call sites run while the destination is alive.

Reproduced and verified on Linux under AddressSanitizer, reloading a config that drops a tunnel while its streams are in flight: without the change the report appears after 10 destination teardowns, with the change there is none after 29. Full build without warnings, make -C tests.