### PR TITLE
keep the acceptor of a server tunnel through a reload

### DIFF
--- a/libi2pd_client/ClientContext.cpp
+++ b/libi2pd_client/ClientContext.cpp
@@ -262,6 +262,10 @@ namespace client
 		ReadSocksProxy ();
 
 		// handle tunnels
+		// take the acceptors off first, a tunnel still in the config sets its own back
+		// while it is read, incoming streams wait in the queue meanwhile
+		for (auto& it: m_ServerTunnels)
+			it.second->DetachAcceptor ();
 		// reset isUpdated for each tunnel
 		VisitTunnels (false);
 		// reload tunnels
@@ -980,6 +984,8 @@ namespace client
 							ins.first->second->SetLocalDestination (serverTunnel->GetLocalDestination ());
 							ins.first->second->Start ();
 						}
+						else
+							ins.first->second->Accept (); // still in the config, take the acceptor back
 						ins.first->second->isUpdated = true;
 						LogPrint (eLogInfo, "Clients: I2P server tunnel for destination/port ", m_AddressBook.ToAddress(localDestination->GetIdentHash ()), "/", inPort, " already exists");
 					}

--- a/libi2pd_client/I2PTunnel.cpp
+++ b/libi2pd_client/I2PTunnel.cpp
@@ -822,12 +822,23 @@ namespace client
 		Accept ();
 	}
 
-	void I2PServerTunnel::Stop ()
+	void I2PServerTunnel::DetachAcceptor ()
 	{
 		if (m_PortDestination)
 			m_PortDestination->ResetAcceptor ();
 		auto localDestination = GetLocalDestination ();
 		if (localDestination)
+			localDestination->StopAcceptingStreams ();
+	}
+
+	void I2PServerTunnel::Stop ()
+	{
+		if (m_PortDestination)
+			m_PortDestination->ResetAcceptor ();
+		auto localDestination = GetLocalDestination ();
+		// another tunnel on the same destination may hold the acceptor by now,
+		// taking it away would leave that one deaf
+		if (localDestination && localDestination->GetRefCounter () <= 1)
 			localDestination->StopAcceptingStreams ();
 		if (m_Resolver)
 			m_Resolver->cancel ();

--- a/libi2pd_client/I2PTunnel.cpp
+++ b/libi2pd_client/I2PTunnel.cpp
@@ -803,7 +803,7 @@ namespace client
 
 	I2PServerTunnel::I2PServerTunnel (const std::string& name, const std::string& address,
 		uint16_t port, std::shared_ptr<ClientDestination> localDestination, uint16_t inport, bool gzip):
-		I2PService (localDestination), m_IsUniqueLocal(true), m_Name (name), m_Address (address), m_Port (port), m_IsAccessList (false)
+		I2PService (localDestination), m_IsUniqueLocal(true), m_IsDefaultAcceptor (false), m_Name (name), m_Address (address), m_Port (port), m_IsAccessList (false)
 	{
 		m_PortDestination = localDestination->GetStreamingDestination (inport);
 		if (!m_PortDestination) // default destination
@@ -827,19 +827,17 @@ namespace client
 		if (m_PortDestination)
 			m_PortDestination->ResetAcceptor ();
 		auto localDestination = GetLocalDestination ();
-		if (localDestination)
+		// the default acceptor may belong to another tunnel on the same destination
+		if (localDestination && m_IsDefaultAcceptor)
+		{
 			localDestination->StopAcceptingStreams ();
+			m_IsDefaultAcceptor = false;
+		}
 	}
 
 	void I2PServerTunnel::Stop ()
 	{
-		if (m_PortDestination)
-			m_PortDestination->ResetAcceptor ();
-		auto localDestination = GetLocalDestination ();
-		// another tunnel on the same destination may hold the acceptor by now,
-		// taking it away would leave that one deaf
-		if (localDestination && localDestination->GetRefCounter () <= 1)
-			localDestination->StopAcceptingStreams ();
+		DetachAcceptor ();
 		if (m_Resolver)
 			m_Resolver->cancel ();
 
@@ -946,7 +944,10 @@ namespace client
 		if (localDestination)
 		{
 			if (!localDestination->IsAcceptingStreams ()) // set it as default if not set yet
+			{
 				localDestination->AcceptStreams (std::bind (&I2PServerTunnel::HandleAccept, this, std::placeholders::_1));
+				m_IsDefaultAcceptor = true;
+			}
 		}
 		else
 			LogPrint (eLogError, "I2PTunnel: Local destination not set for server tunnel");

--- a/libi2pd_client/I2PTunnel.h
+++ b/libi2pd_client/I2PTunnel.h
@@ -229,6 +229,7 @@ namespace client
 		private:
 
 			bool m_IsUniqueLocal;
+			bool m_IsDefaultAcceptor; // this tunnel is the one accepting on the destination
 			std::string m_Name, m_Address;
 			uint16_t m_Port;
 			boost::asio::ip::tcp::endpoint m_Endpoint;

--- a/libi2pd_client/I2PTunnel.h
+++ b/libi2pd_client/I2PTunnel.h
@@ -213,13 +213,15 @@ namespace client
 
 			const char* GetName() const override { return m_Name.c_str (); }
 
+			void Accept ();
+			void DetachAcceptor (); // called before the tunnels are read again on reload
+
 		private:
 
 			bool Resolve (std::shared_ptr<i2p::stream::Stream> stream);
 			void HandleResolve (const boost::system::error_code& ecode, boost::asio::ip::tcp::resolver::results_type endpoints,
 				std::shared_ptr<i2p::stream::Stream> stream);
 
-			void Accept ();
 			void HandleAccept (std::shared_ptr<i2p::stream::Stream> stream);
 			void Connect (std::shared_ptr<i2p::stream::Stream> stream);
 			virtual std::shared_ptr<I2PTunnelConnection> CreateI2PConnection (std::shared_ptr<i2p::stream::Stream> stream);


### PR DESCRIPTION
A server tunnel takes the acceptor of its destination when it starts and gives
it back when it stops. On a reload the new tunnel is made and started first and
the old one is stopped after, so the old one takes away the acceptor the new one
has just set, and the destination accepts nothing. Incoming streams sit in the
pending queue and are dropped ten seconds later:

    Streaming: Pending incoming timeout expired

That happens whenever a server tunnel is replaced rather than kept, for example
when its port changes, since inport defaults to it and the map is keyed by it.

So the acceptors are taken off before the tunnels are read again, a tunnel that
is still in the config sets its own back while it is read, and a tunnel that is
going away no longer touches the acceptor if something else still holds the
destination. The gap is well under the ten seconds the queue keeps streams for.

Checked with two routers on the live network, one serving a local port through a
server tunnel and one reaching it through a client tunnel. Before the change,
moving the server to another local port and reloading kills the connection and
it does not come back in four and a half minutes. After it the connection
answers from the new port twenty seconds after the reload. A reload with no
edits at all keeps working either way, eight times in a row.
