### PR TITLE
apply tunnel parameters on reload

### DIFF
--- a/libi2pd_client/ClientContext.cpp
+++ b/libi2pd_client/ClientContext.cpp
@@ -696,6 +696,14 @@ namespace client
 									if (keys != "transient")
 										destinations[keys] = localDestination;
 								}
+								else
+								{
+									// destination is already running, the pool takes new parameters
+									// on the fly, no need to recreate anything
+									localDestination->Reconfigure (options);
+									if (keys != "transient")
+										destinations[keys] = localDestination;
+								}
 							}
 						}
 					}


### PR DESCRIPTION
Tunnel parameters are taken when the destination is made, so a reload never
changed them: FindLocalDestination hands back the running destination and the
options read from the section were dropped on the floor.

Reconfigure is already there and used by I2CP, so the reload calls it. The pool
takes the new numbers as it is, without being torn down: it builds the tunnels
it lacks and lets the extra ones expire. A destination shared by several
tunnels is left alone, only the section that owns it can change it.

Checked on a live router: with inbound and outbound quantity raised from 3 to 8
a reload took the destination from 6 tunnels to 10 within 150 seconds and it
kept climbing, connections through the tunnel stayed alive, and a reload with
an unchanged config leaves everything as it was.
