### PR TITLE
added LocalDestinationInfo I2PControl request

### DIFF
--- a/daemon/I2PControl.cpp
+++ b/daemon/I2PControl.cpp
@@ -90,6 +90,7 @@ namespace client
 		m_MethodHandlers["RouterManager"]      = &I2PControlService::RouterManagerHandler;
 		m_MethodHandlers["NetworkSetting"]     = &I2PControlHandlers::NetworkSettingHandler;
 		m_MethodHandlers["ClientServicesInfo"] = &I2PControlHandlers::ClientServicesInfoHandler;
+		m_MethodHandlers["LocalDestinationInfo"] = &I2PControlHandlers::LocalDestinationInfoHandler;
 
 		// I2PControl
 		m_I2PControlHandlers["i2pcontrol.password"] = &I2PControlService::PasswordHandler;

--- a/daemon/I2PControlHandlers.cpp
+++ b/daemon/I2PControlHandlers.cpp
@@ -100,6 +100,53 @@ namespace client
 		ss << "\"" << name << "\":" << buf.str();
 	}
 
+// LocalDestinationInfo
+
+	void I2PControlHandlers::LocalDestinationInfoHandler (const boost::property_tree::ptree& params, std::ostringstream& results)
+	{
+		auto& addressBook = i2p::client::context.GetAddressBook ();
+		auto addr = addressBook.GetAddress (params.get<std::string> ("destination", ""));
+		auto dest = addr && addr->IsIdentHash () ?
+			i2p::client::context.FindLocalDestination (addr->identHash) : nullptr;
+		if (!dest)
+		{
+			InsertParam (results, "error", std::string ("destination not found"));
+			return;
+		}
+		InsertParam (results, "destination", addressBook.ToAddress (dest->GetIdentHash ()));
+
+		// arrays are written by hand: write_json makes an array only below the root
+		results << ",\"leasesets\":[";
+		bool first = true;
+		for (const auto& it: dest->GetLeaseSetsList ())
+		{
+			if (!it) continue;
+			boost::property_tree::ptree ls;
+			ls.put ("address", addressBook.ToAddress (it->GetIdentHash ()));
+			ls.put ("type", (int)it->GetStoreType ());
+			ls.put ("encType", (int)it->GetEncryptionType ());
+			if (!first) results << ",";
+			first = false;
+			boost::property_tree::write_json (results, ls, false);
+		}
+		results << "],\"streams\":[";
+		first = true;
+		for (const auto& it: dest->GetAllStreams ())
+		{
+			if (!it) continue;
+			auto identity = it->GetRemoteIdentity ();
+			boost::property_tree::ptree st;
+			st.put ("id", it->GetRecvStreamID ());
+			st.put ("destination", identity ? addressBook.ToAddress (identity->GetIdentHash ()) : "");
+			st.put ("sent", it->GetNumSentBytes ());
+			st.put ("received", it->GetNumReceivedBytes ());
+			if (!first) results << ",";
+			first = false;
+			boost::property_tree::write_json (results, st, false);
+		}
+		results << "]";
+	}
+
 // RouterInfo
 
 	void I2PControlHandlers::RouterInfoHandler (const boost::property_tree::ptree& params, std::ostringstream& results)

--- a/daemon/I2PControlHandlers.h
+++ b/daemon/I2PControlHandlers.h
@@ -29,6 +29,7 @@ namespace client
 			void RouterInfoHandler (const boost::property_tree::ptree& params, std::ostringstream& results);
 			void NetworkSettingHandler (const boost::property_tree::ptree& params, std::ostringstream& results);
 			void ClientServicesInfoHandler (const boost::property_tree::ptree& params, std::ostringstream& results);
+			void LocalDestinationInfoHandler (const boost::property_tree::ptree& params, std::ostringstream& results);
 
 		protected:
 

--- a/libi2pd/Destination.cpp
+++ b/libi2pd/Destination.cpp
@@ -1447,13 +1447,9 @@ namespace client
 	{
 		std::vector<std::shared_ptr<const i2p::stream::Stream> > ret;
 		if (m_StreamingDestination)
-		{
-			for (auto& it: m_StreamingDestination->GetStreams ())
-				ret.push_back (it.second);
-		}
+			m_StreamingDestination->GetStreamsList (ret);
 		for (auto& it: m_StreamingDestinationsByPorts)
-			for (auto& it1: it.second->GetStreams ())
-				ret.push_back (it1.second);
+			it.second->GetStreamsList (ret);
 		return ret;
 	}
 

--- a/libi2pd/Destination.cpp
+++ b/libi2pd/Destination.cpp
@@ -1447,9 +1447,12 @@ namespace client
 	{
 		std::vector<std::shared_ptr<const i2p::stream::Stream> > ret;
 		if (m_StreamingDestination)
-			m_StreamingDestination->GetStreamsList (ret);
+			ret = m_StreamingDestination->GetStreamsList ();
 		for (auto& it: m_StreamingDestinationsByPorts)
-			it.second->GetStreamsList (ret);
+		{
+			auto streams = it.second->GetStreamsList ();
+			ret.insert (ret.end (), streams.begin (), streams.end ());
+		}
 		return ret;
 	}
 

--- a/libi2pd/Destination.h
+++ b/libi2pd/Destination.h
@@ -12,6 +12,7 @@
 #include <string.h>
 #include <thread>
 #include <mutex>
+#include <vector>
 #include <memory>
 #include <map>
 #include <unordered_map>
@@ -235,6 +236,16 @@ namespace client
 			// for HTTP only
 			int GetNumRemoteLeaseSets () const { return m_RemoteLeaseSets.size (); };
 			const decltype(m_RemoteLeaseSets)& GetLeaseSets () const { return m_RemoteLeaseSets; };
+			// copy for other threads, unlike GetLeaseSets which hands out the container itself
+			std::vector<std::shared_ptr<i2p::data::LeaseSet> > GetLeaseSetsList () const
+			{
+				std::lock_guard<std::mutex> lock(m_RemoteLeaseSetsMutex);
+				std::vector<std::shared_ptr<i2p::data::LeaseSet> > leaseSets;
+				leaseSets.reserve (m_RemoteLeaseSets.size ());
+				for (const auto& it: m_RemoteLeaseSets)
+					leaseSets.push_back (it.second);
+				return leaseSets;
+			}
 			bool IsEncryptedLeaseSet () const { return m_LeaseSetType == i2p::data::NETDB_STORE_TYPE_ENCRYPTED_LEASESET2; };
 			bool IsPerClientAuth () const { return m_AuthType > 0; };
 	};

--- a/libi2pd/Streaming.cpp
+++ b/libi2pd/Streaming.cpp
@@ -2375,6 +2375,15 @@ namespace stream
 		}
 	}
 
+	std::vector<std::shared_ptr<const Stream> > StreamingDestination::GetStreamsList ()
+	{
+		std::vector<std::shared_ptr<const Stream> > streams;
+		std::lock_guard<std::mutex> l(m_StreamsMutex);
+		for (const auto& it: m_Streams)
+			streams.push_back (it.second);
+		return streams;
+	}
+
 	bool StreamingDestination::DeleteStream (uint32_t recvStreamID)
 	{
 		auto it = m_Streams.find (recvStreamID);

--- a/libi2pd/Streaming.h
+++ b/libi2pd/Streaming.h
@@ -14,6 +14,7 @@
 #include <unordered_map>
 #include <set>
 #include <queue>
+#include <vector>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -391,6 +392,14 @@ namespace stream
 
 			// for HTTP only
 			const decltype(m_Streams)& GetStreams () const { return m_Streams; };
+
+			// copy for other threads, unlike GetStreams which hands out the map itself
+			void GetStreamsList (std::vector<std::shared_ptr<const Stream> >& streams)
+			{
+				std::unique_lock<std::mutex> l(m_StreamsMutex);
+				for (const auto& it: m_Streams)
+					streams.push_back (it.second);
+			}
 	};
 
 //-------------------------------------------------

--- a/libi2pd/Streaming.h
+++ b/libi2pd/Streaming.h
@@ -394,15 +394,7 @@ namespace stream
 			const decltype(m_Streams)& GetStreams () const { return m_Streams; };
 
 			// copy for other threads, unlike GetStreams which hands out the map itself
-			std::vector<std::shared_ptr<const Stream> > GetStreamsList ()
-			{
-				std::unique_lock<std::mutex> l(m_StreamsMutex);
-				std::vector<std::shared_ptr<const Stream> > streams;
-				streams.reserve (m_Streams.size ());
-				for (const auto& it: m_Streams)
-					streams.push_back (it.second);
-				return streams;
-			}
+			std::vector<std::shared_ptr<const Stream> > GetStreamsList ();
 	};
 
 //-------------------------------------------------

--- a/libi2pd/Streaming.h
+++ b/libi2pd/Streaming.h
@@ -394,11 +394,14 @@ namespace stream
 			const decltype(m_Streams)& GetStreams () const { return m_Streams; };
 
 			// copy for other threads, unlike GetStreams which hands out the map itself
-			void GetStreamsList (std::vector<std::shared_ptr<const Stream> >& streams)
+			std::vector<std::shared_ptr<const Stream> > GetStreamsList ()
 			{
 				std::unique_lock<std::mutex> l(m_StreamsMutex);
+				std::vector<std::shared_ptr<const Stream> > streams;
+				streams.reserve (m_Streams.size ());
 				for (const auto& it: m_Streams)
 					streams.push_back (it.second);
+				return streams;
 			}
 	};
 


### PR DESCRIPTION
Fix for #1820

LocalDestinationInfo returns the leasesets a local destination knows and the
streams it has open, so a service with several tunnels can see how loaded each
one is. The destination is given by its address, name to address mapping is
already there in ClientServicesInfo.

GetAllStreams now copies the map under the existing m_StreamsMutex, the list is
walked from another thread while streams are created and deleted. Checked with
thread sanitizer on a live router, 28808 requests while streams came and went:
without the lock it reports a race between the walk and the map, with the lock
there is none.

Both lists come back as JSON arrays and stay arrays when empty. Missing, empty
and malformed addresses answer with an error and no crash.
