### PR TITLE
Reduced the number of permissions for pledge

### DIFF
--- a/daemon/Daemon.cpp
+++ b/daemon/Daemon.cpp
@@ -115,7 +115,7 @@ namespace util
 				LogPrint(eLogDebug, "Default pledge values are set");
 				// TODO: remove that not need
 				// proc used in daemonunix, flock used in daemonunix, unix using
-				pledge("stdio rpath wpath cpath inet dns unix recvfd sendfd proc error mcast chown flock",nullptr);
+				pledge("stdio rpath wpath cpath inet dns unix proc error mcast chown flock",nullptr);
 			} else {
 				std::ifstream f(pledge_file);
 				if(!f) {


### PR DESCRIPTION
Sendfd and recvfd were removed, because they were not used anywhere. The code does not even have the sendmsg and recvmsg functions needed to provoke these permissions. A router with the following startup parameters '--service --datadir=/var/lib/i2pd --conf=/etc/i2pd/i2pd.conf --tunconf=/etc/i2pd/tunnels.conf --tunnelsdir=/etc/i2pd/tunnels.d --daemon' does not crash even with the error removed.