### PR TITLE
Request an expired encrypted LeaseSet by its blinded key

### DIFF
--- a/libi2pd/Destination.cpp
+++ b/libi2pd/Destination.cpp
@@ -243,6 +243,8 @@ namespace client
 			{
 				LogPrint (eLogWarning, "Destination: Remote LeaseSet expired");
 				std::lock_guard<std::mutex> lock(m_RemoteLeaseSetsMutex);
+				if (remoteLS->IsPublishedEncrypted ())
+					RememberBlindedKey (ident, remoteLS->GetIdentity ());
 				m_RemoteLeaseSets.erase (ident);
 				return nullptr;
 			}
@@ -481,6 +483,7 @@ namespace client
 						{
 							LogPrint (eLogDebug, "Destination: New remote LeaseSet added");
 							m_RemoteLeaseSets.insert_or_assign (key, leaseSet);
+							m_RemoteBlindedKeys.erase (key); // the LeaseSet itself is here now
 							if (from)
 								from->SetDestination (key);
 						}
@@ -513,6 +516,7 @@ namespace client
 							std::lock_guard<std::mutex> lock(m_RemoteLeaseSetsMutex);
 							m_RemoteLeaseSets[ls2->GetIdentHash ()] = ls2; // ident is not key
 							m_RemoteLeaseSets[key] = ls2; // also store as key for next lookup
+							m_RemoteBlindedKeys.erase (ls2->GetIdentHash ()); // the LeaseSet itself is here now
 						}
 						else
 							LogPrint (eLogError, "Destination: New remote encrypted LeaseSet2 failed");
@@ -794,6 +798,18 @@ namespace client
 				boost::asio::post (m_Service, [requestComplete](void){requestComplete (nullptr);});
 			return false;
 		}
+		std::shared_ptr<const i2p::data::BlindedPublicKey> blindedKey;
+		{
+			std::lock_guard<std::mutex> lock(m_RemoteLeaseSetsMutex);
+			auto it = m_RemoteBlindedKeys.find (dest);
+			if (it != m_RemoteBlindedKeys.end ())
+			{
+				blindedKey = it->second.first;
+				it->second.second = i2p::util::GetSecondsSinceEpoch ();
+			}
+		}
+		if (blindedKey)
+			return RequestDestinationWithEncryptedLeaseSet (blindedKey, requestComplete);
 		boost::asio::post (m_Service, std::bind (&LeaseSetDestination::RequestLeaseSet, shared_from_this (), dest, requestComplete, nullptr));
 		return true;
 	}
@@ -996,15 +1012,33 @@ namespace client
 		}
 	}
 
+	void LeaseSetDestination::RememberBlindedKey (const i2p::data::IdentHash& ident, std::shared_ptr<const i2p::data::IdentityEx> identity)
+	{
+		// a destination published as encrypted is not stored by its ident hash, so once its
+		// LeaseSet is gone the only way to ask for a new one is the blinded key
+		if (identity)
+			m_RemoteBlindedKeys.insert_or_assign (ident,
+				std::make_pair (std::make_shared<i2p::data::BlindedPublicKey>(identity), i2p::util::GetSecondsSinceEpoch ()));
+	}
+
 	void LeaseSetDestination::CleanupRemoteLeaseSets ()
 	{
 		auto ts = i2p::util::GetMillisecondsSinceEpoch ();
 		std::lock_guard<std::mutex> lock(m_RemoteLeaseSetsMutex);
+		for (auto it = m_RemoteBlindedKeys.begin (); it != m_RemoteBlindedKeys.end ();)
+		{
+			if (ts/1000 > it->second.second + REMOTE_BLINDED_KEY_KEEP_TIME) // destination is gone for good
+				it = m_RemoteBlindedKeys.erase (it);
+			else
+				++it;
+		}
 		for (auto it = m_RemoteLeaseSets.begin (); it != m_RemoteLeaseSets.end ();)
 		{
 			if (it->second->IsEmpty () || ts > it->second->GetExpirationTime ()) // leaseset expired
 			{
 				LogPrint (eLogDebug, "Destination: Remote LeaseSet ", it->second->GetIdentHash ().ToBase64 (), " expired");
+				if (it->second->IsPublishedEncrypted ())
+					RememberBlindedKey (it->first, it->second->GetIdentity ());
 				it = m_RemoteLeaseSets.erase (it);
 			}
 			else

--- a/libi2pd/Destination.h
+++ b/libi2pd/Destination.h
@@ -49,6 +49,7 @@ namespace client
 	const int STOP_ON_SERVICE_TIMEOUT = 10; // in seconds, how long Stop waits for the destination's thread
 	const int LEASESET_REQUEST_TIMEOUT = 1200; // in milliseconds
 	const int MAX_LEASESET_REQUEST_TIMEOUT = 17000; // in milliseconds
+	const int REMOTE_BLINDED_KEY_KEEP_TIME = 600; // in seconds after the LeaseSet expired
 	const int DESTINATION_CLEANUP_TIMEOUT = 44; // in seconds
 	const int DESTINATION_CLEANUP_TIMEOUT_VARIANCE = 30; // in seconds
 	const unsigned int MAX_NUM_FLOODFILLS_PER_REQUEST = 7;
@@ -208,12 +209,17 @@ namespace client
 			void HandleRequestTimoutTimer (const boost::system::error_code& ecode, const i2p::data::IdentHash& dest, uint64_t requestLeaseSetTimeout);
 			void HandleCleanupTimer (const boost::system::error_code& ecode);
 			void CleanupRemoteLeaseSets ();
+			void RememberBlindedKey (const i2p::data::IdentHash& ident, std::shared_ptr<const i2p::data::IdentityEx> identity); // m_RemoteLeaseSetsMutex must be locked
 
 		private:
 
 			boost::asio::io_context& m_Service;
 			mutable std::mutex m_RemoteLeaseSetsMutex;
 			std::unordered_map<i2p::data::IdentHash, std::shared_ptr<i2p::data::LeaseSet> > m_RemoteLeaseSets;
+			// blinded keys of remote destinations published as encrypted, to request them again when
+			// expired, with the time of last use, so that a key of a gone destination doesn't stay forever
+			std::unordered_map<i2p::data::IdentHash,
+				std::pair<std::shared_ptr<const i2p::data::BlindedPublicKey>, uint64_t> > m_RemoteBlindedKeys;
 			std::unordered_map<i2p::data::IdentHash, std::shared_ptr<LeaseSetRequest> > m_LeaseSetRequests;
 
 			std::list<std::shared_ptr<I2NPMessage> > m_IncomingMsgsQueue;


### PR DESCRIPTION
**What this does not do:** it does not keep the expired LeaseSet. That is erased exactly as before,
in the same place, on the same condition.

**What it keeps:** the unblinded public key of the remote destination, 32 bytes plus two signature
types, in a map next to the LeaseSet cache. Blinding depends on the date and is computed at lookup
time from the current date, so the stored value does not go stale at the day boundary. An entry is
dropped 600 seconds after it was last used, so a destination that went away for good does not stay
in memory.

**Why it is needed at all.** A destination published as encrypted is stored under its blinded hash.
`RequestDestination` receives only the ident hash, and the blinded key is derived from the full
identity, which lived in the LeaseSet and is gone once the LeaseSet is erased. An ident hash is a
hash, so nothing can be derived back from it: without the key kept somewhere, the request cannot be
formed at all. This is not "the cached LeaseSet is stale", it is "there is no way to ask".

Streaming already does this: a stream keeps the remote identity for its lifetime and re-requests by
the blinded key when the LeaseSet expires. A datagram session keeps only the ident hash and is
dropped after ten minutes of silence, so nothing survives to ask with. This change gives datagram
sessions the same ability, at the destination level rather than per session.

**What it looks like without the change.** An incoming datagram carries the sender identity, so the
link recovers only if the encrypted destination speaks first. If our side speaks first, it never
reaches the peer. In practice an encrypted destination stops working as a server for datagram
applications after any pause.

**Measured** on two routers in the live network with SAM datagram sessions on both sides. One
destination has `i2cp.leaseSetType=5`, a plain one next to it on the same router is the control.
The peers exchange datagrams, stay idle for 13 minutes, then the other side sends first, 5 attempts
each:

- before: nothing arrives at the encrypted destination in two runs, its ident hash "was not found
  on 7 floodfills" in the log; the control receives on attempt 3 and 2
- after: the encrypted destination receives on attempt 4 and 3, the control on attempt 3 and 2

Re-checked later on the head of the day: encrypted reached on attempt 2, control on attempt 2.

Builds with no new warnings, `make -C tests` passes.
