### PR TITLE
don't put leading comma in ClientServicesInfo reply

### DIFF
--- a/daemon/I2PControlHandlers.cpp
+++ b/daemon/I2PControlHandlers.cpp
@@ -308,13 +308,15 @@ namespace client
 
 	void I2PControlHandlers::ClientServicesInfoHandler (const boost::property_tree::ptree& params, std::ostringstream& results)
 	{
+		bool first = true;
 		for (auto it = params.begin (); it != params.end (); it++)
 		{
 			LogPrint (eLogDebug, "I2PControl: ClientServicesInfo request: ", it->first);
 			auto it1 = m_ClientServicesInfoHandlers.find (it->first);
 			if (it1 != m_ClientServicesInfoHandlers.end ())
 			{
-				if (it != params.begin ()) results << ",";
+				if (!first) results << ",";
+				else first = false;
 				(this->*(it1->second))(results);
 			}
 			else


### PR DESCRIPTION
The comma was written by iterator position, not by what has already been put
into the reply. Token is a required parameter of every request, so a client
that sends it before the service name gets a reply starting with a comma:

    {"id":2,"result":{,"I2PTunnel":{"client":{...

which is not valid JSON. RouterInfoHandler right above does it with a flag,
this makes ClientServicesInfo do the same.
