### PR TITLE
use find in Mapping::Contains

### DIFF
--- a/libi2pd/util.cpp
+++ b/libi2pd/util.cpp
@@ -324,12 +324,10 @@ namespace util
 
 	bool Mapping::Contains (std::string_view param) const
 	{
-#if __cplusplus >= 202002L // C++20
-		return m_Options.contains (param);
-#else
+		// find rather than contains: the heterogeneous contains is missing in some
+		// standard libraries, while find takes the string_view through std::less<>
 		auto it = m_Options.find (param);
 		return it != m_Options.end ();
-#endif
 	}
 
 	void Mapping::CleanUp ()


### PR DESCRIPTION
Fix for #2380

The heterogeneous `contains()` is missing in the standard library used by clang 15 to 17, so the
call there resolves to `contains(const key_type&)` and a `std::string_view` no longer converts. The
`find()` branch that already sits next to it takes the view without any trouble, because the map
carries `std::less<>`, and it costs the same single lookup. So the conditional goes away and `find`
is used always.

Checked that the file compiles with `-std=c++17`, `-std=c++20` and `-std=c++23`, full build is clean
and the unit tests pass.
