### PR TITLE
give each udp server tunnel its own cleanup timer

### DIFF
--- a/libi2pd_client/ClientContext.cpp
+++ b/libi2pd_client/ClientContext.cpp
@@ -117,13 +117,6 @@ namespace client
 
 		m_AddressBook.StartResolvers ();
 
-		// start UDP cleanup
-		if (!m_ServerForwards.empty ())
-		{
-			m_CleanupUDPTimer.reset (new boost::asio::steady_timer(m_SharedLocalDestination->GetService ()));
-			ScheduleCleanupUDP();
-		}
-
 		// start torrents RPC server
 		for (auto& it: m_TorrentsRPCServers)
 			it.second->Start ();
@@ -218,13 +211,6 @@ namespace client
 			std::lock_guard<std::mutex> lock(m_ForwardsMutex);
 			m_ServerForwards.clear();
 			m_ClientForwards.clear();
-		}
-
-		LogPrint(eLogInfo, "Clients: Stopping UDP Tunnels timers");
-		if (m_CleanupUDPTimer)
-		{
-			m_CleanupUDPTimer->cancel ();
-			m_CleanupUDPTimer = nullptr;
 		}
 
 		{
@@ -1179,26 +1165,6 @@ namespace client
 				LogPrint(eLogCritical, "Clients: Exception in SOCKS Proxy: ", e.what());
 				ThrowFatal ("Unable to start SOCKS Proxy at ", socksProxyAddr, ":", socksProxyPort, ": ", e.what ());
 			}
-		}
-	}
-
-	void ClientContext::ScheduleCleanupUDP()
-	{
-		if (m_CleanupUDPTimer)
-		{
-			// schedule cleanup in 17 seconds
-			m_CleanupUDPTimer->expires_after (std::chrono::seconds (17));
-			m_CleanupUDPTimer->async_wait(std::bind(&ClientContext::CleanupUDP, this, std::placeholders::_1));
-		}
-	}
-
-	void ClientContext::CleanupUDP(const boost::system::error_code & ecode)
-	{
-		if(!ecode)
-		{
-			std::lock_guard<std::mutex> lock(m_ForwardsMutex);
-			for (auto & s : m_ServerForwards ) s.second->ExpireStale();
-			ScheduleCleanupUDP();
 		}
 	}
 

--- a/libi2pd_client/ClientContext.h
+++ b/libi2pd_client/ClientContext.h
@@ -144,8 +144,6 @@ namespace client
 			void ReadI2CPOptions (const Section& section, bool isServer, i2p::util::Mapping& options) const; // for tunnels
 			void ReadI2CPOptionsFromConfig (const std::string& prefix, i2p::util::Mapping& options) const; // for HTTP and SOCKS proxy
 
-			void CleanupUDP(const boost::system::error_code & ecode);
-			void ScheduleCleanupUDP();
 
 			void VisitTunnels (bool clean);
 
@@ -178,7 +176,6 @@ namespace client
 			BOBCommandChannel * m_BOBCommandChannel;
 			I2CPServer * m_I2CPServer;
 
-			std::unique_ptr<boost::asio::steady_timer> m_CleanupUDPTimer;
 
 			// i18n
 			std::shared_ptr<const i2p::i18n::Locale> m_Language;

--- a/libi2pd_client/UDPTunnel.cpp
+++ b/libi2pd_client/UDPTunnel.cpp
@@ -488,6 +488,27 @@ namespace client
 		);
 		m_StatsTimer.reset (new boost::asio::steady_timer (m_LocalDest->GetService ()));
 		ScheduleStatsTimer ();
+		m_CleanupTimer.reset (new boost::asio::steady_timer (m_LocalDest->GetService ()));
+		ScheduleCleanupTimer ();
+	}
+
+	void I2PUDPServerTunnel::ScheduleCleanupTimer ()
+	{
+		if (m_CleanupTimer)
+		{
+			m_CleanupTimer->expires_after (std::chrono::seconds (I2P_UDP_SESSION_CLEANUP_INTERVAL));
+			m_CleanupTimer->async_wait (std::bind (&I2PUDPServerTunnel::HandleCleanupTimer,
+				this, std::placeholders::_1));
+		}
+	}
+
+	void I2PUDPServerTunnel::HandleCleanupTimer (const boost::system::error_code& ecode)
+	{
+		if (ecode != boost::asio::error::operation_aborted)
+		{
+			ExpireStale ();
+			ScheduleCleanupTimer ();
+		}
 	}
 
 	void I2PUDPServerTunnel::ScheduleStatsTimer ()
@@ -524,6 +545,7 @@ namespace client
 	void I2PUDPServerTunnel::Stop ()
 	{
 		if (m_StatsTimer) m_StatsTimer->cancel ();
+		if (m_CleanupTimer) m_CleanupTimer->cancel ();
 		auto dgram = m_LocalDest->GetDatagramDestination ();
 		if (dgram) {
 			dgram->ResetReceiver (m_inPort);

--- a/libi2pd_client/UDPTunnel.h
+++ b/libi2pd_client/UDPTunnel.h
@@ -30,6 +30,7 @@ namespace client
 {
 	/** 2 minute timeout for udp sessions */
 	const uint64_t I2P_UDP_SESSION_TIMEOUT = 1000 * 60 * 2;
+	const int I2P_UDP_SESSION_CLEANUP_INTERVAL = 17; // in seconds
 	const uint64_t I2P_UDP_REPLIABLE_DATAGRAM_INTERVAL = 100; // in milliseconds
 	const uint64_t I2P_UDP_MAX_UNACKED_DATAGRAM_TIME = 8000; // in milliseconds
 	const uint64_t I2P_UDP_MIN_ACK_TIMEOUT = 500; // in milliseconds
@@ -176,6 +177,8 @@ namespace client
 
 			void ScheduleStatsTimer ();
 			void HandleStatsTimer (const boost::system::error_code& ecode);
+			void ScheduleCleanupTimer ();
+			void HandleCleanupTimer (const boost::system::error_code& ecode);
 
 		private:
 
@@ -192,6 +195,7 @@ namespace client
 			uint32_t m_NumRawNoSession = 0;
 			size_t m_MaxWindow = I2P_UDP_MIN_MAX_NUM_UNACKED_DATAGRAMS;
 			std::unique_ptr<boost::asio::steady_timer> m_StatsTimer;
+			std::unique_ptr<boost::asio::steady_timer> m_CleanupTimer;
 
 		public:
 
@@ -240,6 +244,8 @@ namespace client
 
 			void ScheduleStatsTimer ();
 			void HandleStatsTimer (const boost::system::error_code& ecode);
+			void ScheduleCleanupTimer ();
+			void HandleCleanupTimer (const boost::system::error_code& ecode);
 
 		private:
 


### PR DESCRIPTION
The UDP session cleanup timer was created in ClientContext::Start on the service of the shared local destination. ReloadConfig replaces that destination and deletes the old one, so after any SIGHUP the timer sits on a service that no longer exists, and cancelling it at shutdown reads freed memory. AddressSanitizer catches it in ClientContext::Stop, single thread, no race involved - the same family as #2498, just a third timer that lives in the client context rather than in the address book.

As you suggested in the channel, the timer now belongs to the tunnel it serves: every I2PUDPServerTunnel creates its own on its own destination's service, schedules ExpireStale for its own sessions and cancels it in Stop. The shared timer, ScheduleCleanupUDP and CleanupUDP are gone from ClientContext.

Bench, sanitizer build: datagrams flow through a udpserver tunnel while it is removed from tunnels.conf with SIGHUP and put back, three rounds, then the router is stopped. Before the change that run produced two use-after-free reports; with the change there are none, and the datagrams still go through - 16 sent and 14 answered before the rounds.

Builds without warnings, unit tests pass, C++17 syntax check is fine.