### PR TITLE
Handle malformed HTTP input instead of throwing or returning garbage

### DIFF
--- a/libi2pd/HTTP.cpp
+++ b/libi2pd/HTTP.cpp
@@ -133,6 +133,7 @@ namespace http
 			}
 
 			/* hostname[:port][/path] */
+			if (pos_p >= url.length ()) return false; /* nothing left after schema or user part */
 			if (url.at(pos_p) == '[') // ipv6
 			{
 				auto pos_b = url.find(']', pos_p);

--- a/libi2pd/HTTP.cpp
+++ b/libi2pd/HTTP.cpp
@@ -616,6 +616,11 @@ namespace http
 				return false; /* too large chunk */
 			char * buf = new char[len];
 			in.read (buf, len);
+			if (in.gcount () != len) /* chunk is shorter than announced */
+			{
+				delete[] buf;
+				return false;
+			}
 			out.write (buf, len);
 			delete[] buf;
 			std::getline (in, hexLen); // read \r\n after chunk

--- a/tests/test-http-merge_chunked.cpp
+++ b/tests/test-http-merge_chunked.cpp
@@ -21,5 +21,11 @@ int main() {
   assert(MergeChunkedResponse(in, out) == true);
   assert(out.str() == "HTTP response with \r\nchunks.");
 
+  /* a chunk that promises more bytes than the response carries */
+  std::stringstream truncated("20\r\nshort\r\n");
+  std::stringstream out2;
+
+  assert(MergeChunkedResponse(truncated, out2) == false);
+
   return 0;
 }

--- a/tests/test-http-url.cpp
+++ b/tests/test-http-url.cpp
@@ -125,6 +125,12 @@ int main() {
   assert(url->frag == "frag");
   delete url;
 
+  /* nothing after the schema or the user part: must not throw */
+  url = new URL;
+  assert(url->parse("http://") == false);
+  assert(url->parse("http://user@") == false);
+  delete url;
+
   return 0;
 }
 


### PR DESCRIPTION
`MergeChunkedResponse` reads a chunk into a fresh buffer and then writes the whole announced length to the output, no matter how much was actually read. A response whose last chunk is shorter than its header promises is reported as success, and the missing tail is whatever the freshly allocated heap held.

Reproduced with the current head, `20\r\nshort\r\n` (32 bytes announced, 5 delivered), sanitizer build:

    before: returned true, 32 bytes out, first bytes 73 68 6f 72 74 0d 0a be be be ...
    after:  returned false, 0 bytes out

(`be` is the fill AddressSanitizer puts in new memory; in a plain build it is whatever was there.)

The caller is `Reseeder::HttpsRequest`, so today this ends as garbage inside the reseed data rather than an error, and the su3 check fails later for a reason that has nothing to do with the real problem.

Added a case to `tests/test-http-merge_chunked.cpp`. `make -C tests` passes, the build has no new warnings, `g++ -std=c++17 -fsyntax-only` on the changed file passes.