### PR TITLE
Check datagram sessions for empty under the lock

### DIFF
--- a/libi2pd/Datagram.cpp
+++ b/libi2pd/Datagram.cpp
@@ -488,10 +488,10 @@ namespace datagram
 
 	void DatagramDestination::CleanUp ()
 	{
-		if (m_Sessions.empty ()) return;
 		auto now = i2p::util::GetMillisecondsSinceEpoch();
-		LogPrint(eLogDebug, "DatagramDestination: clean up sessions");
 		std::unique_lock<std::mutex> lock(m_SessionsMutex);
+		if (m_Sessions.empty ()) return;
+		LogPrint(eLogDebug, "DatagramDestination: clean up sessions");
 		// for each session ...
 		for (auto it = m_Sessions.begin (); it != m_Sessions.end (); )
 		{


### PR DESCRIPTION
`DatagramDestination::CleanUp` read `m_Sessions.empty ()` before taking `m_SessionsMutex`, while every other access to that map is made under it. Reported as one of the spots in #2394.

The check now sits under the lock, and the debug log line moved with it so it is not printed for an empty list.

Built clean with no warnings, `make -C tests` passes, and `g++ -std=c++17 -fsyntax-only` accepts the file.

Fix for #2394