### PR TITLE
compare tags by value in ordered containers

### DIFF
--- a/libi2pd/Tag.h
+++ b/libi2pd/Tag.h
@@ -14,6 +14,9 @@
 #include <openssl/rand.h>
 #include <string>
 #include <string_view>
+#if __cplusplus >= 202002L // C++20
+#include <compare>
+#endif
 #include "Base.h"
 
 namespace i2p
@@ -35,6 +38,11 @@ namespace data
 			bool operator== (const Tag& other) const { return !memcmp (m_Buf, other.m_Buf, sz); }
 			bool operator!= (const Tag& other) const { return !(*this == other); }
 			bool operator< (const Tag& other) const { return memcmp (m_Buf, other.m_Buf, sz) < 0; }
+#if __cplusplus >= 202002L // C++20
+			// without it std::pair and std::tuple pick the built-in comparison of
+			// the pointer this converts to, and equal tags come out different
+			std::strong_ordering operator<=> (const Tag& other) const { return memcmp (m_Buf, other.m_Buf, sz) <=> 0; }
+#endif
 
 			uint8_t * operator()() { return m_Buf; }
 			const uint8_t * operator()() const { return m_Buf; }


### PR DESCRIPTION
Fix for #2332

Since the switch to C++23 an ordered container keyed by a pair holding an
IdentHash no longer works. std::pair compares through the three way operator,
and for Tag that picks the built in comparison of the pointer Tag converts to
instead of Tag::operator<, so equal tags come out different:

    c++17: pair(a,9021) < pair(b,9021) false both ways, insert finds the key
    c++20: pair(b,9021) < pair(a,9021) true, insert adds a second entry

m_ServerTunnels and m_ServerForwards are keyed like that, so every reload of
the tunnel configuration inserts a server tunnel again instead of finding the
one already there. The old entry is then dropped by the cleanup pass, and its
Stop() resets the acceptor of the destination the new tunnel had just taken,
so the tunnel stops accepting streams.

Checked with two routers on the live network, one serving a local port through
a server tunnel and one reaching it through a client tunnel. Before the change
a reload with no edits at all kills the connection and it does not come back in
four and a half minutes of asking. After the change the same reload answers
again twenty seconds later, and the log says the tunnel already exists instead
of creating one more.
