### PR TITLE
sign I2PControl certificate with sha256

### DIFF
--- a/daemon/I2PControl.cpp
+++ b/daemon/I2PControl.cpp
@@ -466,7 +466,7 @@ namespace client
 		X509_NAME_add_entry_by_txt (name, "O",  MBSTRING_ASC, (unsigned char *)I2P_CONTROL_CERTIFICATE_ORGANIZATION, -1, -1, 0); // organization
 		X509_NAME_add_entry_by_txt (name, "CN", MBSTRING_ASC, (unsigned char *)I2P_CONTROL_CERTIFICATE_COMMON_NAME, -1, -1, 0); // common name
 		X509_set_issuer_name (x509, name); // set issuer to ourselves
-		X509_sign (x509, pkey, EVP_sha1 ()); // sign, last param must be NULL for EdDSA
+		X509_sign (x509, pkey, EVP_sha256 ()); // sha1 is rejected as too weak since OpenSSL 3
 		X509_NAME_free (name);
 
 		// save cert


### PR DESCRIPTION
On OpenSSL 3 the self signed certificate is signed with sha1, which is refused
at the default security level, so I2PControl never gets a working SSL context:

    I2PControl: Failed to load ceritifcate: ca md too weak (SSL routines). Recreating
    I2PControl: Can't load certificates
    I2PControl: Handshake error: no shared cipher (SSL routines)

With sha256 the service starts and answers requests. Checked on Debian 13,
OpenSSL 3.5.6, and on a second machine with the same version.
