### PR TITLE
hold udp tunnel and session by shared_ptr in socket handlers

### DIFF
--- a/libi2pd_client/UDPTunnel.cpp
+++ b/libi2pd_client/UDPTunnel.cpp
@@ -155,6 +155,7 @@ namespace client
 		auto s = std::make_shared<UDPSession>(boost::asio::ip::udp::endpoint(addr, 0),
 			m_LocalDest, m_RemoteEndpoint, ih, localPort, remotePort);
 		s->SetMaxWindow (m_MaxWindow);
+		s->Receive ();
 		std::lock_guard<std::mutex> lock(m_SessionsMutex);
 		m_Sessions.emplace (idx, s);
 		return s;
@@ -377,14 +378,18 @@ namespace client
 		IPSocket.set_option (boost::asio::socket_base::receive_buffer_size (I2P_UDP_SOCKET_BUFFER_SIZE));
 		IPSocket.set_option (boost::asio::socket_base::send_buffer_size (I2P_UDP_SOCKET_BUFFER_SIZE));
 		IPSocket.non_blocking (true);
-		Receive();
+		// Receive is not called here: it takes a shared pointer to this session,
+		// which does not exist yet while the constructor runs
 	}
 
 	void UDPSession::Receive()
 	{
 		LogPrint(eLogDebug, "UDPSession: Receive");
-		IPSocket.async_receive_from(boost::asio::buffer(m_Buffer, I2P_UDP_MAX_MTU),
-			FromEndpoint, std::bind(&UDPSession::HandleReceived, this, std::placeholders::_1, std::placeholders::_2));
+		IPSocket.async_receive_from(boost::asio::buffer(m_Buffer, I2P_UDP_MAX_MTU), FromEndpoint,
+			[s = std::static_pointer_cast<UDPSession>(shared_from_this ())](const boost::system::error_code& ecode, std::size_t len)
+			{
+				s->HandleReceived (ecode, len);
+			});
 	}
 
 	void UDPSession::HandleReceived(const boost::system::error_code & ecode, std::size_t len)
@@ -662,8 +667,11 @@ namespace client
 
 	void I2PUDPClientTunnel::RecvFromLocal ()
 	{
-		m_LocalSocket->async_receive_from (boost::asio::buffer (m_RecvBuff, I2P_UDP_MAX_MTU),
-			m_RecvEndpoint, std::bind (&I2PUDPClientTunnel::HandleRecvFromLocal, this, std::placeholders::_1, std::placeholders::_2));
+		m_LocalSocket->async_receive_from (boost::asio::buffer (m_RecvBuff, I2P_UDP_MAX_MTU), m_RecvEndpoint,
+			[s = std::static_pointer_cast<I2PUDPClientTunnel>(shared_from_this ())](const boost::system::error_code& ecode, std::size_t transferred)
+			{
+				s->HandleRecvFromLocal (ecode, transferred);
+			});
 	}
 
 	void I2PUDPClientTunnel::HandleRecvFromLocal (const boost::system::error_code & ec, std::size_t transferred)

--- a/libi2pd_client/UDPTunnel.h
+++ b/libi2pd_client/UDPTunnel.h
@@ -55,7 +55,9 @@ namespace client
 	/** local socket buffers, not datagram size */
 	const size_t I2P_UDP_SOCKET_BUFFER_SIZE = 4*1024*1024;
 
-	struct UDPConnection
+	// handlers of both sides are queued on sockets and can outlive the object
+	// they belong to, so they hold it by a shared pointer
+	struct UDPConnection: public std::enable_shared_from_this<UDPConnection>
 	{
 		std::shared_ptr<i2p::datagram::DatagramDestination> m_Destination;
 		std::weak_ptr<i2p::datagram::DatagramSession> m_LastDatagramSession;


### PR DESCRIPTION
Socket handlers of the UDP tunnels were bound to a raw this, so a pending read could outlive the object it belongs to. AddressSanitizer catches it in I2PUDPClientTunnel::HandleRecvFromLocal when the router is stopped while datagrams are in flight: ClientContext::Stop clears m_ClientForwards, and the queued async read from the local socket then lands in freed memory. UDPSession::Receive had the same shape, with sessions dropped by ExpireStale and by Stop.

Both now capture a shared_ptr of the object in the completion handler. Both classes are created with make_shared and owned by shared_ptr, so shared_from_this is valid for them.

One detail worth pointing at: UDPSession called Receive from its own constructor, where shared_from_this is not yet allowed and would throw. The first Receive is moved to right after the session is created; the comment in the constructor says why.

Bench, sanitizer build: a udpserver tunnel forwards to a local UDP echo, a udpclient tunnel on a second router reaches it, datagrams are sent continuously and the client router is stopped with SIGINT four times while they are in flight. Before the change that run produced two use-after-free reports; with the change there are none, and the datagrams still flow - 22 sent and 19 answered before the rounds.

Builds without warnings, unit tests pass, C++17 syntax check is fine. acetone said in the channel that this is fine to fix without waiting for him.