### PR TITLE
Own the SOCKS UDP tunnel by shared_ptr

### DIFF
--- a/libi2pd_client/SOCKS.cpp
+++ b/libi2pd_client/SOCKS.cpp
@@ -175,7 +175,7 @@ namespace proxy
 			const bool m_UseUpstreamProxy; // do we want to use the upstream proxy for non i2p addresses?
 			const std::string m_UpstreamProxyAddress;
 			const uint16_t m_UpstreamProxyPort;
-			std::unique_ptr<i2p::client::I2PUDPClientTunnel> m_UDPTunnel;
+			std::shared_ptr<i2p::client::I2PUDPClientTunnel> m_UDPTunnel; // shared, the tunnel takes references to itself
 
 		public:
 
@@ -710,7 +710,7 @@ namespace proxy
 							LogPrint (eLogInfo, "SOCKS: New UDP associate connection");
 							auto owner = GetOwner ();
 							if (!owner) { Terminate (); return; }
-							m_UDPTunnel = std::make_unique<i2p::client::I2PUDPClientTunnel>("", addr,
+							m_UDPTunnel = std::make_shared<i2p::client::I2PUDPClientTunnel>("", addr,
 								GetServer ()->GetNextLocalUDPEndpoint (),
 							    owner->GetLocalDestination (), m_port, false, i2p::datagram::eDatagramV3);
 							boost::asio::post (owner->GetService (), [this](void)


### PR DESCRIPTION
`I2PUDPClientTunnel::RecvFromLocal` takes a reference to itself, which my #2513 added, but the SOCKS
proxy owns the tunnel through `std::unique_ptr`, so the tunnel has no shared owner and `Start` throws
`bad_weak_ptr`. A UDP associate request never completes: the client gets no answer and the tunnel is
dropped right away. This is a regression from #2513 and it is mine.

Checked on this machine, in a network namespace with only loopback up, so nothing else could
interfere. A client sends the SOCKS5 greeting and `UDP ASSOCIATE`, 15 times in a row:

- before: 15 associate requests reach the code, 15 exceptions `bad_weak_ptr` in the log, no
  association is established
- after: the same 15 requests, no exceptions

Builds with no new warnings, `make -C tests` passes, C++17 syntax check passes.
