### PR TITLE
set subject name in I2PControl certificate

### DIFF
--- a/daemon/I2PControl.cpp
+++ b/daemon/I2PControl.cpp
@@ -465,6 +465,7 @@ namespace client
 		X509_NAME_add_entry_by_txt (name, "C",  MBSTRING_ASC, (unsigned char *)"A1", -1, -1, 0); // country (Anonymous proxy)
 		X509_NAME_add_entry_by_txt (name, "O",  MBSTRING_ASC, (unsigned char *)I2P_CONTROL_CERTIFICATE_ORGANIZATION, -1, -1, 0); // organization
 		X509_NAME_add_entry_by_txt (name, "CN", MBSTRING_ASC, (unsigned char *)I2P_CONTROL_CERTIFICATE_COMMON_NAME, -1, -1, 0); // common name
+		X509_set_subject_name (x509, name);
 		X509_set_issuer_name (x509, name); // set issuer to ourselves
 		X509_sign (x509, pkey, EVP_sha1 ()); // sign, last param must be NULL for EdDSA
 		X509_NAME_free (name);


### PR DESCRIPTION
The certificate i2pd makes for I2PControl has an empty subject: the name is
built and then set as the issuer only. OpenSSL 3 does not take it for self
signed, tries to build a chain and refuses the sha1 signature of that "CA":

    I2PControl: Failed to load ceritifcate: ca md too weak (SSL routines). Recreating
    I2PControl: Can't load certificates
    I2PControl: Handshake error: no shared cipher (SSL routines)

so the service never starts at all. A plain self signed sha1 certificate made
by openssl loads on the same machine without a word, so the signature algorithm
is not the cause and is left alone here.

With the subject set the certificate loads and requests are answered, sha1 kept.
A certificate saved by an older version is replaced on start by the code that is
already there. Checked on Debian 13, OpenSSL 3.5.6.
