### PR TITLE
keep service owner of a handler as weak_ptr

### DIFF
--- a/libi2pd_client/BOB.cpp
+++ b/libi2pd_client/BOB.cpp
@@ -140,7 +140,7 @@ namespace client
 	void BOBI2PInboundTunnel::CreateConnection (std::shared_ptr<AddressReceiver> receiver, std::shared_ptr<const i2p::data::LeaseSet> leaseSet)
 	{
 		LogPrint (eLogDebug, "BOB: New inbound connection");
-		auto connection = std::make_shared<I2PTunnelConnection>(this, receiver->socket, leaseSet);
+		auto connection = std::make_shared<I2PTunnelConnection>(shared_from_this (), receiver->socket, leaseSet);
 		AddHandler (connection);
 		connection->I2PConnect (receiver->data, receiver->dataLen);
 	}
@@ -176,7 +176,7 @@ namespace client
 	{
 		if (stream)
 		{
-			auto conn = std::make_shared<BOBI2PTunnelIncomingConnection> (this, stream, m_Endpoint, m_IsQuiet);
+			auto conn = std::make_shared<BOBI2PTunnelIncomingConnection> (shared_from_this (), stream, m_Endpoint, m_IsQuiet);
 			AddHandler (conn);
 			conn->Connect ();
 		}
@@ -194,8 +194,6 @@ namespace client
 
 	BOBDestination::~BOBDestination ()
 	{
-		delete m_OutboundTunnel;
-		delete m_InboundTunnel;
 		i2p::client::context.DeleteLocalDestination (m_LocalDestination);
 	}
 
@@ -218,13 +216,11 @@ namespace client
 		if (m_OutboundTunnel)
 		{
 			m_OutboundTunnel->Stop ();
-			delete m_OutboundTunnel;
 			m_OutboundTunnel = nullptr;
 		}
 		if (m_InboundTunnel)
 		{
 			m_InboundTunnel->Stop ();
-			delete m_InboundTunnel;
 			m_InboundTunnel = nullptr;
 		}
 	}
@@ -246,7 +242,7 @@ namespace client
 				else
 					LogPrint (eLogError, "BOB: ", ec.message ());
 			}
-			m_InboundTunnel = new BOBI2PInboundTunnel (ep, m_LocalDestination);
+			m_InboundTunnel = std::make_shared<BOBI2PInboundTunnel> (ep, m_LocalDestination);
 		}
 	}
 
@@ -257,7 +253,7 @@ namespace client
 			// update outport and outhost (user can stop tunnel and change)
 			m_OutPort = port;
 			m_OutHost = outhost;
-			m_OutboundTunnel = new BOBI2POutboundTunnel (outhost, port, m_LocalDestination, quiet);
+			m_OutboundTunnel = std::make_shared<BOBI2POutboundTunnel> (outhost, port, m_LocalDestination, quiet);
 		}
 	}
 

--- a/libi2pd_client/BOB.h
+++ b/libi2pd_client/BOB.h
@@ -87,7 +87,7 @@ namespace client
 	{
 		public:
 
-			BOBI2PTunnelIncomingConnection (I2PService * owner, std::shared_ptr<i2p::stream::Stream> stream,
+			BOBI2PTunnelIncomingConnection (std::shared_ptr<I2PService> owner, std::shared_ptr<i2p::stream::Stream> stream,
 				const boost::asio::ip::tcp::endpoint& target, bool quiet):
 				I2PTunnelConnection (owner, stream, target), m_IsQuiet (quiet) {};
 
@@ -199,8 +199,8 @@ namespace client
 		private:
 
 			std::shared_ptr<ClientDestination> m_LocalDestination;
-			BOBI2POutboundTunnel * m_OutboundTunnel;
-			BOBI2PInboundTunnel * m_InboundTunnel;
+			std::shared_ptr<BOBI2POutboundTunnel> m_OutboundTunnel;
+			std::shared_ptr<BOBI2PInboundTunnel> m_InboundTunnel;
 
 			std::string m_Nickname;
 			std::string m_InHost, m_OutHost;

--- a/libi2pd_client/HTTPProxy.cpp
+++ b/libi2pd_client/HTTPProxy.cpp
@@ -126,13 +126,13 @@ namespace proxy
 
 		public:
 
-			HTTPReqHandler(HTTPProxy * parent, std::shared_ptr<boost::asio::ip::tcp::socket> sock) :
+			HTTPReqHandler(std::shared_ptr<i2p::client::I2PService> parent, std::shared_ptr<boost::asio::ip::tcp::socket> sock) :
 				I2PServiceHandler(parent), m_sock(sock),
 				m_proxysock(std::make_shared<boost::asio::ip::tcp::socket>(parent->GetService())),
 				m_proxy_resolver(parent->GetService()),
-				m_OutproxyUrl(parent->GetOutproxyURL()),
-				m_Addresshelper(parent->GetHelperSupport()),
-				m_SendUserAgent (parent->GetSendUserAgent ()) {}
+				m_OutproxyUrl(std::static_pointer_cast<HTTPProxy>(parent)->GetOutproxyURL()),
+				m_Addresshelper(std::static_pointer_cast<HTTPProxy>(parent)->GetHelperSupport()),
+				m_SendUserAgent (std::static_pointer_cast<HTTPProxy>(parent)->GetSendUserAgent ()) {}
 			~HTTPReqHandler() { Terminate(); }
 			void Handle () { AsyncSockRead(); } /* overload */
 	};
@@ -567,8 +567,10 @@ namespace proxy
 		m_send_buf.append(m_recv_buf);
 		/* connect to destination */
 		LogPrint(eLogDebug, "HTTPProxy: Connecting to host ", dest_host, ":", dest_port);
-		GetOwner ()->UpdateLastActivityTime ();
-		GetOwner()->CreateStream (std::bind (&HTTPReqHandler::HandleStreamRequestComplete,
+		auto owner = GetOwner ();
+		if (!owner) return true;
+		owner->UpdateLastActivityTime ();
+		owner->CreateStream (std::bind (&HTTPReqHandler::HandleStreamRequestComplete,
 			shared_from_this(), std::placeholders::_1), dest_host, dest_port);
 		return true;
 	}
@@ -611,8 +613,10 @@ namespace proxy
 				m_send_buf = m_ClientRequest.to_string();
 				m_recv_buf.erase(0, m_req_len);
 				m_send_buf.append(m_recv_buf);
-				GetOwner()->CreateStream (std::bind (&HTTPReqHandler::HandleStreamRequestComplete,
-					shared_from_this(), std::placeholders::_1), m_ProxyURL.host, m_ProxyURL.port);
+				auto owner = GetOwner ();
+				if (owner)
+					owner->CreateStream (std::bind (&HTTPReqHandler::HandleStreamRequestComplete,
+						shared_from_this(), std::placeholders::_1), m_ProxyURL.host, m_ProxyURL.port);
 			}
 			else
 			{
@@ -677,10 +681,12 @@ namespace proxy
 	void HTTPReqHandler::HandoverToUpstreamProxy()
 	{
 		LogPrint(eLogDebug, "HTTPProxy: Handover to SOCKS proxy");
-		auto connection = CreateSocketsPipe (GetOwner(), m_proxysock, m_sock);
+		auto owner = GetOwner ();
+		if (!owner) { Terminate (); return; }
+		auto connection = CreateSocketsPipe (owner, m_proxysock, m_sock);
 		m_sock = nullptr;
 		m_proxysock = nullptr;
-		GetOwner()->AddHandler(connection);
+		owner->AddHandler(connection);
 		connection->Start();
 		Terminate();
 	}
@@ -688,9 +694,13 @@ namespace proxy
 	void HTTPReqHandler::HTTPConnect(std::string_view host, uint16_t port)
 	{
 		LogPrint(eLogDebug, "HTTPProxy: CONNECT ",host, ":", port);
+		auto owner = GetOwner ();
 		if(str_rmatch(host, ".i2p"))
-			GetOwner()->CreateStream (std::bind (&HTTPReqHandler::HandleHTTPConnectStreamRequestComplete,
-				shared_from_this(), std::placeholders::_1), host, port);
+		{
+			if (owner)
+				owner->CreateStream (std::bind (&HTTPReqHandler::HandleHTTPConnectStreamRequestComplete,
+					shared_from_this(), std::placeholders::_1), host, port);
+		}
 		else
 			ForwardToUpstreamProxy();
 	}
@@ -705,8 +715,10 @@ namespace proxy
 				m_ClientResponse.status = "OK";
 				m_send_buf = m_ClientResponse.to_string();
 				m_sock->send(boost::asio::buffer(m_send_buf));
-				auto connection = std::make_shared<i2p::client::I2PTunnelConnection>(GetOwner(), m_sock, stream);
-				GetOwner()->AddHandler(connection);
+				auto owner = GetOwner ();
+				if (!owner) { Terminate (); return; }
+				auto connection = std::make_shared<i2p::client::I2PTunnelConnection>(owner, m_sock, stream);
+				owner->AddHandler(connection);
 				connection->I2PConnect();
 			}
 			else
@@ -785,8 +797,10 @@ namespace proxy
 		if (Kill())
 			return;
 		LogPrint (eLogDebug, "HTTPProxy: Created new I2PTunnel stream, sSID=", stream->GetSendStreamID(), ", rSID=", stream->GetRecvStreamID());
-		auto connection = std::make_shared<i2p::client::I2PClientTunnelConnectionHTTP>(GetOwner(), m_sock, stream);
-		GetOwner()->AddHandler (connection);
+		auto owner = GetOwner ();
+		if (!owner) { Done (shared_from_this()); return; }
+		auto connection = std::make_shared<i2p::client::I2PClientTunnelConnectionHTTP>(owner, m_sock, stream);
+		owner->AddHandler (connection);
 		connection->I2PConnect (reinterpret_cast<const uint8_t*>(m_send_buf.data()), m_send_buf.length());
 		Done (shared_from_this());
 	}
@@ -812,7 +826,7 @@ namespace proxy
 
 	std::shared_ptr<i2p::client::I2PServiceHandler> HTTPProxy::CreateHandler(std::shared_ptr<boost::asio::ip::tcp::socket> socket)
 	{
-		return std::make_shared<HTTPReqHandler> (this, socket);
+		return std::make_shared<HTTPReqHandler> (shared_from_this (), socket);
 	}
 } // http
 } // i2p

--- a/libi2pd_client/I2PService.h
+++ b/libi2pd_client/I2PService.h
@@ -118,7 +118,7 @@ namespace client
 	{
 		public:
 
-			I2PServiceHandler(I2PService * parent) : m_Service(parent)
+			I2PServiceHandler(std::shared_ptr<I2PService> parent) : m_Service(parent)
 #if __cplusplus < 202002L // C++20
 				, m_Dead ATOMIC_FLAG_INIT // {0}
 #endif
@@ -135,13 +135,15 @@ namespace client
 			// Call when terminating or handing over to avoid race conditions
 			inline bool Kill () { return m_Dead.test_and_set (); }
 			// Call when done to clean up (make sure Kill is called first)
-			inline void Done (std::shared_ptr<I2PServiceHandler> me) { if(m_Service) m_Service->RemoveHandler(me); }
+			inline void Done (std::shared_ptr<I2PServiceHandler> me) { auto owner = GetOwner (); if (owner) owner->RemoveHandler (me); }
 			// Call to talk with the owner
-			inline I2PService * GetOwner() const { return m_Service; }
+			// the owner may be destroyed while a handler is still working on
+			// another thread, so it is only reachable through a weak pointer
+			inline std::shared_ptr<I2PService> GetOwner () const { return m_Service.lock (); }
 
 		private:
 
-			I2PService * m_Service;
+			std::weak_ptr<I2PService> m_Service;
 			std::atomic_flag m_Dead; //To avoid cleaning up multiple times
 	};
 
@@ -154,7 +156,7 @@ namespace client
 	{
 		public:
 
-			SocketsPipe(I2PService * owner, std::shared_ptr<SocketUpstream> upstream, std::shared_ptr<SocketDownstream> downstream):
+			SocketsPipe(std::shared_ptr<I2PService> owner, std::shared_ptr<SocketUpstream> upstream, std::shared_ptr<SocketDownstream> downstream):
 				I2PServiceHandler(owner), m_up(upstream), m_down(downstream)
 			{
 				try
@@ -240,7 +242,7 @@ namespace client
 	};
 
 	template<typename SocketUpstream, typename SocketDownstream>
-	std::shared_ptr<I2PServiceHandler> CreateSocketsPipe (I2PService * owner, std::shared_ptr<SocketUpstream> upstream, std::shared_ptr<SocketDownstream> downstream)
+	std::shared_ptr<I2PServiceHandler> CreateSocketsPipe (std::shared_ptr<I2PService> owner, std::shared_ptr<SocketUpstream> upstream, std::shared_ptr<SocketDownstream> downstream)
 	{
 		return std::make_shared<SocketsPipe<SocketUpstream, SocketDownstream> >(owner, upstream, downstream);
 	}

--- a/libi2pd_client/I2PTunnel.cpp
+++ b/libi2pd_client/I2PTunnel.cpp
@@ -31,20 +31,22 @@ namespace client
 		}
 	}
 
-	I2PTunnelConnection::I2PTunnelConnection (I2PService * owner, std::shared_ptr<boost::asio::ip::tcp::socket> socket,
+	I2PTunnelConnection::I2PTunnelConnection (std::shared_ptr<I2PService> owner, std::shared_ptr<boost::asio::ip::tcp::socket> socket,
 		std::shared_ptr<const i2p::data::LeaseSet> leaseSet, uint16_t port):
 		I2PServiceHandler(owner), m_Socket (socket), m_IsReceiving (false)
 	{
-		m_Stream = GetOwner()->GetLocalDestination ()->CreateStream (leaseSet, port);
+		auto service = GetOwner ();
+		if (service)
+			m_Stream = service->GetLocalDestination ()->CreateStream (leaseSet, port);
 	}
 
-	I2PTunnelConnection::I2PTunnelConnection (I2PService * owner,
+	I2PTunnelConnection::I2PTunnelConnection (std::shared_ptr<I2PService> owner,
 		std::shared_ptr<boost::asio::ip::tcp::socket> socket, std::shared_ptr<i2p::stream::Stream> stream):
 		I2PServiceHandler(owner), m_Socket (socket), m_Stream (stream), m_IsReceiving (false)
 	{
 	}
 
-	I2PTunnelConnection::I2PTunnelConnection (I2PService * owner, std::shared_ptr<i2p::stream::Stream> stream,
+	I2PTunnelConnection::I2PTunnelConnection (std::shared_ptr<I2PService> owner, std::shared_ptr<i2p::stream::Stream> stream,
 		const boost::asio::ip::tcp::endpoint& target,std::shared_ptr<boost::asio::ssl::context> sslCtx):
 		I2PServiceHandler(owner), m_Stream (stream), m_RemoteEndpoint (target), m_IsReceiving (false)
 	{
@@ -266,7 +268,8 @@ namespace client
 					else
 						s->Terminate ();
 				});
-			GetOwner ()->UpdateLastActivityTime ();
+			auto owner = GetOwner ();
+			if (owner) owner->UpdateLastActivityTime ();
 		}
 	}
 
@@ -338,7 +341,8 @@ namespace client
 		else
 			boost::asio::async_write (*m_Socket, boost::asio::buffer (buf, len), boost::asio::transfer_all (),
 				std::bind (&I2PTunnelConnection::HandleWrite, shared_from_this (), std::placeholders::_1));
-		GetOwner ()->UpdateLastActivityTime ();
+		auto owner = GetOwner ();
+		if (owner) owner->UpdateLastActivityTime ();
 	}
 
 	void I2PTunnelConnection::HandleConnect (const boost::system::error_code& ecode)
@@ -446,7 +450,7 @@ namespace client
 		}
 	}
 
-	I2PServerTunnelConnectionHTTP::I2PServerTunnelConnectionHTTP (I2PService * owner, std::shared_ptr<i2p::stream::Stream> stream,
+	I2PServerTunnelConnectionHTTP::I2PServerTunnelConnectionHTTP (std::shared_ptr<I2PService> owner, std::shared_ptr<i2p::stream::Stream> stream,
 		const boost::asio::ip::tcp::endpoint& target, const std::string& host, const std::string& XI2P,
 	    std::shared_ptr<boost::asio::ssl::context> sslCtx):
 		I2PTunnelConnection (owner, stream, target, sslCtx), m_Host (host), m_XI2P (XI2P),
@@ -597,7 +601,7 @@ namespace client
 		}
 	}
 
-	I2PTunnelConnectionIRC::I2PTunnelConnectionIRC (I2PService * owner, std::shared_ptr<i2p::stream::Stream> stream,
+	I2PTunnelConnectionIRC::I2PTunnelConnectionIRC (std::shared_ptr<I2PService> owner, std::shared_ptr<i2p::stream::Stream> stream,
 		const boost::asio::ip::tcp::endpoint& target, const std::string& webircpass,
 	    std::shared_ptr<boost::asio::ssl::context> sslCtx):
 		I2PTunnelConnection (owner, stream, target, sslCtx), m_From (stream->GetRemoteIdentity ()),
@@ -650,7 +654,7 @@ namespace client
 	class I2PClientTunnelHandler: public I2PServiceHandler, public std::enable_shared_from_this<I2PClientTunnelHandler>
 	{
 		public:
-			I2PClientTunnelHandler (I2PClientTunnel * parent, std::shared_ptr<const Address> address,
+			I2PClientTunnelHandler (std::shared_ptr<I2PService> parent, std::shared_ptr<const Address> address,
 				uint16_t destinationPort, std::shared_ptr<boost::asio::ip::tcp::socket> socket):
 				I2PServiceHandler(parent), m_Address(address),
 				m_DestinationPort (destinationPort), m_Socket(socket) {};
@@ -665,8 +669,10 @@ namespace client
 
 	void I2PClientTunnelHandler::Handle()
 	{
-		GetOwner ()->UpdateLastActivityTime ();
-		GetOwner()->CreateStream (
+		auto owner = GetOwner ();
+		if (!owner) return;
+		owner->UpdateLastActivityTime ();
+		owner->CreateStream (
 			std::bind (&I2PClientTunnelHandler::HandleStreamRequestComplete, shared_from_this(), std::placeholders::_1),
 			m_Address, m_DestinationPort);
 	}
@@ -679,8 +685,10 @@ namespace client
 			if (m_Socket && m_Socket->is_open ())
 			{
 				LogPrint (eLogDebug, "I2PTunnel: New connection");
-				auto connection = std::make_shared<I2PTunnelConnection>(GetOwner(), m_Socket, stream);
-				GetOwner()->AddHandler (connection);
+				auto owner = GetOwner ();
+				if (!owner) { Done (shared_from_this ()); return; }
+				auto connection = std::make_shared<I2PTunnelConnection>(owner, m_Socket, stream);
+				owner->AddHandler (connection);
 				connection->I2PConnect ();
 				Done(shared_from_this());
 			}
@@ -772,7 +780,7 @@ namespace client
 	{
 		auto address = GetAddress ();
 		if (address)
-			return std::make_shared<I2PClientTunnelHandler>(this, address, m_DestinationPort, socket);
+			return std::make_shared<I2PClientTunnelHandler>(shared_from_this (), address, m_DestinationPort, socket);
 		else
 			return nullptr;
 	}
@@ -993,7 +1001,7 @@ namespace client
 
 	std::shared_ptr<I2PTunnelConnection> I2PServerTunnel::CreateI2PConnection (std::shared_ptr<i2p::stream::Stream> stream)
 	{
-		return std::make_shared<I2PTunnelConnection> (this, stream, GetEndpoint (), m_SSLCtx);
+		return std::make_shared<I2PTunnelConnection> (shared_from_this (), stream, GetEndpoint (), m_SSLCtx);
 
 	}
 
@@ -1017,7 +1025,7 @@ namespace client
 			ss << X_I2P_DEST_B64 << ": " << from->ToBase64 () << "\r\n";
 			m_XI2P = ss.str ();
 		}
-		return std::make_shared<I2PServerTunnelConnectionHTTP> (this, stream, GetEndpoint (), m_Host, m_XI2P, GetSSLCtx ());
+		return std::make_shared<I2PServerTunnelConnectionHTTP> (shared_from_this (), stream, GetEndpoint (), m_Host, m_XI2P, GetSSLCtx ());
 	}
 
 	I2PServerTunnelIRC::I2PServerTunnelIRC (const std::string& name, const std::string& address,
@@ -1030,7 +1038,7 @@ namespace client
 
 	std::shared_ptr<I2PTunnelConnection> I2PServerTunnelIRC::CreateI2PConnection (std::shared_ptr<i2p::stream::Stream> stream)
 	{
-		return std::make_shared<I2PTunnelConnectionIRC> (this, stream, GetEndpoint (), m_WebircPass, GetSSLCtx ());
+		return std::make_shared<I2PTunnelConnectionIRC> (shared_from_this (), stream, GetEndpoint (), m_WebircPass, GetSSLCtx ());
 	}
 }
 }

--- a/libi2pd_client/I2PTunnel.h
+++ b/libi2pd_client/I2PTunnel.h
@@ -44,11 +44,11 @@ namespace client
 	{
 		public:
 
-			I2PTunnelConnection (I2PService * owner, std::shared_ptr<boost::asio::ip::tcp::socket> socket,
+			I2PTunnelConnection (std::shared_ptr<I2PService> owner, std::shared_ptr<boost::asio::ip::tcp::socket> socket,
 				std::shared_ptr<const i2p::data::LeaseSet> leaseSet, uint16_t port = 0); // to I2P
-			I2PTunnelConnection (I2PService * owner, std::shared_ptr<boost::asio::ip::tcp::socket> socket,
+			I2PTunnelConnection (std::shared_ptr<I2PService> owner, std::shared_ptr<boost::asio::ip::tcp::socket> socket,
 				std::shared_ptr<i2p::stream::Stream> stream); // to I2P using simplified API
-			I2PTunnelConnection (I2PService * owner, std::shared_ptr<i2p::stream::Stream> stream,
+			I2PTunnelConnection (std::shared_ptr<I2PService> owner, std::shared_ptr<i2p::stream::Stream> stream,
 				const boost::asio::ip::tcp::endpoint& target,
 			    std::shared_ptr<boost::asio::ssl::context> sslCtx = nullptr); // from I2P
 			~I2PTunnelConnection ();
@@ -93,7 +93,7 @@ namespace client
 	{
 		public:
 
-			I2PClientTunnelConnectionHTTP (I2PService * owner, std::shared_ptr<boost::asio::ip::tcp::socket> socket,
+			I2PClientTunnelConnectionHTTP (std::shared_ptr<I2PService> owner, std::shared_ptr<boost::asio::ip::tcp::socket> socket,
 				std::shared_ptr<i2p::stream::Stream> stream):
 				I2PTunnelConnection (owner, socket, stream), m_HeaderSent (false),
 				m_ConnectionSent (false), m_ProxyConnectionSent (false) {};
@@ -112,7 +112,7 @@ namespace client
 	{
 		public:
 
-			I2PServerTunnelConnectionHTTP (I2PService * owner, std::shared_ptr<i2p::stream::Stream> stream,
+			I2PServerTunnelConnectionHTTP (std::shared_ptr<I2PService> owner, std::shared_ptr<i2p::stream::Stream> stream,
 				const boost::asio::ip::tcp::endpoint& target, const std::string& host, const std::string& XI2P,
 			    std::shared_ptr<boost::asio::ssl::context> sslCtx = nullptr);
 
@@ -132,7 +132,7 @@ namespace client
 	{
 		public:
 
-			I2PTunnelConnectionIRC (I2PService * owner, std::shared_ptr<i2p::stream::Stream> stream,
+			I2PTunnelConnectionIRC (std::shared_ptr<I2PService> owner, std::shared_ptr<i2p::stream::Stream> stream,
 				const boost::asio::ip::tcp::endpoint& target, const std::string& m_WebircPass,
 			    std::shared_ptr<boost::asio::ssl::context> sslCtx = nullptr);
 

--- a/libi2pd_client/SOCKS.cpp
+++ b/libi2pd_client/SOCKS.cpp
@@ -128,7 +128,7 @@ namespace proxy
 			void HandleSockRecv(const boost::system::error_code & ecode, std::size_t bytes_transfered);
 			void Terminate();
 			void AsyncSockRead();
-			SOCKSServer * GetServer () { return (SOCKSServer *)GetOwner (); };
+			std::shared_ptr<SOCKSServer> GetServer () { return std::static_pointer_cast<SOCKSServer>(GetOwner ()); };
 			boost::asio::const_buffer GenerateSOCKS4Response(errTypes error, uint32_t ip, uint16_t port);
 			boost::asio::const_buffer GenerateSOCKS5Response(errTypes error, addrTypes type, const address &addr, uint16_t port);
 			bool Socks5ChooseAuth();
@@ -179,7 +179,7 @@ namespace proxy
 
 		public:
 
-			SOCKSHandler(SOCKSServer * parent, std::shared_ptr<boost::asio::ip::tcp::socket> sock, const std::string & upstreamAddr, const uint16_t upstreamPort, const bool useUpstream) :
+			SOCKSHandler(std::shared_ptr<i2p::client::I2PService> parent, std::shared_ptr<boost::asio::ip::tcp::socket> sock, const std::string & upstreamAddr, const uint16_t upstreamPort, const bool useUpstream) :
 				I2PServiceHandler(parent),
 				m_proxy_resolver(parent->GetService()),
 				m_sock(sock), m_stream(nullptr),
@@ -363,7 +363,9 @@ namespace proxy
 				}
 				else
 				{
-					auto s = i2p::client::context.GetAddressBook().ToAddress(GetOwner()->GetLocalDestination()->GetIdentHash());
+					auto owner = GetOwner ();
+					if (!owner) { Terminate (); return; }
+					auto s = i2p::client::context.GetAddressBook().ToAddress(owner->GetLocalDestination()->GetIdentHash());
 					address ad; ad.dns.SetString(s);
 					// HACK only 16 bits passed in port as SOCKS5 doesn't allow for more
 					response = GenerateSOCKS5Response(SOCKS5_OK, ADDR_DNS, ad, m_stream ? (uint16_t)m_stream->GetRecvStreamID() : 0);
@@ -672,7 +674,9 @@ namespace proxy
 				{
 					// resolve to 255.x.x.x address
 					LogPrint(eLogInfo, "SOCKS: Resolve ", addr);
-					boost::asio::post (GetOwner ()->GetService (), [this, addr](void)
+					auto owner = GetOwner ();
+					if (!owner) { Terminate (); return; }
+					boost::asio::post (owner->GetService (), [this, addr](void)
 						{
 							address ad;
 							ad.ip = GetServer ()->ResolveAddress (addr).to_uint();
@@ -691,21 +695,29 @@ namespace proxy
 					switch (m_cmd)
 					{
 						case CMD_CONNECT:
+						{
 							//make an i2p session
-							GetOwner ()->UpdateLastActivityTime ();
-							GetOwner()->CreateStream ( std::bind (&SOCKSHandler::HandleStreamRequestComplete,
+							auto owner = GetOwner ();
+							if (!owner) { Terminate (); return; }
+							owner->UpdateLastActivityTime ();
+							owner->CreateStream ( std::bind (&SOCKSHandler::HandleStreamRequestComplete,
 								shared_from_this(), std::placeholders::_1), addr, m_port);
+						}
 						break;
 						case CMD_UDP:
+						{
 							// create UDP client tunnel
 							LogPrint (eLogInfo, "SOCKS: New UDP associate connection");
+							auto owner = GetOwner ();
+							if (!owner) { Terminate (); return; }
 							m_UDPTunnel = std::make_unique<i2p::client::I2PUDPClientTunnel>("", addr,
 								GetServer ()->GetNextLocalUDPEndpoint (),
-							    GetOwner ()->GetLocalDestination (), m_port, false, i2p::datagram::eDatagramV3);
-							boost::asio::post (GetOwner ()->GetService (), [this](void)
+							    owner->GetLocalDestination (), m_port, false, i2p::datagram::eDatagramV3);
+							boost::asio::post (owner->GetService (), [this](void)
 								{
 									SocksRequestSuccess();
 								});
+						}
 						break;
 						default: ;
 					}
@@ -739,8 +751,10 @@ namespace proxy
 				if (m_sock && m_sock->is_open ())
 				{
 					LogPrint (eLogInfo, "SOCKS: New I2PTunnel connection");
-					auto connection = std::make_shared<i2p::client::I2PTunnelConnection>(GetOwner(), m_sock, m_stream);
-					GetOwner()->AddHandler (connection);
+					auto owner = GetOwner ();
+					if (!owner) { Terminate (); return; }
+					auto connection = std::make_shared<i2p::client::I2PTunnelConnection>(owner, m_sock, m_stream);
+					owner->AddHandler (connection);
 					connection->I2PConnect (m_remaining_data,m_remaining_data_len);
 					Done(shared_from_this());
 				}
@@ -802,7 +816,9 @@ namespace proxy
 		{
 #if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
 			EnterState(UPSTREAM_CONNECT);
-			m_upstreamLocalSock = std::make_shared<boost::asio::local::stream_protocol::socket>(GetOwner()->GetService());
+			auto owner = GetOwner ();
+			if (!owner) { Terminate (); return; }
+			m_upstreamLocalSock = std::make_shared<boost::asio::local::stream_protocol::socket>(owner->GetService());
 			auto s = shared_from_this ();
 			m_upstreamLocalSock->async_connect(m_UpstreamProxyAddress,
 			    [s](const boost::system::error_code& ecode)
@@ -855,10 +871,12 @@ namespace proxy
 			break;
 		}
 		m_sock->send(response);
-		auto forwarder = CreateSocketsPipe (GetOwner(), m_sock, upstreamSock);
+		auto owner = GetOwner ();
+		if (!owner) { Terminate (); return; }
+		auto forwarder = CreateSocketsPipe (owner, m_sock, upstreamSock);
 		upstreamSock = nullptr;
 		m_sock = nullptr;
-		GetOwner()->AddHandler(forwarder);
+		owner->AddHandler(forwarder);
 		forwarder->Start();
 		Terminate();
 	}
@@ -929,7 +947,9 @@ namespace proxy
 		}
 		LogPrint(eLogInfo, "SOCKS: Upstream proxy resolved");
 		EnterState(UPSTREAM_CONNECT);
-		auto & service = GetOwner()->GetService();
+		auto owner = GetOwner ();
+		if (!owner) { Terminate (); return; }
+		auto & service = owner->GetService();
 		m_upstreamSock = std::make_shared<boost::asio::ip::tcp::socket>(service);
 		boost::asio::async_connect(*m_upstreamSock, endpoints,
 			std::bind(&SOCKSHandler::HandleUpstreamConnected,
@@ -948,7 +968,7 @@ namespace proxy
 
 	std::shared_ptr<i2p::client::I2PServiceHandler> SOCKSServer::CreateHandler(std::shared_ptr<boost::asio::ip::tcp::socket> socket)
 	{
-		return std::make_shared<SOCKSHandler> (this, socket, m_UpstreamProxyAddress, m_UpstreamProxyPort, m_UseUpstreamProxy);
+		return std::make_shared<SOCKSHandler> (shared_from_this (), socket, m_UpstreamProxyAddress, m_UpstreamProxyPort, m_UseUpstreamProxy);
 	}
 
 	void SOCKSServer::SetUpstreamProxy(const std::string & addr, const uint16_t port)

--- a/libi2pd_client/Torrents.cpp
+++ b/libi2pd_client/Torrents.cpp
@@ -659,7 +659,7 @@ namespace torrents
 		}
 	}
 
-	PeerConnection::PeerConnection (i2p::client::I2PService * owner,  std::shared_ptr<i2p::stream::Stream> stream):
+	PeerConnection::PeerConnection (std::shared_ptr<i2p::client::I2PService> owner,  std::shared_ptr<i2p::stream::Stream> stream):
 		i2p::client::I2PServiceHandler (owner), m_Stream (stream), m_ReceiveBufferOffset (0),
 		m_IsHandshakeSent (false), m_IsEstablished (false), m_IsChoked (true), m_IsRemoteChoked (true),
 		m_IsInterested (false), m_IsRemoteInterested (false), m_LastReceiveTime (0), m_LastSendTime (0),
@@ -668,7 +668,7 @@ namespace torrents
 		ResetStats ();
 	}
 
-	PeerConnection::PeerConnection (i2p::client::I2PService * owner,
+	PeerConnection::PeerConnection (std::shared_ptr<i2p::client::I2PService> owner,
 		std::shared_ptr<i2p::stream::Stream> stream, std::shared_ptr<Torrent> torrent):
 		PeerConnection (owner, stream)
 	{
@@ -727,9 +727,9 @@ namespace torrents
 			});
 	}
 
-	TorrentsTunnel * PeerConnection::GetTorrentsTunnel () const
+	std::shared_ptr<TorrentsTunnel> PeerConnection::GetTorrentsTunnel () const
 	{
-		return static_cast<TorrentsTunnel *>(GetOwner ());
+		return std::static_pointer_cast<TorrentsTunnel>(GetOwner ());
 	}
 
 	bool PeerConnection::IsPieceAvailable (size_t ind) const
@@ -1766,7 +1766,7 @@ namespace torrents
 					{
 						if (stream)
 						{
-							auto conn = std::make_shared<PeerConnection> (this, stream);
+							auto conn = std::make_shared<PeerConnection> (shared_from_this (), stream);
 							AddHandler (conn);
 							conn->ReceiveHandshake ();
 						}
@@ -1860,7 +1860,7 @@ namespace torrents
 				if (stream)
 				{
 					LogPrint (eLogDebug, "Torrents: Connected to peer ", peer.ToBase32 () + ".b32.i2p");
-					auto connection = std::make_shared<PeerConnection>(this, stream, torrent);
+					auto connection = std::make_shared<PeerConnection>(shared_from_this (), stream, torrent);
 					AddHandler (connection);
 					connection->Connect ();
 				}

--- a/libi2pd_client/Torrents.h
+++ b/libi2pd_client/Torrents.h
@@ -247,8 +247,8 @@ namespace torrents
 
 			using PeerID = std::array<uint8_t, 20>;
 
-			PeerConnection (i2p::client::I2PService * owner,  std::shared_ptr<i2p::stream::Stream> stream); // incoming
-			PeerConnection (i2p::client::I2PService * owner,  std::shared_ptr<i2p::stream::Stream> stream,
+			PeerConnection (std::shared_ptr<i2p::client::I2PService> owner,  std::shared_ptr<i2p::stream::Stream> stream); // incoming
+			PeerConnection (std::shared_ptr<i2p::client::I2PService> owner,  std::shared_ptr<i2p::stream::Stream> stream,
 				std::shared_ptr<Torrent> torrent); // outgoing
 			~PeerConnection ();
 
@@ -280,7 +280,7 @@ namespace torrents
 
 			void Terminate ();
 			void ScheduleHandshakeReceiveTimer ();
-			TorrentsTunnel * GetTorrentsTunnel () const;
+			std::shared_ptr<TorrentsTunnel> GetTorrentsTunnel () const;
 
 			void WriteToStream (const uint8_t * buf, size_t len);
 			void StreamReceive ();


### PR DESCRIPTION
A handler kept its owner as a plain I2PService*, on the assumption that a service outlives its handlers. That does not hold across a configuration reload: ClientContext::ReloadConfig recreates the proxy and destroys the old service on the main thread, while a connection handler on the destination's thread is still receiving data and calls I2PService::UpdateLastActivityTime on the object that is already gone.

AddressSanitizer reports a heap-use-after-free in I2PService::UpdateLastActivityTime, called from I2PTunnelConnection::Write out of HandleStreamReceive; the free is the release of the HTTPProxy shared_ptr in ClientContext::ReloadConfig.

Bench: a small site is served through a server tunnel, requests go through the http proxy of a second router, and SIGHUP is sent while data is flowing. The bench first makes sure the page really comes through the proxy, otherwise a clean result would mean nothing. Before the change the router died on the second reload round in two runs out of two. With the change, and together with the address book timers fix, two rounds of two are clean: the page is served both before and after every reload, and there are no sanitizer reports at all.

The owner is now a weak_ptr, GetOwner returns a shared_ptr, and every place that talks to the owner checks whether it is still alive; a handler whose owner is gone terminates itself. The single line in Torrents.cpp is only the mechanical adaptation of GetOwner to the new return type.

Builds without warnings, unit tests pass, C++17 syntax check is fine.