### PR TITLE
openbsd: fix a issue from IRC chat

### DIFF
--- a/daemon/Daemon.cpp
+++ b/daemon/Daemon.cpp
@@ -12,10 +12,10 @@
 
 #ifdef __OpenBSD__
 #	include<unistd.h>
+#	include<filesystem>
 #endif
 
 #include "Daemon.h"
-
 #include "Config.h"
 #include "Log.h"
 #include "FS.h"
@@ -140,15 +140,31 @@ namespace util
 		};
 		auto unveil_path = [](std::string path, std::string rules = "r")
 		{
+			// https://stackoverflow.com/questions/83439/remove-spaces-from-stdstring-in-c
+			path.erase(remove_if(path.begin(), path.end(), isspace), path.end());
 			if(path=="")
 			{
 				LogPrint(eLogDebug, "empty path for unveil");
 				return;
 			}
+			if ( (!std::filesystem::exists(path) && !std::filesystem::is_directory(path)) ) 
+			{
+				{
+					std::ofstream f{path}; 
+					if(!f)
+					{
+						LogPrint(eLogError, "can't create an empty file " + path);
+						throw std::runtime_error("Can't create a file and it's not directory");
+					}
+				}
+			}
 			if ( unveil(path.c_str(), rules.c_str()) == -1 )
 			{
 				LogPrint(eLogError, "Can't unveil " + path + " with rules " + rules);
-				throw std::runtime_error("can't unveil");
+				bool ignore_unveil;
+				i2p::config::GetOption("openbsd.unveil_ignore", ignore_unveil);
+				if(!ignore_unveil)
+					throw std::runtime_error("can't unveil");
 			}
 			LogPrint(eLogInfo, "unveil " + path + " with rules " + rules);
 		};

--- a/libi2pd/Config.cpp
+++ b/libi2pd/Config.cpp
@@ -410,6 +410,7 @@ namespace config {
 			("openbsd.unveil_file", value<std::string>()->default_value(""), "OpenBSD file with unveil rules")
 			("openbsd.unveil_enabled", value<bool>()->default_value(true),     "use unveil rues")
 			("openbsd.pledge_enabled", value<bool>()->default_value(true),     "use pledge rules")
+			("openbsd.unveil_ignore", value<bool>()->default_value(false),     "ignore unveil errors")
 			;
 #endif
 


### PR DESCRIPTION
```
* uebok (huesos@zpbahf2bvlycl4lik6t47i4jhgmf5uxb4na547kwsm5fpga7hk3q.b32.i2p) был добавлен
* sonja вышел (Ping timeout: 120 seconds)
<uebok> Всем добрый вечер. Я тут тестировал работу unveil в i2pd и заметил такую проблему. В конфигурации по-умолчанию (т.е я не использую файл с кастомными правилами) роутер просто не запускается
<uebok> Я решил посмотреть в чем проблема и выяснил, что по дкфолту в unveil пихаются некорректные данные
<uebok> А именно: туда может передаться пустой unveil_file и не созданный logfile
<ovverride> uebok, привет уважаемый уебок. установи последний коммит, сделай git clone, скомпилируй. Либо, скажи запускаешь через rc.d, либо через ./i2pd / i2pd просто в shell
<ovverride> Какую выдает ошибку?
<ovverride> $ i2pd --version
<ovverride> i2pd version 2.61.0 (0.9.70)
<ovverride> $ i2pd                                                                                                                                                              
<ovverride> 22:46:06@623/info - unveil /home/user/.i2pd with rules rwc
<ovverride> 22:46:06@623/info - unveil /home/user/.i2pd/tunnels.d with rules r
<ovverride> 22:46:06@623/info - unveil /home/user/.i2pd/certificates with rules r
<ovverride> 22:46:06@623/info - unveil /home/user/.i2pd/tunnels.conf with rules r
<ovverride> 22:46:06@623/info - unveil /home/user/.i2pd/i2pd.conf with rules r
<ovverride> 22:46:06@623/info - unveil /home/user/.i2pd/i2pd.pid with rules rwc
<ovverride> 22:46:06@623/info - unveil /home/user/.i2pd/logfile with rules rwc
<ovverride> 22:46:06@623/info - unveil /home/user/.i2pd/i2pcontrol.crt.pem with rules rwc
<ovverride> 22:46:06@623/info - unveil /home/user/.i2pd/i2pcontrol.key.pem with rules rwc
<ovverride> 22:46:06@623/none - i2pd v2.61.0 (0.9.70) starting...
<ovverride> У вас старый получается i2pd может? rcctl у меня так же запускает с unveil, с pledge
<uebok> ошибка: libc++abi: terminating due to uncaught exception of type std::runtime_error: can't unveil
<ovverride> Хммм, а какая папка?
<uebok> папка для чего?
<ovverride> Файл/папка, которую i2pd пытается unveil'ить
<ovverride> lldb путьдоi2pd
<ovverride> run с нужными параметрами
<ovverride> или скинь core файл
<ovverride> если не умеешь
<uebok> я же написал. я запускал роутер вот с таким конфигом для опенбсд
<uebok> #[openbsd]
<uebok> #unveil_enabled = true
<uebok> #pledge_enabled = true
<ovverride> Хорошо, он по умолчанию true
<uebok> только они раскоменчены были
<ovverride> Ну у меня сейчас роутер запущен с pledge и unveil?
<ovverride> Можешь сказать что он не может у тебя unveil'ить там в логах пишет
<uebok> проблема в том, при отсутсвии unveil_file, он попытается заанвеилить пустуб строку
<uebok> т.к в коде нет валидации того, чуществует ли этот параметр
<ovverride> тебе не нужно unveil_file указывать
<ovverride> он по умоланию и должен быть пустым, ладно?
<uebok> так в этом и проблема
<ovverride> В этом нет проблемы.
<uebok> unveil_path(unveil_file, "r");
<uebok> эта штука выполняется без всякой валидации
<ovverride> if(path=="")
<ovverride> LogPrint(..."empty path for unveil"
* злой_овощ (username@Clk-96B132EC.b32.i2p) был добавлен
<ovverride> Там внутри лямбды проверка на пустой путь?
<ovverride> крч
* злой_овощ теперь известен как hypn_
<uebok>  if(path=="") это где такое?
<ovverride> https://github.com/PurpleI2P/i2pd/blob/openssl/daemon/Daemon.cpp#L143
<ovverride> core вышли, либо lldb, либо логи
<ovverride> либо могу для тебя сделать патч где вместо throw будет выдавать warning
<uebok> а
<ovverride> /eror
<uebok> похоже это у меня где-то проблема, извиняюсь
<ovverride>     LogPrint(eLogError, "Can't unveil " + path + " with rules " + rules);
<ovverride> там путь пишет?
<uebok> я хз, куда у меня эти логи улетают. я просто в консоли эту штуку запускаю
<ovverride> В tty/консоль
<uebok> там пусто
<ovverride> Эх, ладно, я понял ты троллишь
<ovverride> хм
<ovverride> ладно, щас патч сделаю
<ovverride> скомпилирую
<ovverride> я убрал throw + remove_if(path.begin(), path.end(), isspace);
<ovverride> просто Error будет выводить в LogPrint
<uebok> я уже нашел ошибку
<uebok> он у меня пытается logfile заанвейлить
<ovverride> хотя хз стоит ли так делать в плане безопасности, если не получится unveil сделать. Ну по идее тогда дропнит i2pd
<ovverride> если он к файлу обратится
<ovverride> ну unveil(NULL,NULL) throw оставить стоит а если какойто файл не вышло просто Error выдавать, думаю не критично
<uebok> Либо надо перед анвейлами все файлы инициализировать
<uebok> если не может создать, то уже кидает ошибку
<uebok> кстати, а в версии, которая лежит в репах опенка пледжа нет?
* hypn_ (username@Clk-96B132EC.b32.i2p) вышел
<uebok> всем спокойной ночи, я спать
* uebok вышел (Quit: Swirc IRC client)
```