### PR TITLE
use std::remove instead of std::erase for C++17

### DIFF
--- a/libi2pd_client/I2PTunnel.cpp
+++ b/libi2pd_client/I2PTunnel.cpp
@@ -6,6 +6,7 @@
 * See full license text in LICENSE file at top of project tree
 */
 
+#include <algorithm>
 #include <cassert>
 #include <boost/algorithm/string.hpp>
 #include "Base.h"
@@ -710,7 +711,7 @@ namespace client
 		std::vector<std::string> destinations;
 		boost::split (destinations, destination, boost::is_any_of (","), boost::token_compress_on);
 		for (auto& it: destinations) boost::trim (it);
-		std::erase (destinations, "");
+		destinations.erase (std::remove (destinations.begin (), destinations.end (), ""), destinations.end ());
 		return destinations;
 	}
 


### PR DESCRIPTION
std::erase is C++20 and the build has to keep working with C++17, so this replaces it with the erase-remove idiom and adds the missing <algorithm> include.

My fault, it came in with #2475. Checked with -std=c++17 -fsyntax-only on the file and with a full build.
