### PR TITLE
skip a torrent file that failed to parse

### DIFF
--- a/libi2pd_client/Torrents.cpp
+++ b/libi2pd_client/Torrents.cpp
@@ -1602,6 +1602,13 @@ namespace torrents
 		else
 			LogPrint (eLogError, "Torrents: Can't open file ", torrentFilePath);
 
+		if (torrent && !torrent->IsValid ())
+		{
+			// a torrent whose parsing stopped, an unsafe name among the rest, must
+			// not be used even in part: it would leave stray files behind
+			LogPrint (eLogError, "Torrents: Invalid torrent file ", torrentFilePath, ". Skipped");
+			torrent = nullptr;
+		}
 		if (torrent)
 		{
 			torrent->SetFullPath (m_TorrentsDir/std::filesystem::path (torrent->GetName ()));

--- a/libi2pd_client/Torrents.h
+++ b/libi2pd_client/Torrents.h
@@ -171,6 +171,7 @@ namespace torrents
 
 			std::string_view GetAnnounce () const { return m_Announce; }
 			std::string_view GetName () const { return m_Name; }
+			bool IsValid () const { return !m_Name.empty () && m_PieceLength && (m_Length || !m_Files.empty ()); }
 			const std::filesystem::path& GetFullPath () const { return m_FullPath; }
 			void SetFullPath (const std::filesystem::path& fullPath) { m_FullPath = fullPath; }
 			const std::list<std::pair<std::filesystem::path, size_t> >& GetFiles () const { return m_Files; }


### PR DESCRIPTION
A follow-up to #2519, and a correction of what I wrote there.

That change refuses unsafe names, and it does keep files inside the torrents folder - checked with crafted torrent files carrying "..", "/etc", a name of "../../evil" and a reserved Windows name: nothing was written outside. But my description claimed such a torrent "fails to parse entirely, rather than being partially accepted", and that part was not true. The parsing stops, yet the half built torrent was still added: the router created directories for those torrents and left a stray file.bin.part in the torrents folder.

Torrent::IsValid is added - a torrent needs a name, a piece length and either a length or a list of files - and ReadTorrentFile now skips anything that does not pass, with a line in the log.

Checked again with the same five files, four unsafe and one normal. Before: four "unsafe" lines, and the directories escape, absolute, good and normal appear along with file.bin.part. After: four "unsafe" lines each followed by "Invalid torrent file ... Skipped", only the directory of the legitimate torrent is created, and nothing else appears.

Builds without warnings, unit tests pass, C++17 syntax check is fine.
