### PR TITLE
round-robin over several outproxies in http proxy

### DIFF
--- a/libi2pd_client/HTTPProxy.cpp
+++ b/libi2pd_client/HTTPProxy.cpp
@@ -6,6 +6,7 @@
 * See full license text in LICENSE file at top of project tree
 */
 
+#include <algorithm>
 #include <cstring>
 #include <cassert>
 #include <string>
@@ -14,6 +15,7 @@
 #include <memory>
 #include <set>
 #include <boost/asio.hpp>
+#include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <mutex>
 
@@ -792,8 +794,20 @@ namespace proxy
 	HTTPProxy::HTTPProxy(const std::string& name, const std::string& address, uint16_t port,
 	    const std::string & outproxy, bool addresshelper, bool senduseragent, std::shared_ptr<i2p::client::ClientDestination> localDestination):
 		TCPIPAcceptor (address, port, localDestination ? localDestination : i2p::client::context.GetSharedLocalDestination ()),
-		m_Name (name), m_OutproxyUrl (outproxy), m_Addresshelper (addresshelper), m_SendUserAgent (senduseragent)
+		m_Name (name), m_NextOutproxy (0), m_Addresshelper (addresshelper), m_SendUserAgent (senduseragent)
 	{
+		// outproxy is a comma separated list, the same way a client tunnel takes several destinations
+		boost::split (m_OutproxyUrls, outproxy, boost::is_any_of (","), boost::token_compress_on);
+		for (auto& it: m_OutproxyUrls) boost::trim (it);
+		m_OutproxyUrls.erase (std::remove (m_OutproxyUrls.begin (), m_OutproxyUrls.end (), ""), m_OutproxyUrls.end ());
+	}
+
+	std::string HTTPProxy::GetOutproxyURL ()
+	{
+		if (m_OutproxyUrls.empty ()) return "";
+		auto url = m_OutproxyUrls[m_NextOutproxy];
+		m_NextOutproxy = (m_NextOutproxy + 1) % m_OutproxyUrls.size ();
+		return url;
 	}
 
 	std::shared_ptr<i2p::client::I2PServiceHandler> HTTPProxy::CreateHandler(std::shared_ptr<boost::asio::ip::tcp::socket> socket)

--- a/libi2pd_client/HTTPProxy.h
+++ b/libi2pd_client/HTTPProxy.h
@@ -23,7 +23,8 @@ namespace proxy
 				HTTPProxy(name, address, port, "", true, false, localDestination) {} ;
 			~HTTPProxy() {};
 
-			std::string GetOutproxyURL() const { return m_OutproxyUrl; }
+			// picks the next outproxy, so several of them are used in turn
+			std::string GetOutproxyURL();
 			bool GetHelperSupport() const { return m_Addresshelper; }
 			bool GetSendUserAgent () const { return m_SendUserAgent; }
 
@@ -36,7 +37,8 @@ namespace proxy
 		private:
 
 			std::string m_Name;
-			std::string m_OutproxyUrl;
+			std::vector<std::string> m_OutproxyUrls;
+			size_t m_NextOutproxy;
 			bool m_Addresshelper, m_SendUserAgent;
 	};
 } // http


### PR DESCRIPTION
httpproxy.outproxy now takes a comma separated list and the proxy picks the next one for every request, the same way a client tunnel picks the next destination since #2475.

Tested on Linux: with two outproxies in the config, eight requests to a host outside I2P were split four and four between them, which the proxy already logs itself. Build without warnings, make -C tests, and the file checked with -std=c++17.
