### PR TITLE
Stop parsing a truncated zip in reseed instead of looping forever

### DIFF
--- a/libi2pd/Reseed.cpp
+++ b/libi2pd/Reseed.cpp
@@ -330,7 +330,9 @@ namespace data
 	{
 		int numFiles = 0;
 		size_t contentPos = s.tellg ();
-		while (!s.eof ())
+		// not !eof: seekg clears eofbit, so a stream broken in the middle of a
+		// header stays not-eof forever and the loop never ends
+		while (s.good ())
 		{
 			uint32_t signature;
 			s.read ((char *)&signature, 4);
@@ -357,13 +359,18 @@ namespace data
 				uint16_t fileNameLength, extraFieldLength;
 				s.read ((char *)&fileNameLength, 2);
 				fileNameLength = le16toh (fileNameLength);
+				s.read ((char *)&extraFieldLength, 2);
+				extraFieldLength = le16toh (extraFieldLength);
+				if (!s.good ())
+				{
+					LogPrint (eLogError, "Reseed: Truncated zip local file header");
+					return numFiles;
+				}
 				if ( fileNameLength >= 255 ) {
 					// too big
 					LogPrint(eLogError, "Reseed: SU3 fileNameLength too large: ", fileNameLength);
 					return numFiles;
 				}
-				s.read ((char *)&extraFieldLength, 2);
-				extraFieldLength = le16toh (extraFieldLength);
 				char localFileName[255];
 				s.read (localFileName, fileNameLength);
 				localFileName[fileNameLength] = 0;

--- a/libi2pd/Reseed.cpp
+++ b/libi2pd/Reseed.cpp
@@ -409,6 +409,12 @@ namespace data
 
 				uint8_t * compressed = new uint8_t[compressedSize];
 				s.read ((char *)compressed, compressedSize);
+				if (!s.good ())
+				{
+					LogPrint (eLogError, "Reseed: Truncated zip file data");
+					delete[] compressed;
+					return numFiles;
+				}
 				if (compressionMethod) // we assume Deflate
 				{
 					z_stream inflator;
@@ -490,7 +496,7 @@ namespace data
 	bool Reseeder::FindZipDataDescriptor (std::istream& s)
 	{
 		size_t nextInd = 0;
-		while (!s.eof ())
+		while (s.good ()) // a broken stream never reaches eof, see ProcessZIPStream
 		{
 			uint8_t nextByte;
 			s.read ((char *)&nextByte, 1);


### PR DESCRIPTION
A zip file that ends in the middle of a local file header makes `ProcessZIPStream` spin forever.

The loop is `while (!s.eof ())`, but `seekg` clears eofbit while failbit stays set. Once a read has failed, every later read leaves its variable untouched and never sets eofbit again, so the loop keeps re-processing the same stale header. When the stale compressed size happens to be zero it takes the `continue` branch, which also skips the content length check at the bottom.

Recipe, no network needed:

```
python3 -c "d=open('good.zip','rb').read(); open('cut.zip','wb').write(d[:10])"
i2pd --datadir=/tmp/zt --reseed.zipfile=/tmp/cut.zip
```

Numbers on 9e342ffd, 25 seconds of run time: 9 922 876 log lines `Reseed: Unexpected size 0. Skipped`, 545 MB written to disk, one core busy, the router never gets past reseed. With this change: 72 log lines, one `Reseed: Truncated zip local file header`, the router carries on.

A valid archive is unaffected: same zip of three routerInfo files, 3 files processed and 3 routers added both before and after.

Also checked with a set of 3000 mutated su3 files under AddressSanitizer: the whole set now runs to the end with no reports, while before it stopped on the first truncated header.

`make` clean with no new warnings, `make -C tests` passes, `g++ -std=c++17 -fsyntax-only` on the changed file passes.