### PR TITLE
use base64 from boost::beast for basic authorization

### DIFF
--- a/daemon/HTTPServer.cpp
+++ b/daemon/HTTPServer.cpp
@@ -1275,7 +1275,7 @@ namespace http {
 		auto provided = req.GetHeader ("Authorization");
 		if (provided.length () > 0)
 		{
-			std::string expected = "Basic " + i2p::data::ToBase64Standard (user + ":" + pass);
+			std::string expected = i2p::http::CreateBasicAuthorizationString (user, pass);
 			if (expected == provided) return true;
 		}
 

--- a/libi2pd/Base.cpp
+++ b/libi2pd/Base.cpp
@@ -201,17 +201,6 @@ namespace data
 		return outCount;
 	}
 
-	std::string ToBase64Standard (std::string_view in)
-	{
-		auto str = ByteStreamToBase64 ((const uint8_t *)in.data (), in.length ());
-		// replace '-' by '+' and '~' by '/'
-		for (auto& ch: str)
-			if (ch == '-')
-				ch = '+';
-			else if (ch == '~')
-				ch = '/';
-		return str;
-	}
 
 	/*
 	*

--- a/libi2pd/Base.h
+++ b/libi2pd/Base.h
@@ -45,7 +45,6 @@ namespace data
 		return 4 * d.quot;
 	}	
 
-	std::string ToBase64Standard (std::string_view in); // using standard table, for Proxy-Authorization
 	
 } // data
 } // i2p

--- a/libi2pd/HTTP.cpp
+++ b/libi2pd/HTTP.cpp
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <ctime>
 #include <charconv>
+#include <boost/beast/core/detail/base64.hpp>
 #include "util.h"
 #include "Base.h"
 #include "HTTP.h"
@@ -625,7 +626,10 @@ namespace http
 	std::string CreateBasicAuthorizationString (const std::string& user, const std::string& pass)
 	{
 		if (user.empty () && pass.empty ()) return "";
-		return "Basic " + i2p::data::ToBase64Standard (user + ":" + pass);
+		auto credentials = user + ":" + pass;
+		std::string encoded (boost::beast::detail::base64::encoded_size (credentials.length ()), 0);
+		encoded.resize (boost::beast::detail::base64::encode (encoded.data (), credentials.data (), credentials.length ()));
+		return "Basic " + encoded;
 	}
 
 } // http


### PR DESCRIPTION
ToBase64Standard encoded with the I2P alphabet and then patched '-' into '+' and '~' into '/'. Boost.Beast is a dependency already, so its base64 does the same thing without the patching.

CreateBasicAuthorizationString now uses it, and the web console builds its expected header with that same function instead of repeating the same two lines, so the encoding lives in one place. ToBase64Standard had no other users and is gone.

Same output as before: the I2P alphabet differs from the standard one only in those two characters, so what the old code produced was already standard base64 and stored console passwords keep working. Checked against known values, including padded and unpadded lengths and a password that encodes to '+' and '/'. Build without warnings, make -C tests, and the file checked with -std=c++17.
