### PR TITLE
Fix setting C++ standard

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -9,9 +9,6 @@ endif()
 # for debugging
 #set(CMAKE_VERBOSE_MAKEFILE on)
 
-# fix: error C2039: 'string_view': is not a member of 'std'
-# MSVC defaults to C++14
-set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
@@ -327,15 +324,21 @@ if(NOT MSVC)
   CHECK_CXX_COMPILER_FLAG("-std=c++17" CXX17_SUPPORTED)
 
   if(CXX23_SUPPORTED)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++23")
+    set(I2PD_CXX_STANDARD 23)
   elseif(CXX20_SUPPORTED)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++20")
+    set(I2PD_CXX_STANDARD 20)
   elseif(CXX17_SUPPORTED)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
+    set(I2PD_CXX_STANDARD 17)
   else()
     message(SEND_ERROR "C++23 nor C++20 nor C++17 standard not seems to be supported by compiler. Too old version?")
   endif()
+else()
+  # fix: error C2039: 'string_view': is not a member of 'std'
+  # MSVC defaults to C++14
+  set(I2PD_CXX_STANDARD 17)
 endif()
+
+set_target_properties(libi2pd libi2pdclient libi2pdlang PROPERTIES CXX_STANDARD ${I2PD_CXX_STANDARD})
 
 # load includes
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS} ${OPENSSL_INCLUDE_DIR} ${ZLIB_INCLUDE_DIR})
@@ -348,6 +351,7 @@ message(STATUS "Compiler version   : ${CMAKE_CXX_COMPILER_VERSION}")
 message(STATUS "Compiler path      : ${CMAKE_CXX_COMPILER}")
 message(STATUS "Architecture       : ${ARCHITECTURE}")
 message(STATUS "Compiler flags     : ${CMAKE_CXX_FLAGS}")
+message(STATUS "C++ standard       : ${I2PD_CXX_STANDARD}")
 message(STATUS "Install prefix:    : ${CMAKE_INSTALL_PREFIX}")
 message(STATUS "Options:")
 message(STATUS "  HARDENING        : ${WITH_HARDENING}")
@@ -391,6 +395,8 @@ if(WITH_BINARY)
   if(WITH_HARDENING AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set_target_properties("${PROJECT_NAME}" PROPERTIES LINK_FLAGS "-z relro -z now")
   endif()
+
+  set_target_properties("${PROJECT_NAME}" PROPERTIES CXX_STANDARD ${I2PD_CXX_STANDARD})
 
   # FindBoost pulls pthread for thread which is broken for static linking at least on Ubuntu 15.04
   list(GET Boost_LIBRARIES -1 LAST_Boost_LIBRARIES)


### PR DESCRIPTION
The -std=c++X flag was set in three different places, (1) at the beginning of the CMakeLists.txt with `set(CMAKE_CXX_STANDARD)`, later (2) with `CMAKE_CXX_FLAGS` and finally (3) by the combination cmake's CMP0128=NEW policy, some versions of g++ and the settings of CMAKE_CXX_STANDARD_REQUIRED=ON and CMAKE_CXX_EXTENSIONS=OFF.

Because of (1) _or_ (2) the MinGW compiler (and possibly others) would add -std=c++17 to the build arguments _after_ the -std=c++X defined in `CMAKE_CXX_FLAGS` resulting in the c++17 standard being used regardless of what `CMAKE_CXX_FLAGS` has to say.

This patch also applies the c++ standard per target to avoid the `CMAKE_CXX_STANDARD` setting leaking into projects which include this i2pd's CMakeLists.txt.