### PR TITLE
stop runnable destination in its own thread

### DIFF
--- a/libi2pd/Destination.cpp
+++ b/libi2pd/Destination.cpp
@@ -12,6 +12,7 @@
 #include <set>
 #include <vector>
 #include <charconv>
+#include <future>
 #include <boost/algorithm/string.hpp>
 #include "Crypto.h"
 #include "ECIESX25519AEADRatchetSession.h"
@@ -1680,7 +1681,20 @@ namespace client
 	{
 		if (IsRunning ())
 		{
-			ClientDestination::Stop ();
+			// the destination's own thread may still be handling packets of this
+			// very destination, so tear it down there rather than under the caller
+			if (GetIOService ().get_executor ().running_in_this_thread ())
+				ClientDestination::Stop ();
+			else
+			{
+				std::promise<void> done;
+				boost::asio::post (GetIOService (), [this, &done]()
+					{
+						ClientDestination::Stop ();
+						done.set_value ();
+					});
+				done.get_future ().wait ();
+			}
 			StopIOService ();
 		}
 	}


### PR DESCRIPTION
A destination with its own thread was torn down on the thread that let it go, while its io service was still handling packets of the same destination. AddressSanitizer catches a use-after-free: the free is the assignment of m_StreamingDestination in ClientDestination::Stop, the read is StreamingDestination::DeletePacket from Stream::HandleNextPacket on the destination's thread.

Reproduced on a bench with two SAM sessions in one process and sam.singlethread=false, closing both control sockets in the middle of a transfer: 3 rounds of 4 crashed. With sam.singlethread=true, where both live in one thread, 4 rounds of 4 are clean.

The teardown is now posted into the destination's own io service and waited for, and the service is stopped afterwards. Swapping the two lines would not do: the teardown itself posts work, such as closing streams with a close packet, which would never run on a stopped service.

With the change: 5 rounds of 5 clean, and a server tunnel reload soak is 6 of 6 with the sanitizer silent. Builds without warnings, unit tests pass, C++17 syntax check is fine.