### PR TITLE
stop the web console and I2PControl before what they read

### DIFF
--- a/daemon/Daemon.cpp
+++ b/daemon/Daemon.cpp
@@ -579,6 +579,19 @@ namespace util
 	bool Daemon_Singleton::stop()
 	{
 		LogPrint(eLogInfo, "Daemon: Shutting down");
+		// these two serve pages from their own threads, they must go before
+		// anything they read is taken apart
+		if (d.httpServer) {
+			LogPrint(eLogInfo, "Daemon: Stopping HTTP Server");
+			d.httpServer->Stop();
+			d.httpServer = nullptr;
+		}
+		if (d.m_I2PControlService)
+		{
+			LogPrint(eLogInfo, "Daemon: Stopping I2PControl");
+			d.m_I2PControlService->Stop ();
+			d.m_I2PControlService = nullptr;
+		}
 		LogPrint(eLogInfo, "Daemon: Stopping Client");
 		i2p::client::context.Stop();
 		LogPrint(eLogInfo, "Daemon: Stopping Router context");
@@ -602,17 +615,6 @@ namespace util
 		i2p::transport::transports.Stop();
 		LogPrint(eLogInfo, "Daemon: Stopping NetDB");
 		i2p::data::netdb.Stop();
-		if (d.httpServer) {
-			LogPrint(eLogInfo, "Daemon: Stopping HTTP Server");
-			d.httpServer->Stop();
-			d.httpServer = nullptr;
-		}
-		if (d.m_I2PControlService)
-		{
-			LogPrint(eLogInfo, "Daemon: Stopping I2PControl");
-			d.m_I2PControlService->Stop ();
-			d.m_I2PControlService = nullptr;
-		}
 		i2p::crypto::TerminateCrypto ();
 		i2p::log::Logger().Stop();
 


### PR DESCRIPTION
The web console and I2PControl each serve requests from their own thread, and both used to be
stopped at the very end of the shutdown, after the client context, the tunnels, the transports and
the netdb were already taken apart. So a page being rendered at that moment reads structures that
are being freed underneath it.

Caught with AddressSanitizer on a router carrying transit, stopped the way a service manager stops
it (plain kill, not the graceful SIGINT), while the console pages were being requested:

    ERROR: AddressSanitizer: heap-use-after-free
    read  : NetDb::FindRouter (NetDb.cpp:432)
            Tunnel::VisitTunnelHops (Tunnel.cpp:275)
            ShowTunnels (HTTPServer.cpp:783)      <- console thread
    freed : NetDb::Stop (NetDb.cpp:109)
            Daemon_Singleton::stop (Daemon.cpp:588)

So both are stopped first now, before anything they read goes away. Nothing else changes.

Before the change the sanitizer fired on the first round, with eight transit tunnels alive. After it,
three rounds with up to twenty three transit tunnels are clean, and the router still shuts down in
two seconds. Full build is warning free and the unit tests pass.
