### PR TITLE
Процентики

### DIFF
--- a/libi2pd_client/TorrentsRPC.cpp
+++ b/libi2pd_client/TorrentsRPC.cpp
@@ -273,8 +273,10 @@ namespace torrents
 			{ "totalSize", [](std::shared_ptr<Torrent> torrent) { return boost::json::value(torrent->GetLength ()); } },
 			{ "percentDone", [](std::shared_ptr<Torrent> torrent)
 				{
-				 if(!torrent->GetLength()) return boost::json::value ( 100 );
-				 return boost::json::value(  (torrent->GetLength () - torrent->GetLeft ())*100/torrent->GetLength ()  );
+				 if(!torrent->GetLength()) return boost::json::value ( 100.0 );
+				 double left = torrent->GetLength () - torrent->GetLeft();
+				 double percent = (left*100)/torrent->GetLength();
+				 return boost::json::value(  percent  );
 				}
 			},
 			{ "hashString", [](std::shared_ptr<Torrent> torrent)

--- a/libi2pd_client/TorrentsRPC.cpp
+++ b/libi2pd_client/TorrentsRPC.cpp
@@ -271,6 +271,12 @@ namespace torrents
 			{ "pieceCount", [](std::shared_ptr<Torrent> torrent) { return boost::json::value(torrent->GetNumPieces ()); } },
 			{ "pieceSize", [](std::shared_ptr<Torrent> torrent) { return boost::json::value(torrent->GetPieceLength ()); } },
 			{ "totalSize", [](std::shared_ptr<Torrent> torrent) { return boost::json::value(torrent->GetLength ()); } },
+			{ "percentDone", [](std::shared_ptr<Torrent> torrent)
+				{
+				 if(!torrent->GetLength()) return boost::json::value ( 100 );
+				 return boost::json::value(  (torrent->GetLength () - torrent->GetLeft ())*100/torrent->GetLength ()  );
+				}
+			},
 			{ "hashString", [](std::shared_ptr<Torrent> torrent)
 				{
 					std::string hexHash;


### PR DESCRIPTION
```:~/XenoneI2P$ python3 main.py 
{'id': 1, 'percent_done': 100.0, 'status': 6, 'rate_upload': 0, 'total_size': 22847284, 'name': 'tetrazoles', 'rate_download': 0, 'hash_string': 'C8A431D53B00314211A78B6B8388CEB8DCBB3680'}
{'id': 2, 'percent_done': 3.4162817904597715, 'status': 4, 'rate_upload': 0, 'total_size': 1514891428, 'name': 'Ludwig 2024 S02E02 1080p iP WEB-DL AAC2 0 H 264-RAWR[EZTVx.to].mkv', 'rate_download': 0, 'hash_string': '87FEB0BC4EF94E5D51C6E7D7EDFBD766B471C397'}
:~/XenoneI2P$ python3 main.py 
{'id': 2, 'total_size': 1514891428, 'percent_done': 3.4162817904597715, 'status': 4, 'hash_string': '87FEB0BC4EF94E5D51C6E7D7EDFBD766B471C397', 'name': 'Ludwig 2024 S02E02 1080p iP WEB-DL AAC2 0 H 264-RAWR[EZTVx.to].mkv', 'rate_download': 0, 'rate_upload': 0}
:~/XenoneI2P$ python3 main.py 
{'id': 2, 'rate_download': 0, 'rate_upload': 0, 'total_size': 1514891428, 'status': 4, 'percent_done': 3.4162817904597715, 'name': 'Ludwig 2024 S02E02 1080p iP WEB-DL AAC2 0 H 264-RAWR[EZTVx.to].mkv', 'hash_string': '87FEB0BC4EF94E5D51C6E7D7EDFBD766B471C397'}
:~/XenoneI2P$ python3 main.py 
{'id': 2, 'total_size': 1514891428, 'hash_string': '87FEB0BC4EF94E5D51C6E7D7EDFBD766B471C397', 'status': 4, 'rate_upload': 0, 'name': 'Ludwig 2024 S02E02 1080p iP WEB-DL AAC2 0 H 264-RAWR[EZTVx.to].mkv', 'percent_done': 3.4162817904597715, 'rate_download': 0}
:~/XenoneI2P$ python3 main.py 
{'id': 2, 'total_size': 1514891428, 'rate_download': 0, 'percent_done': 3.4162817904597715, 'rate_upload': 0, 'status': 4, 'name': 'Ludwig 2024 S02E02 1080p iP WEB-DL AAC2 0 H 264-RAWR[EZTVx.to].mkv', 'hash_string': '87FEB0BC4EF94E5D51C6E7D7EDFBD766B471C397'}
```
UPD:
я в коде t.remove(1) не убрал, 