### PR TITLE
Don't send packets from a terminated stream

### DIFF
--- a/libi2pd/Streaming.cpp
+++ b/libi2pd/Streaming.cpp
@@ -1531,6 +1531,9 @@ namespace stream
 
 	void Stream::SendPackets (const std::list<Packet *>& packets)
 	{
+		// the local destination is a reference and it can be gone already: a handler
+		// queued before the destination was stopped runs after it
+		if (m_Status == eStreamStatusTerminated) return;
 		if (!m_RemoteLeaseSet)
 		{
 			CancelRemoteLeaseChange ();


### PR DESCRIPTION
Follows the discussion in #dev about a report sent to me by mail: a use-after-free in `Stream::SendPackets` after `ClientDestination::Stop`. A stream keeps its owner as a reference (`StreamingDestination& m_LocalDestination`), `StopInternal` drops the last `shared_ptr` to that object, and a send handler queued earlier on the same service runs afterwards and dereferences the reference.

orignal's suggestion, implemented here: `StreamingDestination::Stop` already calls `Terminate` on every stream, so the status is `eStreamStatusTerminated` by then, and `SendPackets` can bail out on it. The check is the first line of the function, before the owner is touched - otherwise the reference would be dereferenced ahead of it.

Measured rather than assumed. With a temporary log line in a separate build, two destinations in one process transferring data over the network, each on its own service lane, the client stopped mid-transfer: across three rounds of stops the send handlers entered `SendBuffer` on already terminated streams **6398 times**. So handlers do keep running after the destination is stopped, and the status at that point is exactly the one this check reads.

In my scenarios they stop inside `SendBuffer` before reaching `SendPackets` (the window is closed by then), which is why I could not reproduce the reported crash locally in seven attempts; the reporter's application did reach `SendPackets`, and this check sits on that path.

A soak on this branch - a site behind a server tunnel, requests through the http proxy, a SAM transfer and two config reloads - opens the page after the reloads with zero sanitizer reports. `make` has no new warnings, `make -C tests` passes, `g++ -std=c++17 -fsyntax-only` on the changed file passes.