### PR TITLE
recreate addressbook timers when shared destination is replaced

### DIFF
--- a/libi2pd_client/AddressBook.cpp
+++ b/libi2pd_client/AddressBook.cpp
@@ -781,6 +781,31 @@ namespace client
 			m_SubscriptionsUpdateTimer->cancel ();
 	}
 
+	void AddressBook::ResetTimers ()
+	{
+		// both timers run on the shared local destination's service, so they must be
+		// created anew when that destination is replaced
+		auto dest = i2p::client::context.GetSharedLocalDestination ();
+		if (m_SubscriptionsUpdateTimer)
+		{
+			m_SubscriptionsUpdateTimer->cancel ();
+			m_SubscriptionsUpdateTimer = nullptr;
+			if (dest)
+			{
+				m_SubscriptionsUpdateTimer = std::make_unique<boost::asio::steady_timer>(dest->GetService ());
+				m_SubscriptionsUpdateTimer->expires_after (std::chrono::minutes(INITIAL_SUBSCRIPTION_UPDATE_TIMEOUT));
+				m_SubscriptionsUpdateTimer->async_wait (std::bind (&AddressBook::HandleSubscriptionsUpdateTimer,
+					this, std::placeholders::_1));
+			}
+		}
+		if (m_AddressCacheUpdateTimer)
+		{
+			m_AddressCacheUpdateTimer->cancel ();
+			m_AddressCacheUpdateTimer = nullptr;
+			ScheduleCacheUpdate (); // creates it again on the current destination
+		}
+	}
+
 	void AddressBook::HandleSubscriptionsUpdateTimer (const boost::system::error_code& ecode)
 	{
 		if (ecode != boost::asio::error::operation_aborted)

--- a/libi2pd_client/AddressBook.h
+++ b/libi2pd_client/AddressBook.h
@@ -89,6 +89,7 @@ namespace client
 			AddressBook ();
 			~AddressBook ();
 			void Start ();
+			void ResetTimers (); // after the shared local destination is replaced
 			void StartResolvers ();
 			void Stop ();
 			std::shared_ptr<const Address> GetAddress (std::string_view address);

--- a/libi2pd_client/ClientContext.cpp
+++ b/libi2pd_client/ClientContext.cpp
@@ -250,6 +250,7 @@ namespace client
 		// change shared local destination
 		m_SharedLocalDestination->Release ();
 		CreateNewSharedLocalDestination ();
+		m_AddressBook.ResetTimers (); // its timers are left on a destination about to go
 
 		// recreate HTTP proxy
 		auto httpProxy = DetachHttpProxy ();


### PR DESCRIPTION
ClientContext::ReloadConfig releases the shared local destination and creates a new one, and the old destination is then deleted as unused. Both address book timers - the subscriptions one and the address cache one - were created on the old destination's io_service and are never recreated, so after any SIGHUP they sit on a service that no longer exists: they can never fire again, and cancelling them at shutdown reads freed memory.

AddressSanitizer catches it on shutdown, single thread, no race involved: the read is in AddressBook::Stop, the free is ~RunnableClientDestination from ClientContext::ReloadConfig.

Bench: a server tunnel is removed from tunnels.conf and put back with SIGHUP while data is going through it, then the router is stopped. Before the change every run ended with a use-after-free report; with only the subscriptions timer recreated the report moved to the address cache timer, which is why both are handled here. After the change, 4 rounds of 4 and then 2 more rounds with reloads confirmed in the log are clean, no sanitizer reports at all.

Builds without warnings, unit tests pass, C++17 syntax check is fine.