### PR TITLE
duplicated subsession id was never detected

### DIFF
--- a/libi2pd_client/SAM.cpp
+++ b/libi2pd_client/SAM.cpp
@@ -878,7 +878,7 @@ namespace client
 			auto masterSession = std::static_pointer_cast<SAMMasterSession>(session);
 			auto params = ExtractParams (buf);
 			std::string_view id = params[SAM_PARAM_ID];
-			if (masterSession->subsessions.count (id) > 1)
+			if (masterSession->subsessions.count (id) > 0)
 			{
 				// session exists
 				SendMessageReply (SAM_SESSION_CREATE_DUPLICATED_ID, false);


### PR DESCRIPTION
subsessions is a std::set, so count returns 0 or 1 and the check for a duplicated subsession id could never fire.

Behaviour does not change: a duplicate is still refused, just a little later, by AddSession. Checked on Linux with both builds, SESSION ADD with an id that already exists answers DUPLICATED_ID either way. Build without warnings, make -C tests.
