### PR TITLE
Own BOB proxy tunnels by shared_ptr

### DIFF
--- a/libi2pd_client/BOB.cpp
+++ b/libi2pd_client/BOB.cpp
@@ -507,7 +507,7 @@ namespace client
 				case TunnelType::SOCKS:
 					try
 					{
-						auto SocksProxy = std::make_unique<i2p::proxy::SOCKSProxy>(m_Nickname, m_InHost, m_InPort,
+						auto SocksProxy = std::make_shared<i2p::proxy::SOCKSProxy>(m_Nickname, m_InHost, m_InPort,
 							false, m_OutHost, m_OutPort, m_CurrentDestination->GetLocalDestination());
 						SocksProxy->Start();
 						m_Owner.SetProxy(m_Nickname, std::move(SocksProxy));
@@ -521,7 +521,7 @@ namespace client
 				case TunnelType::HTTP_PROXY:
 					try
 					{
-						auto HttpProxy = std::make_unique<i2p::proxy::HTTPProxy>(m_Nickname, m_InHost, m_InPort,
+						auto HttpProxy = std::make_shared<i2p::proxy::HTTPProxy>(m_Nickname, m_InHost, m_InPort,
 							m_OutHost, true, true, m_CurrentDestination->GetLocalDestination());
 						HttpProxy->Start();
 						m_Owner.SetProxy(m_Nickname, std::move(HttpProxy));
@@ -1113,7 +1113,7 @@ namespace client
 		return nullptr;
 	}
 
-	void BOBCommandChannel::SetProxy (const std::string& name, std::unique_ptr<I2PService> proxy)
+	void BOBCommandChannel::SetProxy (const std::string& name, std::shared_ptr<I2PService> proxy)
 	{
 		m_proxy[name] = std::move(proxy);
 	}

--- a/libi2pd_client/BOB.h
+++ b/libi2pd_client/BOB.h
@@ -299,7 +299,7 @@ namespace client
 			void AddDestination (const std::string& name, std::shared_ptr<BOBDestination> dest);
 			void DeleteDestination (const std::string& name);
 			std::shared_ptr<BOBDestination> FindDestination (const std::string& name);
-			void SetProxy (const std::string& name, std::unique_ptr<I2PService> proxy);
+			void SetProxy (const std::string& name, std::shared_ptr<I2PService> proxy);
 			const I2PService* GetProxy(const std::string& name) const;
 			void RemoveProxy(const std::string& name);
 
@@ -314,7 +314,8 @@ namespace client
 			std::map<std::string, std::shared_ptr<BOBDestination> > m_Destinations;
 			std::map<std::string_view, BOBCommandHandler> m_CommandHandlers;
 			std::map<std::string_view, std::string_view> m_HelpStrings;
-			std::map<std::string, std::unique_ptr<I2PService>> m_proxy;
+			// shared, a proxy takes a reference to itself when it accepts a connection
+			std::map<std::string, std::shared_ptr<I2PService>> m_proxy;
 
 		public:
 


### PR DESCRIPTION
`SOCKSProxy::CreateHandler` and `HTTPProxy::CreateHandler` take a reference to the service itself,
which my #2500 added, but BOB creates those proxies through `std::make_unique`, so the service has no
shared owner and the first connection to such a tunnel throws `bad_weak_ptr`. The `settunneltype
socks` and `settunneltype httpproxy` tunnels of BOB have not worked since then. This is mine as well.

Checked on the bench with a sanitizer build. A client speaks BOB, sets a nickname, keys, an inbound
host and port, `settunneltype socks`, `start`, and then connects to the port the tunnel opened:

- before: the router logs `Runtime exception: bad_weak_ptr` and the connection is reset
- after: the proxy answers the SOCKS5 greeting and the connection stands, no exceptions in the log

The proxies created by `ClientContext` are already owned by `shared_ptr`, so only BOB needed the
change.
