### PR TITLE
Treat reseed connect timeout as a failure instead of a connection

### DIFF
--- a/libi2pd/Reseed.cpp
+++ b/libi2pd/Reseed.cpp
@@ -732,7 +732,14 @@ namespace data
 								ecode = ec;
 							});
 						service.run_for (std::chrono::seconds (RESEED_CONNECT_TIMEOUT));
-						if (!service.stopped()) s.lowest_layer().close ();
+						if (!service.stopped())
+						{
+							// the handler never ran, so ecode still holds success from resolve:
+							// without this the timeout reads as a connection and the request goes
+							// out on a socket that was just closed
+							ecode = boost::asio::error::timed_out;
+							s.lowest_layer().close ();
+						}
 
 						if (!ecode)
 						{
@@ -857,7 +864,11 @@ namespace data
 							ecode = ec;
 						});
 					service.run_for (std::chrono::seconds (2*RESEED_CONNECT_TIMEOUT));
-					if (!service.stopped()) s.close ();
+					if (!service.stopped())
+					{
+						ecode = boost::asio::error::timed_out;
+						s.close ();
+					}
 
 					if (!ecode)
 					{


### PR DESCRIPTION
When run_for expires the connect handler never runs, so ecode still holds the success left by
resolve and the timeout reads as a connection. The socket is closed right after, the request is
written to it anyway, and write_some throws with a bad file descriptor, taking the netdb thread
with it.

Reproduced on 0d655bef with a yggdrasil reseed host on a dummy interface that nobody answers, so
connect hangs instead of being refused. The log shows "Connected" ten seconds after resolve, which
is the timeout expiring, and then terminate on write_some. With this change the same run logs
"Failed to connect", throws nothing, and the router stays up and retries.

Both reseed paths, https and yggdrasil. Build is clean and the unit tests pass.

Fix for #2429
