### PR TITLE
fix compilation error

### DIFF
--- a/libi2pd_client/TorrentsRPC.cpp
+++ b/libi2pd_client/TorrentsRPC.cpp
@@ -540,7 +540,7 @@ namespace torrents
 				if (tunnel)
 				{
 					static constexpr std::string_view appjson { "application/json" };
-					if (m_Request[boost::beast::http::field::content_type].compare (0, appjson.size (), appjson) || // starts with
+					if (m_Request[boost::beast::http::field::content_type].compare (0, appjson.size (), appjson.data()) || // starts with
 						m_Request[boost::beast::http::field::content_type] == "application/x-www-form-urlencoded")
 					{
 #ifdef JSON_SUPPORTED


### PR DESCRIPTION
```
libi2pd_client/TorrentsRPC.cpp:543:61: error: no matching member function for call to 'compare'
  543 |                                         if (m_Request[boost::beast::http::field::content_type].compare (0, appjson.size (), appjson) || // starts with
      |                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
```