### PR TITLE
Hold a reference to the destination in UDP tunnels

### DIFF
--- a/libi2pd_client/UDPTunnel.cpp
+++ b/libi2pd_client/UDPTunnel.cpp
@@ -470,11 +470,15 @@ namespace client
 		m_IsUniqueLocal (true), m_Name (name), m_LocalAddress (localAddress),
 		m_RemoteEndpoint (forwardTo), m_LocalDest (localDestination), m_inPort(inPort), m_Gzip (gzip)
 	{
+		// without a reference the destination counts as unused and a config reload
+		// stops it, leaving the tunnel with a destination that receives nothing
+		if (m_LocalDest) m_LocalDest->Acquire ();
 	}
 
 	I2PUDPServerTunnel::~I2PUDPServerTunnel ()
 	{
 		Stop ();
+		if (m_LocalDest) m_LocalDest->Release ();
 	}
 
 	void I2PUDPServerTunnel::Start ()
@@ -594,11 +598,13 @@ namespace client
 		m_ResolveThread (nullptr), m_LocalSocket (nullptr), RemotePort (remotePort),
 		m_LastPort (0), m_cancel_resolve (false), m_Gzip (gzip), m_DatagramVersion (datagramVersion)
 	{
+		if (m_LocalDest) m_LocalDest->Acquire ();
 	}
 
 	I2PUDPClientTunnel::~I2PUDPClientTunnel ()
 	{
 		Stop ();
+		if (m_LocalDest) m_LocalDest->Release ();
 	}
 
 	void I2PUDPClientTunnel::Start ()


### PR DESCRIPTION
Fix for #2507.

After a configuration reload the router walks its destinations and stops those with no references
(`ClientContext::ReloadConfig`). Every service takes that reference in the `I2PService` constructor,
but UDP tunnels are not services and never take it, so the destination of a UDP tunnel counts as
unused. It is stopped and erased on any reload, which drops its datagram destination, and from then
on incoming datagrams have nowhere to go: the delivery path checks for a datagram destination and
silently does nothing. The tunnel stays deaf for good, without a crash and without a log line.

The change makes UDP tunnels hold the destination the same way services do, taking the reference in
the constructor and giving it back in the destructor.

Checked on a bench with two routers in the live network, sanitizer build. Datagrams flow through a
UDP server tunnel; in the middle of the traffic the tunnel is removed from the config, `SIGHUP`,
12 seconds later it is put back, `SIGHUP` again. Then the traffic stops for 13 minutes and a probe is
sent, "sent/returned":

- before: baseline 22/20, probe after the pause 15/0, and the next rounds 22/0 and 22/0 - it never
  recovers
- after: baseline 16/14, probe after the pause 23/19

A gap right after the reload remains: removing the tunnel destroys the destination, a new one is
created with new tunnels, and the peer keeps using the lease set it has cached until it expires.
