### PR TITLE
add_jsonrpc2_torrent_get

### DIFF
--- a/libi2pd_client/TorrentsRPC.cpp
+++ b/libi2pd_client/TorrentsRPC.cpp
@@ -208,6 +208,7 @@ namespace torrents
 
 	std::string JSONRPCHandler::HandleTorrentGet (boost::json::object&& jsonRequest)
 	{
+
 		auto arguments = jsonRequest.at ("arguments").as_object ();
 		std::vector<int> torrentIds;
 		bool torrentsRequested = arguments.contains ("ids");
@@ -225,6 +226,7 @@ namespace torrents
 		auto fields = arguments.at ("fields").as_array ();
 
 		boost::json::object response;
+		response["jsonrpc"] = "2.0";
 		boost::json::array torrents;
 		for (auto id: torrentIds)
 		{


### PR DESCRIPTION
А так же snake_case нужно по https://github.com/transmission/transmission/blob/main/docs/rpc-spec.md#33-torrent-accessor-torrent_get

но я у себя это поправлю, так что пофиг