### PR TITLE
Don't reset shared receivers from a UDP tunnel that was never started

### DIFF
--- a/libi2pd_client/UDPTunnel.cpp
+++ b/libi2pd_client/UDPTunnel.cpp
@@ -483,6 +483,7 @@ namespace client
 
 	void I2PUDPServerTunnel::Start ()
 	{
+		m_IsStarted = true;
 		m_LocalDest->Start ();
 
 		auto dgram = m_LocalDest->CreateDatagramDestination (m_Gzip);
@@ -553,6 +554,11 @@ namespace client
 
 	void I2PUDPServerTunnel::Stop ()
 	{
+		// a config reload builds a second tunnel object and drops it when the same
+		// one is already there. Its destructor must not reset the receiver of the
+		// live tunnel: they share the datagram destination
+		if (!m_IsStarted) return;
+		m_IsStarted = false;
 		if (m_StatsTimer) m_StatsTimer->cancel ();
 		if (m_CleanupTimer) m_CleanupTimer->cancel ();
 		auto dgram = m_LocalDest->GetDatagramDestination ();
@@ -609,6 +615,7 @@ namespace client
 
 	void I2PUDPClientTunnel::Start ()
 	{
+		m_IsStarted = true;
 		UDPConnection::Start ();
 		// Reset flag in case of tunnel reload
 		if (m_cancel_resolve) m_cancel_resolve = false;
@@ -643,6 +650,8 @@ namespace client
 
 	void I2PUDPClientTunnel::Stop ()
 	{
+		if (!m_IsStarted) return; // see the comment in I2PUDPServerTunnel::Stop
+		m_IsStarted = false;
 		if (m_KeepAliveTimer) m_KeepAliveTimer->cancel ();
 		if (m_StatsTimer) m_StatsTimer->cancel ();
 

--- a/libi2pd_client/UDPTunnel.h
+++ b/libi2pd_client/UDPTunnel.h
@@ -194,6 +194,7 @@ namespace client
 			UDPSessionPtr m_LastSession;
 			uint16_t m_inPort;
 			bool m_Gzip;
+			bool m_IsStarted = false; // a tunnel that never started shares nothing to tear down
 			uint32_t m_NumRawNoSession = 0;
 			size_t m_MaxWindow = I2P_UDP_MIN_MAX_NUM_UNACKED_DATAGRAMS;
 			std::unique_ptr<boost::asio::steady_timer> m_StatsTimer;
@@ -264,6 +265,7 @@ namespace client
 			uint16_t RemotePort, m_LastPort;
 			bool m_cancel_resolve;
 			bool m_Gzip;
+			bool m_IsStarted = false; // see the comment in I2PUDPServerTunnel
 			i2p::datagram::DatagramVersion m_DatagramVersion;
 			std::shared_ptr<UDPConvo> m_LastSession;
 			uint32_t m_KeepAliveInterval = 0;


### PR DESCRIPTION
A configuration reload silently stops UDP tunnels from delivering anything. The tunnel keeps running, the destination stays, nothing is recreated - and every datagram that arrives is dropped.

Mechanism: `ClientContext` builds the tunnel object first and only then discovers that the same forward already exists (`libi2pd_client/ClientContext.cpp:911` for a server forward, `:740` for a client one). The extra object is discarded, its destructor runs `Stop ()`, and `Stop ()` calls `ResetReceiver` on the datagram destination - which is **shared** with the live tunnel. From that moment the live tunnel has no receiver.

The server log says exactly that: `Datagram: no receiver for port 0`, 65 times after the reload.

Reproduction, a scenario that checks what must still work after a reload - a page through the http proxy, a datagram through a udp tunnel pair, and a SAM answer:

    before the reload:        page 1, datagram 1, sam 1
    after the first reload:   page 1, datagram 0, sam 1
    after the second reload:  page 1, datagram 0, sam 1

A control run of the same scenario without reloads keeps all three at 1 in all three checks, so it is the reload and not elapsed time or the network. In the logs the client keeps sending (its sequence number grows, acks time out) while the server's session shows nothing received.

With this change, on the same scenario and the same bench:

    before the reload:        page 1, datagram 1, sam 1
    after the first reload:   page 1, datagram 1, sam 1
    after the second reload:  page 1, datagram 1, sam 1

and `no receiver for port` never appears in the log. Zero sanitizer reports in both runs.

The fix keeps a tunnel from tearing down shared state it never set up: `Start ()` marks the tunnel started, and `Stop ()` returns early if it was not. The client tunnel gets the same guard - its `Stop ()` resets the receiver in the same way.

`make` has no new warnings, `make -C tests` passes, `g++ -std=c++17 -fsyntax-only` on the changed file passes.